### PR TITLE
remove unnecessary decode trait bound.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
   stages {
     stage('Start substrate-test-nodes') {
       steps {
-        copyArtifacts fingerprintArtifacts: true, projectName: 'substraTEE/substrate-api-client-test-node/master', selector: lastCompleted()
+        copyArtifacts fingerprintArtifacts: true, projectName: 'substraTEE/substrate-api-client-test-node_nightly', selector: lastCompleted()
         sh 'target/release/node-template purge-chain --dev -y'
         sh 'target/release/node-template --dev &'
       }

--- a/src/extrinsic/xt_primitives.rs
+++ b/src/extrinsic/xt_primitives.rs
@@ -62,7 +62,7 @@ pub struct SignedPayload<Call>((Call, GenericExtra, AdditionalSigned));
 
 impl<Call> SignedPayload<Call>
 where
-    Call: Encode + Decode,
+    Call: Encode,
 {
     pub fn from_raw(call: Call, extra: GenericExtra, additional_signed: AdditionalSigned) -> Self {
         Self((call, extra, additional_signed))


### PR DESCRIPTION
There was an unneccesarry decode trait bound on signed-payload.

This interfered with the `OpaqueCall` struct defined in the substratee-worker, that only implements encode and on purpose does not implement decode.