### PR TITLE
user-extendable-eventdecoder

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -64,6 +64,7 @@ pub enum EventsError {
     TypeSizeUnavailable(String),
 }
 
+#[derive(Clone)]
 pub struct EventsDecoder {
     metadata: Metadata,
     type_sizes: HashMap<String, usize>,

--- a/src/examples/example_generic_event_callback.rs
+++ b/src/examples/example_generic_event_callback.rs
@@ -42,7 +42,7 @@ fn main() {
 
     api.subscribe_events(events_in.clone());
     let args: TransferEventArgs = api
-        .wait_for_event("Balances", "Transfer", &events_out)
+        .wait_for_event("Balances", "Transfer", None, &events_out)
         .unwrap()
         .unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -359,9 +359,10 @@ where
         &self,
         module: &str,
         variant: &str,
+        decoder: Option<EventsDecoder>,
         receiver: &Receiver<String>,
     ) -> Option<Result<E, CodecError>> {
-        self.wait_for_raw_event(module, variant, receiver)
+        self.wait_for_raw_event(module, variant, decoder, receiver)
             .map(|raw| E::decode(&mut &raw.data[..]))
     }
 
@@ -369,15 +370,18 @@ where
         &self,
         module: &str,
         variant: &str,
+        decoder: Option<EventsDecoder>,
         receiver: &Receiver<String>,
     ) -> Option<RawEvent> {
+        let event_decoder =
+            decoder.unwrap_or_else(|| EventsDecoder::try_from(self.metadata.clone()).unwrap());
+
         loop {
             let event_str = receiver.recv().unwrap();
 
             let _unhex = hexstr_to_vec(event_str).unwrap();
             let mut _er_enc = _unhex.as_slice();
 
-            let event_decoder = EventsDecoder::try_from(self.metadata.clone()).unwrap();
             let _events = event_decoder.decode_events(&mut _er_enc);
             info!("wait for raw event");
             match _events {


### PR DESCRIPTION
api.wait_for_event now takes Option<EventsDecoder> as argument such that a user is able to extend the encoder with custom primitive types

* tested with substratee-client example