### PR TITLE
add alloc feature to no-std hex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 env_logger      = { version = "0.7", optional = true }
 ws              = { version = "0.9.1", optional = true, features = ["ssl"] }
-hex             = { version = "0.4.2", default-features = false }
+hex             = { version = "0.4.3", default-features = false, features = ["alloc"] }
 log             = { version = "0.4", optional = true }
 serde           = { version = "1.0", optional = true, features = ["derive"] }
 serde_json      = { version = "1.0", optional = true }

--- a/client-keystore/Cargo.toml
+++ b/client-keystore/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 parking_lot = "0.10.0"
 async-trait = "0.1.30"
-hex = "0.4.2"
+hex = "0.4"
 serde_json = "1.0"
 
 [dependencies.sp-core]


### PR DESCRIPTION
Necessary from v 0.4.3 on - otherwise decode will not work in no-std environment anymore