### PR TITLE
Upstream upgrade 00a400f82539e2f78e8ddbcd98aea512c87c5f3c

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,10 @@ serde           = { version = "1.0", optional = true, features = ["derive"] }
 serde_json      = { version = "1.0", optional = true }
 primitive-types = { version = "0.6", default-features = false, features = ["codec"] }
 
-[dependencies.primitives]
+[dependencies.sp-core]
 git = "https://github.com/paritytech/substrate"
-rev = "3bf9540e72df5ecb3955845764dfee7dcdbb26b5"
-package = "substrate-primitives"
+rev = "00a400f82539e2f78e8ddbcd98aea512c87c5f3c"
+package = "sp-core"
 default-features = false
 features = ["full_crypto"]
 
@@ -28,72 +28,72 @@ default-features = false
 
 [dependencies.indices]
 git = "https://github.com/paritytech/substrate"
-rev = "3bf9540e72df5ecb3955845764dfee7dcdbb26b5"
+rev = "00a400f82539e2f78e8ddbcd98aea512c87c5f3c"
 package = "pallet-indices"
 default-features=false
 
 [dependencies.runtime_io]
 git = "https://github.com/paritytech/substrate"
-rev = "3bf9540e72df5ecb3955845764dfee7dcdbb26b5"
-package = "sr-io"
+rev = "00a400f82539e2f78e8ddbcd98aea512c87c5f3c"
+package = "sp-io"
 default-features=false
 
 [dependencies.metadata]
 git = "https://github.com/paritytech/substrate"
-rev = "3bf9540e72df5ecb3955845764dfee7dcdbb26b5"
-package = "palette-metadata"
+rev = "00a400f82539e2f78e8ddbcd98aea512c87c5f3c"
+package = "frame-metadata"
 default-features=false
 
-[dependencies.runtime_version]
+[dependencies.sp-version]
 git = "https://github.com/paritytech/substrate"
-rev = "3bf9540e72df5ecb3955845764dfee7dcdbb26b5"
-package = "sr-version"
+rev = "00a400f82539e2f78e8ddbcd98aea512c87c5f3c"
+package = "sp-version"
 default-features=false
 
 [dependencies.balances]
 git = "https://github.com/paritytech/substrate"
-rev = "3bf9540e72df5ecb3955845764dfee7dcdbb26b5"
+rev = "00a400f82539e2f78e8ddbcd98aea512c87c5f3c"
 package = "pallet-balances"
 default-features=false
 
 [dependencies.system]
 git = "https://github.com/paritytech/substrate"
-rev = "3bf9540e72df5ecb3955845764dfee7dcdbb26b5"
-package = "palette-system"
+rev = "00a400f82539e2f78e8ddbcd98aea512c87c5f3c"
+package = "frame-system"
 default-features=false
 
-[dependencies.runtime_primitives]
+[dependencies.sp-runtime]
 git = "https://github.com/paritytech/substrate"
-rev = "3bf9540e72df5ecb3955845764dfee7dcdbb26b5"
-package = "sr-primitives"
+rev = "00a400f82539e2f78e8ddbcd98aea512c87c5f3c"
+package = "sp-runtime"
 default-features=false
 
-[dependencies.runtime_support]
+[dependencies.support]
 git = "https://github.com/paritytech/substrate"
-rev = "3bf9540e72df5ecb3955845764dfee7dcdbb26b5"
-package = "palette-support"
+rev = "00a400f82539e2f78e8ddbcd98aea512c87c5f3c"
+package = "frame-support"
 default-features=false
 
-[dependencies.rstd]
+[dependencies.sp-std]
 git = "https://github.com/paritytech/substrate"
-rev = "3bf9540e72df5ecb3955845764dfee7dcdbb26b5"
-package = "sr-std"
+rev = "00a400f82539e2f78e8ddbcd98aea512c87c5f3c"
+package = "sp-std"
 default-features = false
 
 [dev-dependencies.node_runtime]
 git = "https://github.com/paritytech/substrate"
-rev = "3bf9540e72df5ecb3955845764dfee7dcdbb26b5"
+rev = "00a400f82539e2f78e8ddbcd98aea512c87c5f3c"
 package = "node-runtime"
 
 [dependencies.node_primitives]
 git = "https://github.com/paritytech/substrate"
-rev = "3bf9540e72df5ecb3955845764dfee7dcdbb26b5"
+rev = "00a400f82539e2f78e8ddbcd98aea512c87c5f3c"
 package = "node-primitives"
 default-features=false
 
 [dev-dependencies.contracts]
 git = "https://github.com/paritytech/substrate"
-rev = "3bf9540e72df5ecb3955845764dfee7dcdbb26b5"
+rev = "00a400f82539e2f78e8ddbcd98aea512c87c5f3c"
 package = "pallet-contracts"
 
 [dev-dependencies]
@@ -101,8 +101,8 @@ wabt = "0.9.0"
 
 [dev-dependencies.keyring]
 git = "https://github.com/paritytech/substrate"
-rev = "3bf9540e72df5ecb3955845764dfee7dcdbb26b5"
-package = "substrate-keyring"
+rev = "00a400f82539e2f78e8ddbcd98aea512c87c5f3c"
+package = "sp-keyring"
 
 [dev-dependencies.clap] 
 version = "2.33"
@@ -111,18 +111,18 @@ features = ["yaml"]
 [features]
 default = ["std"]
 std = [
-	"primitives/std",
+	"sp-core/std",
 	"codec/std",
-    "runtime_primitives/std",
-	"runtime_support/std",
-	"runtime_primitives/std",
+    "sp-runtime/std",
+	"support/std",
+	"sp-runtime/std",
 	"system/std",
 	"balances/std",
-	"runtime_version/std",
+	"sp-version/std",
 	"metadata/std",
 	"runtime_io/std",
 	"indices/std",
-	"primitives/std",
+	"sp-core/std",
 	"serde/std",
 	"serde_json",
 	"env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,6 +168,3 @@ path = "src/examples/example_compose_extrinsic_offline.rs"
 [[example]]
 name = "example_sudo"
 path = "src/examples/example_sudo.rs"
-
-[patch.crates-io]
-ed25519-dalek = { git = "https://github.com/scs/ed25519-dalek.git", branch = "no_std_sgx"}

--- a/ci/install_rust.sh
+++ b/ci/install_rust.sh
@@ -14,7 +14,7 @@ source $HOME/.cargo/env
 
 # Install nightly that supports clippy
 # Overview: https://rust-lang.github.io/rustup-components-history/index.html
-rustup default nightly-2019-11-17
+rustup default nightly--2020-02-06
 
 # Install aux components, clippy for linter, rustfmt for formatting
 rustup component add clippy

--- a/ci/install_rust.sh
+++ b/ci/install_rust.sh
@@ -14,7 +14,7 @@ source $HOME/.cargo/env
 
 # Install nightly that supports clippy
 # Overview: https://rust-lang.github.io/rustup-components-history/index.html
-rustup default nightly--2020-02-06
+rustup default nightly-2020-02-06
 
 # Install aux components, clippy for linter, rustfmt for formatting
 rustup component add clippy

--- a/src/examples/example_compose_extrinsic_offline.rs
+++ b/src/examples/example_compose_extrinsic_offline.rs
@@ -20,7 +20,7 @@ use clap::{load_yaml, App};
 
 use keyring::AccountKeyring;
 use node_runtime::{BalancesCall, Call};
-use primitives::crypto::Pair;
+use sp_core::crypto::Pair;
 
 use substrate_api_client::{
     compose_extrinsic_offline, extrinsic::xt_primitives::UncheckedExtrinsicV4, Api,

--- a/src/examples/example_contract.rs
+++ b/src/examples/example_contract.rs
@@ -27,8 +27,8 @@ use clap::{load_yaml, App};
 use codec::Decode;
 use keyring::AccountKeyring;
 use log::*;
-use primitives::H256 as Hash;
-use rstd::prelude::*;
+use sp_core::H256 as Hash;
+use sp_std::prelude::*;
 
 // FIXME: this type doesn't include contract events -> example broken (would rely on test-node-runtime which we try
 // to avoid because of a cargo issue https://github.com/rust-lang/cargo/issues/6571)

--- a/src/examples/example_contract.rs
+++ b/src/examples/example_contract.rs
@@ -122,7 +122,7 @@ fn subcribe_to_code_stored_event(events_out: &Receiver<String>) -> Hash {
         if let Ok(evts) = _events {
             for evr in &evts {
                 debug!("decoded: phase {:?} event {:?}", evr.phase, evr.event);
-                if let Event::contracts(ce) = &evr.event {
+                if let Event::pallet_contracts(ce) = &evr.event {
                     if let contracts::RawEvent::CodeStored(code_hash) = &ce {
                         info!("Received Contract.CodeStored event");
                         info!("Codehash: {:?}", code_hash);
@@ -144,7 +144,7 @@ fn subscribe_to_code_instantiated_event(events_out: &Receiver<String>) -> Generi
         if let Ok(evts) = _events {
             for evr in &evts {
                 debug!("decoded: phase {:?} event {:?}", evr.phase, evr.event);
-                if let Event::contracts(ce) = &evr.event {
+                if let Event::pallet_contracts(ce) = &evr.event {
                     if let contracts::RawEvent::Instantiated(from, deployed_at) = &ce {
                         info!("Received Contract.Instantiated Event");
                         info!("From: {:?}", from);

--- a/src/examples/example_custom_storage_struct.rs
+++ b/src/examples/example_custom_storage_struct.rs
@@ -23,7 +23,7 @@ use clap::{load_yaml, App};
 use codec::{Decode, Encode};
 use keyring::AccountKeyring;
 use log::*;
-use primitives::{crypto::Pair, H256};
+use sp_core::{crypto::Pair, H256};
 
 use substrate_api_client::{
     compose_extrinsic, extrinsic::xt_primitives::UncheckedExtrinsicV4, utils::*, Api,

--- a/src/examples/example_event_callback.rs
+++ b/src/examples/example_event_callback.rs
@@ -19,8 +19,8 @@ use std::sync::mpsc::channel;
 use clap::{load_yaml, App};
 use codec::Decode;
 use log::{debug, error};
-use primitives::sr25519;
-use primitives::H256 as Hash;
+use sp_core::sr25519;
+use sp_core::H256 as Hash;
 
 // This module depends on node_runtime.
 // To avoid dependency collisions, node_runtime has been removed from the substrate-api-client library.

--- a/src/examples/example_event_callback.rs
+++ b/src/examples/example_event_callback.rs
@@ -51,7 +51,7 @@ fn main() {
                 for evr in &evts {
                     println!("decoded: phase {:?} event {:?}", evr.phase, evr.event);
                     match &evr.event {
-                        Event::balances(be) => {
+                        Event::pallet_balances(be) => {
                             println!(">>>>>>>>>> balances event: {:?}", be);
                             match &be {
                                 balances::RawEvent::Transfer(transactor, dest, value, fee) => {

--- a/src/examples/example_generic_extrinsic.rs
+++ b/src/examples/example_generic_extrinsic.rs
@@ -18,7 +18,7 @@
 
 use clap::{load_yaml, App};
 use keyring::AccountKeyring;
-use primitives::crypto::Pair;
+use sp_core::crypto::Pair;
 
 use substrate_api_client::{
     compose_extrinsic, extrinsic::xt_primitives::UncheckedExtrinsicV4, Api,

--- a/src/examples/example_get_storage.rs
+++ b/src/examples/example_get_storage.rs
@@ -18,7 +18,7 @@ use clap::{load_yaml, App};
 use codec::Encode;
 use keyring::AccountKeyring;
 
-use primitives::crypto::Pair;
+use sp_core::crypto::Pair;
 use substrate_api_client::{utils::hexstr_to_u256, Api};
 
 fn main() {

--- a/src/examples/example_print_metadata.rs
+++ b/src/examples/example_print_metadata.rs
@@ -21,7 +21,7 @@ extern crate clap;
 
 use clap::App;
 
-use primitives::sr25519;
+use sp_core::sr25519;
 
 use substrate_api_client::node_metadata;
 use substrate_api_client::Api;

--- a/src/examples/example_sudo.rs
+++ b/src/examples/example_sudo.rs
@@ -19,7 +19,7 @@
 use clap::{load_yaml, App};
 use codec::Compact;
 use keyring::AccountKeyring;
-use primitives::crypto::Pair;
+use sp_core::crypto::Pair;
 use substrate_api_client::{
     compose_call, compose_extrinsic,
     extrinsic::xt_primitives::{GenericAddress, UncheckedExtrinsicV4},

--- a/src/examples/example_transfer.rs
+++ b/src/examples/example_transfer.rs
@@ -30,8 +30,8 @@ fn main() {
 
     let to = AccountKeyring::Bob.to_account_id();
 
-    let result = api.get_free_balance(&to);
-    println!("[+] Bob's Free Balance is is {}\n", result);
+    let bob = api.get_account_data(&to).unwrap();
+    println!("[+] Bob's Free Balance is is {}\n", bob.free);
 
     // generate extrinsic
     let xt = api.balance_transfer(GenericAddress::from(to.clone()), 1000);
@@ -49,8 +49,8 @@ fn main() {
     println!("[+] Transaction got finalized. Hash: {:?}\n", tx_hash);
 
     // verify that Bob's free Balance increased
-    let result = api.get_free_balance(&to);
-    println!("[+] Bob's Free Balance is now {}\n", result);
+    let bob = api.get_account_data(&to).unwrap();
+    println!("[+] Bob's Free Balance is now {}\n", bob.free);
 }
 
 pub fn get_node_url_from_cli() -> String {

--- a/src/examples/example_transfer.rs
+++ b/src/examples/example_transfer.rs
@@ -16,7 +16,7 @@
 ///! Very simple example that shows how to use a predefined extrinsic from the extrinsic module
 use clap::{load_yaml, App};
 use keyring::AccountKeyring;
-use primitives::crypto::Pair;
+use sp_core::crypto::Pair;
 
 use substrate_api_client::{extrinsic::xt_primitives::*, Api};
 

--- a/src/extrinsic/balances.rs
+++ b/src/extrinsic/balances.rs
@@ -20,8 +20,8 @@ use codec::Compact;
 use super::xt_primitives::*;
 #[cfg(feature = "std")]
 use crate::{compose_extrinsic, Api};
-use primitives::crypto::Pair;
-use runtime_primitives::MultiSignature;
+use sp_core::crypto::Pair;
+use sp_runtime::MultiSignature;
 
 pub const BALANCES_MODULE: &str = "Balances";
 pub const BALANCES_TRANSFER: &str = "transfer";

--- a/src/extrinsic/contract.rs
+++ b/src/extrinsic/contract.rs
@@ -16,10 +16,10 @@
 */
 
 use codec::Compact;
-use primitives::crypto::Pair;
-use primitives::H256 as Hash;
-use rstd::prelude::*;
-use runtime_primitives::MultiSignature;
+use sp_core::crypto::Pair;
+use sp_core::H256 as Hash;
+use sp_std::prelude::*;
+use sp_runtime::MultiSignature;
 
 #[cfg(feature = "std")]
 use crate::{compose_extrinsic, Api};

--- a/src/extrinsic/xt_primitives.rs
+++ b/src/extrinsic/xt_primitives.rs
@@ -15,7 +15,7 @@
 
 */
 
-use rstd::prelude::*;
+use sp_std::prelude::*;
 
 #[cfg(feature = "std")]
 use std::fmt;
@@ -24,8 +24,8 @@ use codec::{Compact, Decode, Encode};
 use indices::address::Address;
 use node_primitives::{AccountId, AccountIndex};
 use primitive_types::H256;
-use primitives::blake2_256;
-use runtime_primitives::{generic::Era, MultiSignature};
+use sp_core::blake2_256;
+use sp_runtime::{generic::Era, MultiSignature};
 pub type GenericAddress = Address<AccountId, AccountIndex>;
 
 /// Simple generic extra mirroring the SignedExtra currently used in extrinsics. Does not implement
@@ -144,7 +144,7 @@ where
 
 /// Same function as in primitives::generic. Needed to be copied as it is private there.
 fn encode_with_vec_prefix<T: Encode, F: Fn(&mut Vec<u8>)>(encoder: F) -> Vec<u8> {
-    let size = rstd::mem::size_of::<T>();
+    let size = sp_std::mem::size_of::<T>();
     let reserve = match size {
         0..=0b0011_1111 => 1,
         0..=0b0011_1111_1111_1111 => 2,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use rstd::prelude::*;
+use sp_std::prelude::*;
 
 #[cfg(feature = "std")]
 use std::sync::mpsc::channel;
@@ -30,8 +30,8 @@ use codec::{Decode, Encode};
 use log::{debug, info};
 
 use metadata::RuntimeMetadataPrefixed;
-use primitives::crypto::Pair;
-use primitives::H256 as Hash;
+use sp_core::crypto::Pair;
+use sp_core::H256 as Hash;
 
 #[cfg(feature = "std")]
 use ws::Result as WsResult;
@@ -46,7 +46,7 @@ use rpc::json_req;
 use utils::*;
 
 use primitive_types::U256;
-use runtime_version::RuntimeVersion;
+use sp_version::RuntimeVersion;
 
 #[macro_use]
 pub mod extrinsic;
@@ -58,7 +58,7 @@ pub mod rpc;
 #[cfg(feature = "std")]
 pub mod utils;
 
-use runtime_primitives::{AccountId32, MultiSignature};
+use sp_runtime::{AccountId32, MultiSignature};
 
 #[cfg(feature = "std")]
 #[derive(Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ use std::sync::mpsc::channel;
 #[cfg(feature = "std")]
 use std::sync::mpsc::Sender as ThreadOut;
 
+use balances::AccountData;
 use codec::{Decode, Encode};
 
 #[cfg(feature = "std")]
@@ -191,12 +192,13 @@ where
         }
     }
 
-    pub fn get_free_balance(&self, address: &AccountId32) -> U256 {
+    pub fn get_account_data(&self, address: &AccountId32) -> Option<AccountData<u128>> {
         let id: &[u8; 32] = address.as_ref();
         let result_str = self
-            .get_storage("Balances", "FreeBalance", Some(id.to_owned().encode()))
+            .get_storage("Balances", "Account", Some(id.to_owned().encode()))
             .unwrap();
-        hexstr_to_u256(result_str).unwrap()
+
+        hexstr_to_account_data(result_str).ok()
     }
 
     pub fn get_request(&self, jsonreq: String) -> WsResult<String> {

--- a/src/node_metadata.rs
+++ b/src/node_metadata.rs
@@ -140,7 +140,7 @@ impl Arg {
 pub fn parse_metadata(metadata: &RuntimeMetadataPrefixed) -> Vec<Module> {
     let mut mod_vec = Vec::<Module>::new();
     match &metadata.1 {
-        RuntimeMetadata::V8(value) => {
+        RuntimeMetadata::V11(value) => {
             match &value.modules {
                 DecodeDifferent::Decoded(mods) => {
                     let modules = mods;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -17,9 +17,9 @@
 
 use hex::FromHexError;
 use primitive_types::U256;
-use primitives::blake2_256;
-use primitives::twox_128;
-use primitives::H256 as Hash;
+use sp_core::blake2_256;
+use sp_core::twox_128;
+use sp_core::H256 as Hash;
 
 fn storage_key_hash_vec(module: &str, storage_key_name: &str, param: Option<Vec<u8>>) -> Vec<u8> {
     let mut key = [module, storage_key_name].join(" ").as_bytes().to_vec();

--- a/test_no_std/Cargo.toml
+++ b/test_no_std/Cargo.toml
@@ -21,15 +21,15 @@ features=["full_crypto"]
 
 [dependencies.application-crypto]
 git = "https://github.com/paritytech/substrate"
-rev = "3bf9540e72df5ecb3955845764dfee7dcdbb26b5"
-package = "substrate-application-crypto"
+rev = "00a400f82539e2f78e8ddbcd98aea512c87c5f3c"
+package = "sp-application-crypto"
 default-features = false
 features = ["full_crypto"]
 
-[dependencies.sr-io]
+[dependencies.sp-io]
 git = "https://github.com/paritytech/substrate"
-rev = "3bf9540e72df5ecb3955845764dfee7dcdbb26b5"
-package = 'sr-io'
+rev = "00a400f82539e2f78e8ddbcd98aea512c87c5f3c"
+package = 'sp-io'
 default-features=false
 features = ["disable_oom", "disable_panic_handler"]
 

--- a/tutorials/api-client-tutorial/Cargo.toml
+++ b/tutorials/api-client-tutorial/Cargo.toml
@@ -8,12 +8,12 @@ edition = "2018"
 substrate-api-client = { path = "../.." }
 codec = { package = "parity-scale-codec", features = ["derive"], version = "1.0.0", default-features = false }
 
-[dependencies.primitives]
+[dependencies.sp-core]
 git = "https://github.com/paritytech/substrate"
-rev = "3bf9540e72df5ecb3955845764dfee7dcdbb26b5"
-package = "substrate-primitives"
+rev = "00a400f82539e2f78e8ddbcd98aea512c87c5f3c"
+package = "sp-core"
 
 [dependencies.keyring]
 git = "https://github.com/paritytech/substrate"
-rev = "3bf9540e72df5ecb3955845764dfee7dcdbb26b5"
-package = "substrate-keyring"
+rev = "00a400f82539e2f78e8ddbcd98aea512c87c5f3c"
+package = "sp-keyring"

--- a/tutorials/api-client-tutorial/src/main.rs
+++ b/tutorials/api-client-tutorial/src/main.rs
@@ -16,7 +16,7 @@
 use codec::{Decode, Encode};
 use keyring::AccountKeyring;
 
-use primitives::crypto::Pair;
+use sp_core::crypto::Pair;
 
 use substrate_api_client::{
     Api,

--- a/tutorials/api-client-tutorial/src/main.rs
+++ b/tutorials/api-client-tutorial/src/main.rs
@@ -39,7 +39,7 @@ fn main() {
     let api = Api::new(format!("ws://{}", url))
         .set_signer(signer.clone());
 
-    let xt: UncheckedExtrinsicV3<_> = compose_extrinsic!(
+    let xt: UncheckedExtrinsicV4<_> = compose_extrinsic!(
         api.clone(),
         "KittyModule",
         "create_kitty",


### PR DESCRIPTION
* upstream upgrade
** updated storage_key_hash computation
** replaced get_fee_balance with get_account_data

examples work except for compose_exctrinsic_offline and example_contract, which is the status_quo from before.