### PR TITLE
adding option to select json request id

### DIFF
--- a/src/rpc/json_req.rs
+++ b/src/rpc/json_req.rs
@@ -20,50 +20,74 @@ use serde_json::{json, Value};
 pub const REQUEST_TRANSFER: u32 = 3;
 
 pub fn chain_get_block_hash() -> Value {
+    chain_get_block_hash_with_id(1)
+}
+
+pub fn chain_get_block_hash_with_id(id: u32) -> Value {
     json!({
     "method": "chain_getBlockHash",
     "params": [0],
     "jsonrpc": "2.0",
-    "id": "1",
+    "id": id.to_string(),
     })
 }
 
 pub fn state_get_metadata() -> Value {
+    state_get_metadata_with_id(1)
+}
+
+pub fn state_get_metadata_with_id(id: u32) -> Value {
     json!({
         "method": "state_getMetadata",
         "params": null,
         "jsonrpc": "2.0",
-        "id": "1",
+        "id": id.to_string(),
     })
 }
 
 pub fn state_get_runtime_version() -> Value {
+    state_get_runtime_version_with_id(1)
+}
+
+pub fn state_get_runtime_version_with_id(id: u32) -> Value {
     json!({
         "method": "state_getRuntimeVersion",
         "params": null,
         "jsonrpc": "2.0",
-        "id": "1",
+        "id": id.to_string(),
     })
 }
 
 pub fn state_subscribe_storage(key: &str) -> Value {
+    state_subscribe_storage_with_id(key, 1)
+}
+
+pub fn state_subscribe_storage_with_id(key: &str, id: u32) -> Value {
     json!({
         "method": "state_subscribeStorage",
         "params": [[key]],
         "jsonrpc": "2.0",
-        "id": "1",
+        "id": id.to_string(),
     })
 }
 
 pub fn state_get_storage(key_hash: &str) -> Value {
-    json_req("state_getStorage", key_hash, 1 as u32)
+    state_get_storage_with_id(key_hash, 1)
+}
+
+pub fn state_get_storage_with_id(key_hash: &str, id: u32) -> Value {
+    json_req("state_getStorage", key_hash, id)
 }
 
 pub fn author_submit_and_watch_extrinsic(xthex_prefixed: &str) -> Value {
+    author_submit_and_watch_extrinsic_with_id(xthex_prefixed, REQUEST_TRANSFER)
+}
+
+pub fn author_submit_and_watch_extrinsic_with_id(xthex_prefixed: &str, id: u32) -> Value {
     json_req(
         "author_submitAndWatchExtrinsic",
         xthex_prefixed,
-        REQUEST_TRANSFER,
+        id,
     )
 }
 


### PR DESCRIPTION
allows lib user to specify id for each RPC subscription. necessary if there's more than one