### PR TITLE
[test_no_std] add `resolver = 2` in toml

### DIFF
--- a/test_no_std/Cargo.lock
+++ b/test_no_std/Cargo.lock
@@ -944,7 +944,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "substrate-api-client"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "frame-metadata",
  "frame-support",
@@ -992,7 +992,7 @@ dependencies = [
 
 [[package]]
 name = "test_no_std"
-version = "0.1.0"
+version = "0.6.0"
 dependencies = [
  "libc",
  "sp-application-crypto",

--- a/test_no_std/Cargo.toml
+++ b/test_no_std/Cargo.toml
@@ -3,6 +3,7 @@ name = "test_no_std"
 version = "0.6.0"
 authors = ["Alain Brenzikofer <alain.brenzikofer@scs.ch>"]
 edition = "2018"
+resolver = "2"
 
 [profile.dev]
 panic = "abort"


### PR DESCRIPTION
Currently, this changes nothing, but this is an improvement of the cargo dependency resolution that might prevent `std` leakage into `no_std` builds for dev-dependencies of procedural macros. See: https://github.com/paritytech/substrate/issues/8891