### PR TITLE
Small api changes

### DIFF
--- a/src/examples/example_get_blocks.rs
+++ b/src/examples/example_get_blocks.rs
@@ -25,6 +25,8 @@ use sp_core::sr25519;
 
 use substrate_api_client::utils::hexstr_to_hash;
 use substrate_api_client::Api;
+use node_template_runtime::opaque::{Header};
+use node_template_runtime::Block;
 
 fn main() {
     env_logger::init();
@@ -39,19 +41,15 @@ fn main() {
 
     println!("Finalized Head:\n {} \n", head);
 
-    println!(
-        "Finalized header:\n {} \n",
-        api.get_header(Some(head.clone())).unwrap()
-    );
+    let h: Header = api.get_header(Some(head.clone())).unwrap();
+    println!("Finalized header:\n {:?} \n", h);
 
-    println!(
-        "Finalized block:\n {} \n",
-        api.get_block(Some(head)).unwrap()
-    );
+    let b: Block = api.get_block(Some(head)).unwrap();
+    println!("Finalized block:\n {:?} \n",b);
 
-    println!("Latest Header: \n {} \n", api.get_header(None).unwrap());
+    println!("Latest Header: \n {:?} \n", api.get_header::<Header>(None).unwrap());
 
-    println!("Latest block: \n {} \n", api.get_block(None).unwrap());
+    println!("Latest block: \n {:?} \n", api.get_block::<Block>(None).unwrap());
 }
 
 pub fn get_node_url_from_cli() -> String {

--- a/src/examples/example_get_blocks.rs
+++ b/src/examples/example_get_blocks.rs
@@ -23,9 +23,9 @@ use clap::App;
 
 use sp_core::sr25519;
 
-use substrate_api_client::Api;
-use node_template_runtime::opaque::{Header};
+use node_template_runtime::opaque::Header;
 use node_template_runtime::Block;
+use substrate_api_client::Api;
 
 fn main() {
     env_logger::init();
@@ -33,9 +33,7 @@ fn main() {
 
     let api = Api::<sr25519::Pair>::new(format!("ws://{}", url));
 
-    let head = api
-        .get_finalized_head()
-        .unwrap();
+    let head = api.get_finalized_head().unwrap();
 
     println!("Finalized Head:\n {} \n", head);
 
@@ -43,11 +41,17 @@ fn main() {
     println!("Finalized header:\n {:?} \n", h);
 
     let b: Block = api.get_block(Some(head)).unwrap();
-    println!("Finalized block:\n {:?} \n",b);
+    println!("Finalized block:\n {:?} \n", b);
 
-    println!("Latest Header: \n {:?} \n", api.get_header::<Header>(None).unwrap());
+    println!(
+        "Latest Header: \n {:?} \n",
+        api.get_header::<Header>(None).unwrap()
+    );
 
-    println!("Latest block: \n {:?} \n", api.get_block::<Block>(None).unwrap());
+    println!(
+        "Latest block: \n {:?} \n",
+        api.get_block::<Block>(None).unwrap()
+    );
 }
 
 pub fn get_node_url_from_cli() -> String {

--- a/src/examples/example_get_blocks.rs
+++ b/src/examples/example_get_blocks.rs
@@ -23,7 +23,6 @@ use clap::App;
 
 use sp_core::sr25519;
 
-use substrate_api_client::utils::hexstr_to_hash;
 use substrate_api_client::Api;
 use node_template_runtime::opaque::{Header};
 use node_template_runtime::Block;
@@ -36,7 +35,6 @@ fn main() {
 
     let head = api
         .get_finalized_head()
-        .map(|h_str| hexstr_to_hash(h_str).unwrap())
         .unwrap();
 
     println!("Finalized Head:\n {} \n", head);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -259,7 +259,7 @@ where
         Self::_get_request(self.url.clone(), jsonreq)
     }
 
-    pub fn get_storage_value<V: Decode + Clone>(
+    pub fn get_storage_value<V: Decode>(
         &self,
         storage_prefix: &'static str,
         storage_key_name: &'static str,
@@ -316,7 +316,7 @@ where
         self.get_storage_by_key_hash(storagekey.0)
     }
 
-    pub fn get_storage_by_key_hash<V: Decode + Clone>(&self, hash: Vec<u8>) -> Option<V> {
+    pub fn get_storage_by_key_hash<V: Decode>(&self, hash: Vec<u8>) -> Option<V> {
         let mut keyhash_str = hex::encode(hash);
         keyhash_str.insert_str(0, "0x");
         let jsonreq = json_req::state_get_storage(&keyhash_str);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,7 @@ use events::{EventsDecoder, RawEvent, RuntimeEvent};
 use sp_runtime::{AccountId32 as AccountId, MultiSignature};
 
 pub use sp_core::H256 as Hash;
+
 /// The block number type used in this runtime.
 pub type BlockNumber = u64;
 /// The timestamp moment type used in this runtime.
@@ -228,31 +229,37 @@ where
     }
 
     pub fn get_finalized_head(&self) -> Option<Hash> {
-        Self::_get_request(self.url.clone(),
-            json_req::chain_get_finalized_head().to_string())
-            .map(|h_str| hexstr_to_hash(h_str).unwrap())
-            .ok()
+        Self::_get_request(
+            self.url.clone(),
+            json_req::chain_get_finalized_head().to_string(),
+        )
+        .map(|h_str| hexstr_to_hash(h_str).unwrap())
+        .ok()
     }
 
     pub fn get_header<H>(&self, hash: Option<Hash>) -> Option<H>
-        where H: Header + DeserializeOwned
+    where
+        H: Header + DeserializeOwned,
     {
         Self::_get_request(
             self.url.clone(),
-            json_req::chain_get_header(hash).to_string())
-            .map(|h| serde_json::from_str(&h).unwrap())
-            .ok()
+            json_req::chain_get_header(hash).to_string(),
+        )
+        .map(|h| serde_json::from_str(&h).unwrap())
+        .ok()
     }
 
     pub fn get_block<B>(&self, hash: Option<Hash>) -> Option<B>
-        where B: Block + DeserializeOwned
+    where
+        B: Block + DeserializeOwned,
     {
         Self::_get_request(
             self.url.clone(),
-            json_req::chain_get_block(hash).to_string())
-            .map(|s| serde_json::from_str(&s).unwrap())
-            .map(|b: Value| serde_json::from_value(b["block"].clone()).unwrap())
-            .ok()
+            json_req::chain_get_block(hash).to_string(),
+        )
+        .map(|s| serde_json::from_str(&s).unwrap())
+        .map(|b: Value| serde_json::from_value(b["block"].clone()).unwrap())
+        .ok()
     }
 
     pub fn get_request(&self, jsonreq: String) -> WsResult<String> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,11 +227,11 @@ where
         }
     }
 
-    pub fn get_finalized_head(&self) -> WsResult<String> {
-        Self::_get_request(
-            self.url.clone(),
-            json_req::chain_get_finalized_head().to_string(),
-        )
+    pub fn get_finalized_head(&self) -> Option<Hash> {
+        Self::_get_request(self.url.clone(),
+            json_req::chain_get_finalized_head().to_string())
+            .map(|h_str| hexstr_to_hash(h_str).unwrap())
+            .ok()
     }
 
     pub fn get_header<H>(&self, hash: Option<Hash>) -> Option<H>


### PR DESCRIPTION
* `get_header` and `get_block` now return generics with the `Header`, `Block` trait bound
* get_finalized_head now returns `Option<Hash>`
* Unecessary `Clone` trait bound is removed from `get_storage_value` and `get_storage_by_keyhash`