### PR TITLE
get map key prefix

### DIFF
--- a/src/examples/example_get_storage.rs
+++ b/src/examples/example_get_storage.rs
@@ -44,8 +44,7 @@ fn main() {
     println!("[+] block hash for blocknumber 42 is {:?}", result);
 
     // get StorageMap key prefix
-    let result = api
-    .get_storage_map_key_prefix("System", "BlockHash");
+    let result = api.get_storage_map_key_prefix("System", "BlockHash");
     println!("[+] key prefix for System BlockHash map is {:?}", result);
 
     // get StorageDoubleMap

--- a/src/examples/example_get_storage.rs
+++ b/src/examples/example_get_storage.rs
@@ -43,6 +43,11 @@ fn main() {
         .unwrap();
     println!("[+] block hash for blocknumber 42 is {:?}", result);
 
+    // get StorageMap key prefix
+    let result = api
+    .get_storage_map_key_prefix("System", "BlockHash");
+    println!("[+] key prefix for System BlockHash map is {:?}", result);
+
     // get StorageDoubleMap
     let result: u32 = api
         .get_storage_double_map("TemplateModule", "SomeDoubleMap", 1_u32, 2_u32, None)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -305,6 +305,16 @@ where
         self.get_storage_by_key_hash(storagekey, at_block)
     }
 
+    pub fn get_storage_map_key_prefix(
+        &self,
+        storage_prefix: &'static str,
+        storage_key_name: &'static str,
+    ) -> StorageKey {
+        self.metadata
+            .storage_map_key_prefix(storage_prefix, storage_key_name)
+            .unwrap()
+    }
+
     pub fn get_storage_double_map<K: Encode, Q: Encode, V: Decode + Clone>(
         &self,
         storage_prefix: &'static str,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -410,11 +410,7 @@ where
             .map(|proof| serde_json::from_str(&proof).unwrap())
     }
 
-    pub fn get_keys(
-        &self,
-        key: StorageKey,
-        at_block: Option<Hash>,
-    ) -> Option<Vec<String>> {
+    pub fn get_keys(&self, key: StorageKey, at_block: Option<Hash>) -> Option<Vec<String>> {
         let jsonreq = json_req::state_get_keys(key, at_block);
         Self::_get_request(self.url.clone(), jsonreq.to_string())
             .map(|keys| serde_json::from_str(&keys).unwrap())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -410,6 +410,16 @@ where
             .map(|proof| serde_json::from_str(&proof).unwrap())
     }
 
+    pub fn get_keys(
+        &self,
+        key: StorageKey,
+        at_block: Option<Hash>,
+    ) -> Option<Vec<String>> {
+        let jsonreq = json_req::state_get_keys(key, at_block);
+        Self::_get_request(self.url.clone(), jsonreq.to_string())
+            .map(|keys| serde_json::from_str(&keys).unwrap())
+    }
+
     pub fn send_extrinsic(
         &self,
         xthex_prefixed: String,

--- a/src/node_metadata.rs
+++ b/src/node_metadata.rs
@@ -172,6 +172,16 @@ impl Metadata {
             .key(map_key))
     }
 
+    pub fn storage_map_key_prefix(
+        &self,
+        storage_prefix: &'static str,
+        storage_key_name: &'static str,
+    ) -> Result<StorageKey, MetadataError> {
+        self.module(storage_prefix)?
+            .storage(storage_key_name)?
+            .get_map_prefix()
+    }
+
     pub fn storage_double_map_key<K: Encode, Q: Encode, V: Decode + Clone>(
         &self,
         storage_prefix: &'static str,
@@ -326,6 +336,17 @@ impl StorageMetadata {
             _ => Err(MetadataError::StorageTypeError),
         }
     }
+    pub fn get_map_prefix(&self) -> Result<StorageKey, MetadataError> {
+        match &self.ty {
+            StorageEntryType::Map { .. } => {
+                let mut bytes = sp_core::twox_128(&self.module_prefix.as_bytes().to_vec()).to_vec();
+                bytes.extend(&sp_core::twox_128(&self.storage_prefix.as_bytes().to_vec())[..]);
+                Ok(StorageKey(bytes))
+            }
+            _ => Err(MetadataError::StorageTypeError),
+        }
+    }
+
     pub fn get_value(&self) -> Result<StorageValue, MetadataError> {
         match &self.ty {
             StorageEntryType::Plain { .. } => {

--- a/src/rpc/json_req.rs
+++ b/src/rpc/json_req.rs
@@ -99,6 +99,14 @@ pub fn state_get_read_proof(keys: Vec<StorageKey>, at_block: Option<Hash>) -> Va
     )
 }
 
+pub fn state_get_keys(key: StorageKey, at_block: Option<Hash>) -> Value {
+    json_req(
+        "state_getKeys",
+        vec![to_value(key).unwrap(), to_value(at_block).unwrap()],
+        1,
+    )
+}
+
 pub fn author_submit_and_watch_extrinsic(xthex_prefixed: &str) -> Value {
     author_submit_and_watch_extrinsic_with_id(xthex_prefixed, REQUEST_TRANSFER)
 }


### PR DESCRIPTION
This may be useful for getting keys with key prefix in storage maps

- use `state_getKeys` in json_req
- add `get_storage_map_key_prefix` method for api client