### PR TITLE
Allow for immortal transactions in compose_extrinsic_offline macro

### DIFF
--- a/src/examples/example_benchmark_bulk_xt.rs
+++ b/src/examples/example_benchmark_bulk_xt.rs
@@ -52,6 +52,8 @@ fn main() {
             api.clone().signer.unwrap(),
             Call::Balances(BalancesCall::transfer(to.clone(), 1_000_000)),
             nonce,
+            Era::Immortal,
+            api.genesis_hash,
             api.genesis_hash,
             api.runtime_version.spec_version
         );

--- a/src/examples/example_compose_extrinsic_offline.rs
+++ b/src/examples/example_compose_extrinsic_offline.rs
@@ -19,7 +19,7 @@
 use clap::{load_yaml, App};
 
 use keyring::AccountKeyring;
-use node_template_runtime::{BalancesCall, Call};
+use node_template_runtime::{BalancesCall, Call, Header};
 use sp_core::crypto::Pair;
 
 use substrate_api_client::{
@@ -33,6 +33,11 @@ fn main() {
     // initialize api and set the signer (sender) that is used to sign the extrinsics
     let from = AccountKeyring::Alice.pair();
     let api = Api::new(format!("ws://{}", url)).set_signer(from);
+
+    // Information for Era for mortal transactions
+    let head = api.get_finalized_head().unwrap();
+    let h: Header = api.get_header(Some(head)).unwrap();
+    let period = 5;
 
     println!(
         "[+] Alice's Account Nonce is {}\n",
@@ -48,10 +53,13 @@ fn main() {
         api.clone().signer.unwrap(),
         Call::Balances(BalancesCall::transfer(to.clone(), 42)),
         api.get_nonce().unwrap(),
+        Era::mortal(period, h.number.into()),
         api.genesis_hash,
+        head,
         api.runtime_version.spec_version
     );
 
+    
     println!("[+] Composed Extrinsic:\n {:?}\n", xt);
 
     // send and watch extrinsic until finalized

--- a/src/examples/example_compose_extrinsic_offline.rs
+++ b/src/examples/example_compose_extrinsic_offline.rs
@@ -58,7 +58,6 @@ fn main() {
         head,
         api.runtime_version.spec_version
     );
-
     
     println!("[+] Composed Extrinsic:\n {:?}\n", xt);
 

--- a/src/examples/example_compose_extrinsic_offline.rs
+++ b/src/examples/example_compose_extrinsic_offline.rs
@@ -58,7 +58,7 @@ fn main() {
         head,
         api.runtime_version.spec_version
     );
-    
+
     println!("[+] Composed Extrinsic:\n {:?}\n", xt);
 
     // send and watch extrinsic until finalized

--- a/src/extrinsic/mod.rs
+++ b/src/extrinsic/mod.rs
@@ -68,8 +68,8 @@ macro_rules! compose_extrinsic_offline {
     $genesis_hash: expr,
     $genesis_or_current_hash: expr,
     $runtime_spec_version: expr) => {{
-        use $crate::extrinsic::xt_primitives::*;
         use sp_runtime::generic::Era;
+        use $crate::extrinsic::xt_primitives::*;
         let extra = GenericExtra::new($era, $nonce);
         let raw_payload = SignedPayload::from_raw(
             $call.clone(),

--- a/src/extrinsic/mod.rs
+++ b/src/extrinsic/mod.rs
@@ -56,6 +56,7 @@ macro_rules! compose_call {
 /// * 'signer' - AccountKey that is used to sign the extrinsic.
 /// * 'call' - call as returned by the compose_call! macro or via substrate's call enums.
 /// * 'nonce' - signer's account nonce: u32
+/// * 'era' - Era for extrinsic to be valid
 /// * 'genesis_hash' - sp-runtime::Hash256/[u8; 32].
 /// * 'runtime_spec_version' - RuntimeVersion.spec_version/u32
 #[macro_export]
@@ -63,18 +64,20 @@ macro_rules! compose_extrinsic_offline {
     ($signer: expr,
     $call: expr,
     $nonce: expr,
+    $era: expr,
     $genesis_hash: expr,
+    $genesis_or_current_hash: expr,
     $runtime_spec_version: expr) => {{
         use $crate::extrinsic::xt_primitives::*;
-
-        let extra = GenericExtra::new($nonce);
+        use sp_runtime::generic::Era;
+        let extra = GenericExtra::new($era, $nonce);
         let raw_payload = SignedPayload::from_raw(
             $call.clone(),
             extra.clone(),
             (
                 $runtime_spec_version,
                 $genesis_hash,
-                $genesis_hash,
+                $genesis_or_current_hash,
                 (),
                 (),
                 (),
@@ -125,6 +128,8 @@ macro_rules! compose_extrinsic {
                     signer,
                     call.clone(),
                     $api.get_nonce().unwrap(),
+                    Era::Immortal,
+                    $api.genesis_hash,
                     $api.genesis_hash,
                     $api.runtime_version.spec_version
                 )

--- a/src/extrinsic/xt_primitives.rs
+++ b/src/extrinsic/xt_primitives.rs
@@ -42,14 +42,14 @@ pub type GenericAddress = AccountId; //Address<AccountId, AccountIndex>;
 pub struct GenericExtra(Era, Compact<u32>, Compact<u128>);
 
 impl GenericExtra {
-    pub fn new(nonce: u32) -> GenericExtra {
-        GenericExtra(Era::Immortal, Compact(nonce), Compact(0 as u128))
+    pub fn new(era: Era, nonce: u32) -> GenericExtra {
+        GenericExtra(era, Compact(nonce), Compact(0 as u128))
     }
 }
 
 impl Default for GenericExtra {
     fn default() -> Self {
-        Self::new(0)
+        Self::new(Era::Immortal, 0)
     }
 }
 


### PR DESCRIPTION
PR referencing Issue #88 

- mortal era for compose_extrinsic_offline macro
- example_benchmark_bulk_xt updated to use macro
- example_compose_extrinsic_offline updated to use macro