### PR TITLE
adding pub fn for double map storage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -136,11 +136,11 @@ pipeline {
     }
   }
   post {
-    changed {
+    unsuccessful {
         emailext (
           subject: "Jenkins Build '${env.JOB_NAME} [${env.BUILD_NUMBER}]' is ${currentBuild.currentResult}",
           body: "${env.JOB_NAME} build ${env.BUILD_NUMBER} changed state and is now ${currentBuild.currentResult}\n\nMore info at: ${env.BUILD_URL}",
-          to: '${env.RECIPIENTS_SUBSTRATEE}'
+          to: "${env.RECIPIENTS_SUBSTRATEE}"
         )
     }
   }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,7 +144,19 @@ impl<P> Api<P>
         param: Option<Vec<u8>>,
     ) -> WsResult<String> {
         let keyhash = storage_key_hash(module, storage_key_name, param);
+        debug!("with storage key: {}", keyhash);
+        let jsonreq = json_req::state_get_storage(&keyhash);
+        Self::_get_request(url, jsonreq.to_string())
+    }
 
+    fn _get_storage_double_map(
+        url: String,
+        module: &str,
+        storage_key_name: &str,
+        first: Vec<u8>,
+        second: Vec<u8>
+    ) -> WsResult<String> {
+        let keyhash = storage_key_hash_double_map(module, storage_key_name, first, second);
         debug!("with storage key: {}", keyhash);
         let jsonreq = json_req::state_get_storage(&keyhash);
         Self::_get_request(url, jsonreq.to_string())
@@ -199,6 +211,17 @@ impl<P> Api<P>
         param: Option<Vec<u8>>,
     ) -> WsResult<String> {
         Self::_get_storage(self.url.clone(), storage_prefix, storage_key_name, param)
+    }
+
+    pub fn get_storage_double_map(
+        &self,
+        storage_prefix: &str,
+        storage_key_name: &str,
+        first: Vec<u8>,
+        second: Vec<u8>,
+    ) -> WsResult<String> {
+        Self::_get_storage_double_map(self.url.clone(), storage_prefix, storage_key_name, 
+            first, second)
     }
 
     pub fn send_extrinsic(&self, xthex_prefixed: String) -> WsResult<Hash> {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -25,7 +25,7 @@ fn storage_key_hash_vec(module: &str, storage_key_name: &str, param: Option<Vec<
     let mut key = [module, storage_key_name].join(" ").as_bytes().to_vec();
     match param {
         Some(par) => {
-            key.append(&mut par.clone());
+            key.extend(&par.clone());
             blake2_256(&key).to_vec()
         },
         _ => {
@@ -43,7 +43,7 @@ pub fn storage_key_hash(module: &str, storage_key_name: &str, param: Option<Vec<
 
 pub fn storage_key_hash_double_map(module: &str, storage_key_name: &str, first: Vec<u8>, second: Vec<u8>) -> String {
     let mut keyhash = storage_key_hash_vec(module, storage_key_name, Some(first));
-    keyhash.append(&mut blake2_256(&second).to_vec());
+    keyhash.extend(&blake2_256(&second).to_vec());
     let mut keyhash_str = hex::encode(keyhash);
     keyhash_str.insert_str(0, "0x");
     keyhash_str

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -25,7 +25,7 @@ fn storage_key_hash_vec(module: &str, storage_key_name: &str, param: Option<Vec<
     let mut key = [module, storage_key_name].join(" ").as_bytes().to_vec();
     match param {
         Some(par) => {
-            key.extend(&par.clone());
+            key.extend(&par);
             blake2_256(&key).to_vec()
         },
         _ => {


### PR DESCRIPTION
this is tested against encointer-node.
There is a caveat:
the runtime module has to define the double_map with blake2_256 hasher, not twox128. We could add functions for both, but shawns tutorial silently assumes blake2

this works:
```
decl_storage! {
	trait Store for Module<T: Trait> as EncointerCeremonies {
		ParticipantRegistry get(participant_registry): double_map CeremonyIndexType, blake2_256(ParticipantIndexType) => T::AccountId;
	}
}
```