### PR TITLE
Add ability to exit on InBlock and Broadcast status for send_extrinsic

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -338,13 +338,25 @@ where
                 info!("finalized: {}", res);
                 Ok(Some(hexstr_to_hash(res).unwrap()))
             }
+            XtStatus::InBlock => {
+                rpc::send_extrinsic_and_wait_until_in_block(self.url.clone(), jsonreq, result_in);
+                let res = result_out.recv().unwrap();
+                info!("inBlock: {}", res);
+                Ok(Some(hexstr_to_hash(res).unwrap()))
+            }
+            XtStatus::Broadcast => {
+                rpc::send_extrinsic_and_wait_until_broadcast(self.url.clone(), jsonreq, result_in);
+                let res = result_out.recv().unwrap();
+                info!("broadcast: {}", res);
+                Ok(None)
+            }
             XtStatus::Ready => {
                 rpc::send_extrinsic(self.url.clone(), jsonreq, result_in);
                 let res = result_out.recv().unwrap();
                 info!("ready: {}", res);
                 Ok(None)
             }
-            _ => panic!("can only wait for finalized or ready extrinsic status"),
+            _ => panic!("can only wait for finalized, in block, broadcast and ready extrinsic status"),
         }
     }
 

--- a/src/rpc/client.rs
+++ b/src/rpc/client.rs
@@ -22,6 +22,8 @@ use ws::{CloseCode, Handler, Handshake, Message, Result, Sender};
 #[derive(Debug, PartialEq)]
 pub enum XtStatus {
     Finalized,
+    InBlock,
+    Broadcast,
     Ready,
     Future,
     Error,
@@ -104,6 +106,40 @@ pub fn on_extrinsic_msg_until_finalized(
     Ok(())
 }
 
+pub fn on_extrinsic_msg_until_in_block(
+    msg: Message,
+    out: Sender,
+    result: ThreadOut<String>,
+) -> Result<()> {
+    let retstr = msg.as_text().unwrap();
+    debug!("got msg {}", retstr);
+    match parse_status(retstr) {
+        (XtStatus::Finalized, val) => end_process(out, result, val),
+        (XtStatus::InBlock, val) => end_process(out, result, val),
+        (XtStatus::Future, _) => end_process(out, result, None),
+        (XtStatus::Error, _) => end_process(out, result, None),
+        _ => (),
+    };
+    Ok(())
+}
+
+pub fn on_extrinsic_msg_until_broadcast(
+    msg: Message,
+    out: Sender,
+    result: ThreadOut<String>,
+) -> Result<()> {
+    let retstr = msg.as_text().unwrap();
+    debug!("got msg {}", retstr);
+    match parse_status(retstr) {
+        (XtStatus::Finalized, val) => end_process(out, result, val),
+        (XtStatus::Broadcast, _) => end_process(out, result, None),
+        (XtStatus::Future, _) => end_process(out, result, None),
+        (XtStatus::Error, _) => end_process(out, result, None),
+        _ => (),
+    };
+    Ok(())
+}
+
 pub fn on_extrinsic_msg_until_ready(
     msg: Message,
     out: Sender,
@@ -144,6 +180,12 @@ fn parse_status(msg: &str) -> (XtStatus, Option<String>) {
                 if let Some(hash) = obj.get("finalized") {
                     info!("finalized: {:?}", hash);
                     (XtStatus::Finalized, Some(hash.to_string()))
+                } else if let Some(hash) = obj.get("inBlock") {
+                    info!("inBlock: {:?}", hash);
+                    (XtStatus::InBlock, Some(hash.to_string()))
+                } else if let Some(array) = obj.get("broadcast") {
+                    info!("broadcast: {:?}", array);
+                    (XtStatus::Broadcast, Some(array.to_string()))
                 } else {
                     (XtStatus::Unknown, None)
                 }
@@ -169,6 +211,30 @@ mod tests {
 
         let msg = "{\"jsonrpc\":\"2.0\",\"method\":\"author_extrinsicUpdate\",\"params\":{\"result\":\"ready\",\"subscription\":7185}}";
         assert_eq!(parse_status(msg), (XtStatus::Ready, None));
+
+        let msg = "{\"jsonrpc\":\"2.0\",\"method\":\"author_extrinsicUpdate\",\"params\":{\"result\":{\"broadcast\":[\"QmfSF4VYWNqNf5KYHpDEdY8Rt1nPUgSkMweDkYzhSWirGY\",\"Qmchhx9SRFeNvqjUK4ZVQ9jH4zhARFkutf9KhbbAmZWBLx\",\"QmQJAqr98EF1X3YfjVKNwQUG9RryqX4Hv33RqGChbz3Ncg\"]},\"subscription\":232}}";
+        assert_eq!(
+            parse_status(msg),
+            (
+                XtStatus::Broadcast,
+                Some(
+                    "[\"QmfSF4VYWNqNf5KYHpDEdY8Rt1nPUgSkMweDkYzhSWirGY\",\"Qmchhx9SRFeNvqjUK4ZVQ9jH4zhARFkutf9KhbbAmZWBLx\",\"QmQJAqr98EF1X3YfjVKNwQUG9RryqX4Hv33RqGChbz3Ncg\"]"
+                        .to_string()
+                )
+            )
+        );
+
+        let msg = "{\"jsonrpc\":\"2.0\",\"method\":\"author_extrinsicUpdate\",\"params\":{\"result\":{\"inBlock\":\"0x3104d362365ff5ddb61845e1de441b56c6722e94c1aee362f8aa8ba75bd7a3aa\"},\"subscription\":232}}";
+        assert_eq!(
+            parse_status(msg),
+            (
+                XtStatus::InBlock,
+                Some(
+                    "\"0x3104d362365ff5ddb61845e1de441b56c6722e94c1aee362f8aa8ba75bd7a3aa\""
+                        .to_string()
+                )
+            )
+        );
 
         let msg = "{\"jsonrpc\":\"2.0\",\"method\":\"author_extrinsicUpdate\",\"params\":{\"result\":{\"finalized\":\"0x934385b11c483498e2b5bca64c2e8ef76ad6c74d3372a05595d3a50caf758d52\"},\"subscription\":7185}}";
         assert_eq!(

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -34,6 +34,14 @@ pub fn send_extrinsic(url: String, json_req: String, result_in: ThreadOut<String
     start_rpc_client_thread(url, json_req, result_in, on_extrinsic_msg_until_ready)
 }
 
+pub fn send_extrinsic_and_wait_until_broadcast(url: String, json_req: String, result_in: ThreadOut<String>) {
+    start_rpc_client_thread(url, json_req, result_in, on_extrinsic_msg_until_broadcast)
+}
+
+pub fn send_extrinsic_and_wait_until_in_block(url: String, json_req: String, result_in: ThreadOut<String>) {
+    start_rpc_client_thread(url, json_req, result_in, on_extrinsic_msg_until_in_block)
+}
+
 pub fn send_extrinsic_and_wait_until_finalized(
     url: String,
     json_req: String,


### PR DESCRIPTION
`send_extrinsic` can now take `XtStatus::InBlock` and `XtStatus::Broadcast` as statuses to exit on.

## Changes

* Add `XtStatus::InBlock` and `XtStatus::Broadcast` cases to `send_extrinsic`
* Add `send_extrinsic_and_wait_until...` functions for `InBlock` and `Broadcast` to the rpc module
* Implement `on_extrinsic_msg_until...` functions in the rpc client
* Add tests against `parse_status` for `Inblock` and `Broadcast

## Testing against a substrate node

### InBlock

Modified `example_generic_extrinsic` (ln 51) to:

```rust
let tx_hash = api
    .send_extrinsic(xt.hex_encode(), XtStatus::InBlock)
    .unwrap();
println!("[+] Transaction got in block. Hash: {:?}", tx_hash);
```

Console output using `RUST_LOG=debug cargo run --example example_generic_extrinsic`:

```
...
2020-05-01T08:11:06Z DEBUG substrate_api_client::rpc::client] got msg {"jsonrpc":"2.0","method":"author_extrinsicUpdate","params":{"result":{"inBlock":"0x1377c2c36f2776c80d903895b74dfd726ad1d1e599ac2ba7f991d5f08abd69f5"},"subscription":6}}
[2020-05-01T08:11:06Z INFO  substrate_api_client::rpc::client] inBlock: String("0x1377c2c36f2776c80d903895b74dfd726ad1d1e599ac2ba7f991d5f08abd69f5")
[2020-05-01T08:11:06Z INFO  substrate_api_client] inBlock: "0x1377c2c36f2776c80d903895b74dfd726ad1d1e599ac2ba7f991d5f08abd69f5"
[+] Transaction got in block. Hash: Some(0x1377c2c36f2776c80d903895b74dfd726ad1d1e599ac2ba7f991d5f08abd69f5)
```

### Broadcast

Modified `example_generic_extrinsic` (ln 51) to:

```rust
let _ = api
   .send_extrinsic(xt.hex_encode(), XtStatus::Broadcast)
   .unwrap();
```

Console output using `RUST_LOG=debug cargo run --example example_generic_extrinsic`:

```
...
[2020-05-01T08:39:24Z INFO  substrate_api_client::rpc::client] inBlock: String("0x46ab184e79d23c7e30a0589c825d6f1148d5b9c2a9907bc1e5b0bc6239c74042")
...             
[2020-05-01T08:29:55Z DEBUG substrate_api_client::rpc::client] got msg {"jsonrpc":"2.0","method":"author_extrinsicUpdate","params":{"result":{"finalized":"0x91f73815187eb639de5ee2a7ae29f695dc335e0a8586cd6a4598a15155ceaf06"},"subscription":8}}
[2020-05-01T08:29:55Z INFO  substrate_api_client::rpc::client] finalized: String("0x91f73815187eb639de5ee2a7ae29f695dc335e0a8586cd6a4598a15155ceaf06")
[2020-05-01T08:29:55Z INFO  substrate_api_client] broadcast: "0x91f73815187eb639de5ee2a7ae29f695dc335e0a8586cd6a4598a15155ceaf06"
```

This showed that when waiting for broadcast, the broadcast status never appeared, so it just stopped on finalised instead. I think the reason for this is that I was only running a single validator node in my test, so there was nowhere for the node to broadcast the transaction.

Addresses https://github.com/scs/substrate-api-client/issues/65