### PR TITLE
Re export sp_runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3349,7 +3349,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-api-client"
-version = "0.4.7-sub2.0.0-rc5"
+version = "0.4.8-sub2.0.0-rc5"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-api-client"
-version = "0.4.7-sub2.0.0-rc5"
+version = "0.4.8-sub2.0.0-rc5"
 authors = ["Supercomputing Systems AG <info@scs.ch>"]
 edition = "2018"
 

--- a/src/extrinsic/mod.rs
+++ b/src/extrinsic/mod.rs
@@ -69,8 +69,8 @@ macro_rules! compose_extrinsic_offline {
     $genesis_or_current_hash: expr,
     $runtime_spec_version: expr,
     $transaction_version: expr) => {{
-        use sp_runtime::generic::Era;
         use $crate::extrinsic::xt_primitives::*;
+        use $crate::sp_runtime::generic::Era;
         let extra = GenericExtra::new($era, $nonce);
         let raw_payload = SignedPayload::from_raw(
             $call.clone(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,6 +80,8 @@ use events::{EventsDecoder, RawEvent, RuntimeEvent};
 #[cfg(feature = "std")]
 use sp_runtime::{generic::SignedBlock, AccountId32 as AccountId, MultiSignature};
 
+pub extern crate sp_runtime;
+
 pub use sp_core::H256 as Hash;
 
 /// The block number type used in this runtime.

--- a/test_no_std/Cargo.lock
+++ b/test_no_std/Cargo.lock
@@ -978,7 +978,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "substrate-api-client"
-version = "0.4.7-sub2.0.0-rc5"
+version = "0.4.8-sub2.0.0-rc5"
 dependencies = [
  "frame-metadata",
  "frame-support",


### PR DESCRIPTION
re-export sp_runtime such that third parties importing the api-client do not need to depend on it if the use the compose macros.
Closes #97 