### PR TITLE
fix + remove full-crypto feature flag and make it implicit.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3863,6 +3863,7 @@ dependencies = [
  "primitive-types 0.6.2",
  "serde",
  "serde_json",
+ "sp-application-crypto",
  "sp-core",
  "sp-keyring",
  "sp-rpc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,13 @@ branch = "master"
 package = "sp-std"
 default-features = false
 
+# need to add this for the app_crypto macro
+[dependencies.sp-application-crypto]
+git = "https://github.com/paritytech/substrate.git"
+branch = "master"
+default-features = false
+features = ["full_crypto"]
+
 [dev-dependencies.node-template-runtime]
 branch = "bump-to-polkadot-v0.9.2"
 git = "https://github.com/scs/substrate-api-client-test-node"
@@ -107,6 +114,7 @@ version = "2.33"
 [features]
 default = ["std", "ws-client"]
 std = [
+	"sp-application-crypto/std",
 	"sp-core/std",
 	"codec/std",
 	"metadata/std",
@@ -127,9 +135,6 @@ std = [
 ]
 ws-client = ["ws"]
 staking-xt = ["std", "staking"]
-
-# need to add this for the app_crypto macro
-full_crypto = []
 
 [[example]]
 name = "example_get_storage"

--- a/test_no_std/Cargo.lock
+++ b/test_no_std/Cargo.lock
@@ -950,6 +950,7 @@ dependencies = [
  "frame-support",
  "hex",
  "parity-scale-codec",
+ "sp-application-crypto",
  "sp-core",
  "sp-runtime",
  "sp-std",
@@ -995,7 +996,6 @@ name = "test_no_std"
 version = "0.6.0"
 dependencies = [
  "libc",
- "sp-application-crypto",
  "sp-io",
  "substrate-api-client",
 ]

--- a/test_no_std/Cargo.toml
+++ b/test_no_std/Cargo.toml
@@ -18,14 +18,6 @@ libc = { version="0.2", default-features=false }
 package = "substrate-api-client"
 path = ".."
 default-features=false
-features=["full_crypto"]
-
-[dependencies.application-crypto]
-git = "https://github.com/paritytech/substrate.git"
-branch = "master"
-package = "sp-application-crypto"
-default-features = false
-features = ["full_crypto"]
 
 [dependencies.sp-io]
 git = "https://github.com/paritytech/substrate.git"


### PR DESCRIPTION
This removes the need to depend on `sp-application-crypto` in the depending crate  when the api-client is used in a no_std environment.