### PR TITLE
Cl sync

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ wabt = "0.9.0"
 
 [dependencies.primitives]
 git = 'https://github.com/paritytech/substrate'
-rev = '6d47fd919b4d86e4348c6c19d99c80372587d215'
+rev = '9b08e7ff938a45dbec7fcdb854063202e2b0cb48'
 package = "substrate-primitives"
 
 [dependencies.codec]
@@ -34,71 +34,71 @@ version = "1.0.0"
 
 [dependencies.indices]
 git = 'https://github.com/paritytech/substrate'
-rev = '6d47fd919b4d86e4348c6c19d99c80372587d215'
+rev = '9b08e7ff938a45dbec7fcdb854063202e2b0cb48'
 package = "srml-indices"
 
 [dependencies.node-primitives]
 git = 'https://github.com/paritytech/substrate'
-rev = '6d47fd919b4d86e4348c6c19d99c80372587d215'
+rev = '9b08e7ff938a45dbec7fcdb854063202e2b0cb48'
 
 [dependencies.runtime_io]
 git = 'https://github.com/paritytech/substrate'
-rev = '6d47fd919b4d86e4348c6c19d99c80372587d215'
+rev = '9b08e7ff938a45dbec7fcdb854063202e2b0cb48'
 package = "sr-io"
 
 [dependencies.transaction_pool]
 git = 'https://github.com/paritytech/substrate'
-rev = '6d47fd919b4d86e4348c6c19d99c80372587d215'
+rev = '9b08e7ff938a45dbec7fcdb854063202e2b0cb48'
 package = "substrate-transaction-pool"
 
 [dependencies.metadata]
 git = 'https://github.com/paritytech/substrate'
-rev = '6d47fd919b4d86e4348c6c19d99c80372587d215'
+rev = '9b08e7ff938a45dbec7fcdb854063202e2b0cb48'
 package = "srml-metadata"
 
 [dependencies.balances]
 git = 'https://github.com/paritytech/substrate'
-rev = '6d47fd919b4d86e4348c6c19d99c80372587d215'
+rev = '9b08e7ff938a45dbec7fcdb854063202e2b0cb48'
 package = "srml-balances"
 
 [dependencies.keyring]
 git = 'https://github.com/paritytech/substrate'
-rev = '6d47fd919b4d86e4348c6c19d99c80372587d215'
+rev = '9b08e7ff938a45dbec7fcdb854063202e2b0cb48'
 package = "substrate-keyring"
 
 [dependencies.system]
 git = 'https://github.com/paritytech/substrate'
-rev = '6d47fd919b4d86e4348c6c19d99c80372587d215'
+rev = '9b08e7ff938a45dbec7fcdb854063202e2b0cb48'
 package = "srml-system"
 
 [dependencies.runtime_primitives]
 git = 'https://github.com/paritytech/substrate'
-rev = '6d47fd919b4d86e4348c6c19d99c80372587d215'
+rev = '9b08e7ff938a45dbec7fcdb854063202e2b0cb48'
 package = "sr-primitives"
 
 [dependencies.runtime_support]
 git = 'https://github.com/paritytech/substrate'
-rev = '6d47fd919b4d86e4348c6c19d99c80372587d215'
+rev = '9b08e7ff938a45dbec7fcdb854063202e2b0cb48'
 package = "srml-support"
 
 [dev-dependencies.rstd]
 git = 'https://github.com/paritytech/substrate'
-rev = '6d47fd919b4d86e4348c6c19d99c80372587d215'
+rev = '9b08e7ff938a45dbec7fcdb854063202e2b0cb48'
 package = "sr-std"
 
 [dev-dependencies.node_runtime]
 git = 'https://github.com/paritytech/substrate'
-rev = '6d47fd919b4d86e4348c6c19d99c80372587d215'
+rev = '9b08e7ff938a45dbec7fcdb854063202e2b0cb48'
 package = "node-runtime"
 
 [dev-dependencies.test_node_runtime]
 git = 'https://github.com/scs/substrate-test-nodes.git'
-tag = "M1.Api"
+branch = "brenzi-upstream-sync"
 package = "test-node-runtime"
 
 [dev-dependencies.contracts]
 git = 'https://github.com/paritytech/substrate'
-rev = "6d47fd919b4d86e4348c6c19d99c80372587d215"
+rev = "9b08e7ff938a45dbec7fcdb854063202e2b0cb48"
 package = "srml-contracts"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,11 @@ git = 'https://github.com/paritytech/substrate'
 rev = '9b08e7ff938a45dbec7fcdb854063202e2b0cb48'
 package = "srml-metadata"
 
+[dependencies.runtime_version]
+git = 'https://github.com/paritytech/substrate'
+rev = '9b08e7ff938a45dbec7fcdb854063202e2b0cb48'
+package = "sr-version"
+
 [dependencies.balances]
 git = 'https://github.com/paritytech/substrate'
 rev = '9b08e7ff938a45dbec7fcdb854063202e2b0cb48'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ regex = "1.1"
 serde_json = "1.0"
 hex-literal = "0.1"
 serde_derive = "1.0"
-primitive-types = { version = "0.2", default-features = false, features = ["codec"] }
+primitive-types = { version = "0.5", default-features = false, features = ["codec"] }
 parity-codec-derive = { version = "3.3", default-features = false }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ For more information, please refer to the [substrate](https://github.com/parityt
 
 ## Setup
 
-Setup a substrate node. Tested with [revision 6d47fd91 of substrate](https://github.com/paritytech/substrate/commit/6d47fd919b4d86e4348c6c19d99c80372587d215). Alternatively, the test node found at https://github.com/scs/substrate-test-nodes is guaranteed to work, which is anyhow needed for some examples.
+Setup a substrate node. Tested with [revision 9b08e7ff of substrate](https://github.com/paritytech/substrate/commit/9b08e7ff938a45dbec7fcdb854063202e2b0cb48). Alternatively, the test node found at https://github.com/scs/substrate-test-nodes is guaranteed to work, which is anyhow needed for some examples.
 
     git clone https://github.com/scs/substrate-test-nodes
     cd substrate-test-nodes/

--- a/src/examples/example_get_storage.rs
+++ b/src/examples/example_get_storage.rs
@@ -33,9 +33,9 @@ fn main() {
     let mut api = Api::new(format!("ws://{}", url));
 
     // get some plain storage value
-    let result_str = api.get_storage("Balances", "TransactionBaseFee", None).unwrap();
+    let result_str = api.get_storage("Balances", "TotalIssuance", None).unwrap();
     let result = hexstr_to_u256(result_str);
-    println!("[+] TransactionBaseFee is {}", result);
+    println!("[+] TotalIssuance is {}", result);
 
     // get Alice's AccountNonce
     let accountid = AccountId::from(AccountKeyring::Alice);

--- a/src/extrinsic/mod.rs
+++ b/src/extrinsic/mod.rs
@@ -65,7 +65,7 @@ macro_rules! compose_extrinsic {
 	$call: expr
 	$(, $args: expr) *) => {
 		{
-            use codec::{Compact, Encode};
+            use codec::Compact;
             use log::info;
             use crate::extrinsic::xt_primitives::*;
 
@@ -79,7 +79,7 @@ macro_rules! compose_extrinsic {
                 let raw_payload = SignedPayload::from_raw(
                     call.clone(),
                     extra.clone(),
-                    (4 as u32, $api.genesis_hash, $api.genesis_hash, (), (), ())
+                    ($api.runtime_version.spec_version, $api.genesis_hash, $api.genesis_hash, (), (), ())
                 );
 
                 let signature = raw_payload.using_encoded(|payload|  {

--- a/src/extrinsic/xt_primitives.rs
+++ b/src/extrinsic/xt_primitives.rs
@@ -27,9 +27,9 @@ use runtime_primitives::generic::Era;
 pub type GenericAddress = Address<[u8; 32], u32>;
 
 /// Simple generic extra mirroring the SignedExtra currently used in extrinsics. Does not implement
-/// the SignedExtension trait. It simply encodes to the same bytes as the real SignedExtra.
-/// Order  is (CheckVersion, CheckGenesis, Check::Era, CheckNonce, CheckWeight, TakeFees). This can
-///  be locked up in the System module. Fields that are merely PhantomData are not encoded, and are
+/// the SignedExtension trait. It simply encodes to the same bytes as the real SignedExtra. The
+/// Order is (CheckVersion, CheckGenesis, Check::Era, CheckNonce, CheckWeight, TakeFees). This can
+/// be locked up in the System module. Fields that are merely PhantomData are not encoded and are
 /// therefore omitted here.
 #[derive(Decode, Encode, Clone, Debug, Eq, PartialEq)]
 pub struct GenericExtra(Era, Compact<u32>, Compact<u128>);
@@ -45,7 +45,7 @@ impl GenericExtra {
 }
 
 /// additionalSigned fields of the respective SignedExtra fields.
-/// Order is the same as the declared in the extra.
+/// Order is the same as declared in the extra.
 pub type AdditionalSigned = (u32, H256, H256, (), (), ());
 
 #[derive(Encode)]

--- a/src/extrinsic/xt_primitives.rs
+++ b/src/extrinsic/xt_primitives.rs
@@ -28,6 +28,9 @@ pub type GenericAddress = Address<[u8; 32], u32>;
 
 /// Simple generic extra mirroring the SignedExtra currently used in extrinsics. Does not implement
 /// the SignedExtension trait. It simply encodes to the same bytes as the real SignedExtra.
+/// Order  is (CheckVersion, CheckGenesis, Check::Era, CheckNonce, CheckWeight, TakeFees). This can
+///  be locked up in the System module. Fields that are merely PhantomData are not encoded, and are
+/// therefore omitted here.
 #[derive(Decode, Encode, Clone, Debug, Eq, PartialEq)]
 pub struct GenericExtra(Era, Compact<u32>, Compact<u128>);
 
@@ -36,11 +39,13 @@ impl GenericExtra {
         GenericExtra(
             Era::Immortal,
             Compact(nonce),
-            Compact(0 as u128),
+            Compact(0 as u128), //weight
         )
     }
 }
 
+/// additionalSigned fields of the respective SignedExtra fields.
+/// Order is the same as the declared in the extra.
 pub type AdditionalSigned = (u32, H256, H256, (), (), ());
 
 #[derive(Encode)]

--- a/src/rpc/client.rs
+++ b/src/rpc/client.rs
@@ -48,13 +48,7 @@ pub fn on_get_request_msg(msg: Message, out: Sender, result: ThreadOut<String>) 
     let retstr = msg.as_text().unwrap();
     let value: serde_json::Value = serde_json::from_str(retstr).unwrap();
 
-    // FIXME: defaulting zo zero can be problematic. better to use Option<String>
-    let hexstr = match value["result"].as_str() {
-        Some(res) => res.to_string(),
-        _ => "0x00".to_string(),
-    };
-
-    result.send(hexstr).unwrap();
+    result.send(value["result"].to_string()).unwrap();
     out.close(CloseCode::Normal).unwrap();
     Ok(())
 }

--- a/src/rpc/json_req.rs
+++ b/src/rpc/json_req.rs
@@ -37,6 +37,15 @@ pub fn state_get_metadata() -> Value {
         })
 }
 
+pub fn state_get_runtime_version() -> Value {
+    json!({
+            "method": "state_getRuntimeVersion",
+            "params": null,
+            "jsonrpc": "2.0",
+            "id": "1",
+        })
+}
+
 pub fn state_subscribe_storage(key: &str) -> Value {
     json!({
             "method": "state_subscribeStorage",

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -15,7 +15,6 @@
 
 */
 
-use log::info;
 use node_primitives::Hash;
 use primitive_types::U256;
 use primitives::blake2_256;
@@ -38,13 +37,13 @@ pub fn storage_key_hash(module: &str, storage_key_name: &str, param: Option<Vec<
     keyhash
 }
 
-pub fn hexstr_to_vec(mut hexstr: String) -> Vec<u8> {
-    if hexstr.starts_with("0x") {
-        hex::decode(hexstr.split_off(2)).unwrap()
-    } else {
-        info!("converting non-prefixed hex string");
-        hex::decode(&hexstr).unwrap()
-    }
+pub fn hexstr_to_vec(hexstr: String) -> Vec<u8> {
+    let hexstr = hexstr.trim_matches('\"')
+        .to_string()
+        .trim_start_matches("0x")
+        .to_string();
+
+    hex::decode(&hexstr).unwrap()
 }
 
 pub fn hexstr_to_u64(hexstr: String) -> u64 {


### PR DESCRIPTION
- Bump to substrate `rev=9b08e7ff938a45dbec7fcdb854063202e2b0cb48`
- updated extrinsic format
- get `RuntimeVersion` via RPC call.