### PR TITLE
Add staking extrinsics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -875,6 +875,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "frame-election-provider-support"
+version = "3.0.0"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1d7f6e12c651d776fc0dc1adefd007bb60f60b63"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec 2.1.1",
+ "sp-arithmetic",
+ "sp-npos-elections",
+ "sp-std",
+]
+
+[[package]]
 name = "frame-executive"
 version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=master#1d7f6e12c651d776fc0dc1adefd007bb60f60b63"
@@ -2125,6 +2138,28 @@ dependencies = [
  "sp-staking",
  "sp-std",
  "sp-trie",
+]
+
+[[package]]
+name = "pallet-staking"
+version = "3.0.0"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1d7f6e12c651d776fc0dc1adefd007bb60f60b63"
+dependencies = [
+ "frame-election-provider-support",
+ "frame-support",
+ "frame-system",
+ "log",
+ "pallet-authorship",
+ "pallet-session",
+ "parity-scale-codec 2.1.1",
+ "paste 1.0.5",
+ "serde",
+ "sp-application-crypto",
+ "sp-io",
+ "sp-runtime",
+ "sp-staking",
+ "sp-std",
+ "static_assertions",
 ]
 
 [[package]]
@@ -3482,6 +3517,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-npos-elections"
+version = "3.0.0"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1d7f6e12c651d776fc0dc1adefd007bb60f60b63"
+dependencies = [
+ "parity-scale-codec 2.1.1",
+ "serde",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-npos-elections-compact",
+ "sp-std",
+]
+
+[[package]]
+name = "sp-npos-elections-compact"
+version = "3.0.0"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1d7f6e12c651d776fc0dc1adefd007bb60f60b63"
+dependencies = [
+ "proc-macro-crate 1.0.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "sp-offchain"
 version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=master#1d7f6e12c651d776fc0dc1adefd007bb60f60b63"
@@ -3787,6 +3846,7 @@ dependencies = [
  "log",
  "node-template-runtime",
  "pallet-balances",
+ "pallet-staking",
  "parity-scale-codec 2.1.1",
  "primitive-types 0.6.2",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3559,6 +3559,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-rpc"
+version = "3.0.0"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1d7f6e12c651d776fc0dc1adefd007bb60f60b63"
+dependencies = [
+ "rustc-hash",
+ "serde",
+ "sp-core",
+ "tracing-core",
+]
+
+[[package]]
 name = "sp-runtime"
 version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=master#1d7f6e12c651d776fc0dc1adefd007bb60f60b63"
@@ -3847,12 +3858,14 @@ dependencies = [
  "node-template-runtime",
  "pallet-balances",
  "pallet-staking",
+ "pallet-transaction-payment",
  "parity-scale-codec 2.1.1",
  "primitive-types 0.6.2",
  "serde",
  "serde_json",
  "sp-core",
  "sp-keyring",
+ "sp-rpc",
  "sp-runtime",
  "sp-std",
  "sp-version",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,20 @@ branch = "master"
 package = "frame-system"
 optional = true
 
+[dependencies.transaction-payment]
+git = "https://github.com/paritytech/substrate.git"
+branch = "master"
+package = "pallet-transaction-payment"
+default-features = false
+optional = true
+
+[dependencies.sp-rpc]
+git = "https://github.com/paritytech/substrate.git"
+branch = "master"
+package = "sp-rpc"
+default-features = false
+optional = true
+
 [dependencies.sp-runtime]
 git = "https://github.com/paritytech/substrate.git"
 branch = "master"
@@ -98,7 +112,6 @@ std = [
 	"metadata/std",
 	"sp-version",
 	"balances",
-	"staking",
 	"system",
 	"sp-runtime/std",
 	"support/std",
@@ -109,8 +122,11 @@ std = [
 	"hex/std",
 	"primitive-types",
 	"thiserror",
+	"sp-rpc",
+	"transaction-payment/std"
 ]
 ws-client = ["ws"]
+staking-xt = ["std", "staking"]
 
 # need to add this for the app_crypto macro
 full_crypto = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,12 @@ branch = "master"
 package = "pallet-balances"
 optional = true
 
+[dependencies.staking]
+git = "https://github.com/paritytech/substrate.git"
+branch = "master"
+package = "pallet-staking"
+optional = true
+
 [dependencies.system]
 git = "https://github.com/paritytech/substrate.git"
 branch = "master"
@@ -92,6 +98,7 @@ std = [
 	"metadata/std",
 	"sp-version",
 	"balances",
+	"staking",
 	"system",
 	"sp-runtime/std",
 	"support/std",

--- a/src/extrinsic/balances.rs
+++ b/src/extrinsic/balances.rs
@@ -18,6 +18,7 @@
 use codec::Compact;
 
 use super::xt_primitives::*;
+use crate::extrinsic::CallIndex;
 #[cfg(feature = "std")]
 use crate::{
     compose_extrinsic,
@@ -30,7 +31,6 @@ pub const BALANCES_MODULE: &str = "Balances";
 pub const BALANCES_TRANSFER: &str = "transfer";
 pub const BALANCES_SET_BALANCE: &str = "set_balance";
 
-pub type CallIndex = [u8; 2];
 pub type Balance = u128;
 
 pub type BalanceTransferFn = (CallIndex, GenericAddress, Compact<Balance>);

--- a/src/extrinsic/contract.rs
+++ b/src/extrinsic/contract.rs
@@ -21,6 +21,7 @@ use sp_core::H256 as Hash;
 use sp_runtime::{MultiSignature, MultiSigner};
 use sp_std::prelude::*;
 
+use crate::extrinsic::CallIndex;
 #[cfg(feature = "std")]
 use crate::{
     compose_extrinsic,
@@ -33,8 +34,6 @@ pub const CONTRACTS_MODULE: &str = "Contract";
 pub const CONTRACTS_PUT_CODE: &str = "put_code";
 pub const CONTRACTS_INSTANTIATE: &str = "instantiate";
 pub const CONTRACTS_CALL: &str = "call";
-
-type CallIndex = [u8; 2];
 
 type Gas = u64;
 type Data = Vec<u8>;

--- a/src/extrinsic/mod.rs
+++ b/src/extrinsic/mod.rs
@@ -27,7 +27,11 @@ pub extern crate log;
 pub mod balances;
 #[cfg(feature = "std")]
 pub mod contract;
+#[cfg(feature = "std")]
+pub mod staking;
 pub mod xt_primitives;
+
+pub type CallIndex = [u8; 2];
 
 /// Generates the extrinsic's call field for a given module and call passed as &str
 /// # Arguments
@@ -119,6 +123,7 @@ macro_rules! compose_extrinsic {
 	$call: expr
 	$(, $args: expr) *) => {
 		{
+            #[allow(unused_imports)] // For when extrinsic does not use Compact
             use $crate::extrinsic::codec::Compact;
             use $crate::extrinsic::log::info;
             use $crate::extrinsic::xt_primitives::*;

--- a/src/extrinsic/mod.rs
+++ b/src/extrinsic/mod.rs
@@ -27,7 +27,7 @@ pub extern crate log;
 pub mod balances;
 #[cfg(feature = "std")]
 pub mod contract;
-#[cfg(feature = "std")]
+#[cfg(feature = "staking-xt")]
 pub mod staking;
 pub mod xt_primitives;
 

--- a/src/extrinsic/staking.rs
+++ b/src/extrinsic/staking.rs
@@ -16,6 +16,7 @@ const STAKING_REBOND: &str = "rebond";
 const STAKING_WITHDRAW_UNBONDED: &str = "withdraw_unbonded";
 const STAKING_NOMINATE: &str = "nominate";
 const STAKING_CHILL: &str = "chill";
+const STAKING_SET_CONTROLLER: &str = "set_controller";
 
 pub type StakingBondFn = (
     CallIndex,
@@ -29,6 +30,7 @@ pub type StakingRebondFn = (CallIndex, Compact<Balance>);
 pub type StakingWithdrawUnbondedFn = (CallIndex, u32);
 pub type StakingNominateFn = (CallIndex, Vec<GenericAddress>);
 pub type StakingChillFn = CallIndex;
+pub type StakingSetControllerFn = (CallIndex, GenericAddress);
 
 pub type StakingBondXt = UncheckedExtrinsicV4<StakingBondFn>;
 pub type StakingBondExtraXt = UncheckedExtrinsicV4<StakingBondExtraFn>;
@@ -37,6 +39,7 @@ pub type StakingRebondXt = UncheckedExtrinsicV4<StakingRebondFn>;
 pub type StakingWithdrawUnbondedXt = UncheckedExtrinsicV4<StakingWithdrawUnbondedFn>;
 pub type StakingNominateXt = UncheckedExtrinsicV4<StakingNominateFn>;
 pub type StakingChillXt = UncheckedExtrinsicV4<StakingChillFn>;
+pub type StakingSetControllerXt = UncheckedExtrinsicV4<StakingSetControllerFn>;
 
 // https://polkadot.js.org/docs/substrate/extrinsics#staking
 impl<P, Client> Api<P, Client>
@@ -101,5 +104,12 @@ where
     /// Stop nominating por validating. Effects take place in the next era
     pub fn staking_chill(&self) -> StakingChillXt {
         compose_extrinsic!(self, STAKING_MODULE, STAKING_CHILL)
+    }
+
+    /// (Re-)set the controller of the stash
+    /// Effects will be felt at the beginning of the next era.
+    /// Must be Signed by the stash, not the controller.
+    pub fn staking_set_controller(&self, controller: GenericAddress) -> StakingSetControllerXt {
+        compose_extrinsic!(self, STAKING_MODULE, STAKING_SET_CONTROLLER, controller)
     }
 }

--- a/src/extrinsic/staking.rs
+++ b/src/extrinsic/staking.rs
@@ -1,0 +1,105 @@
+pub use staking::RewardDestination;
+
+use codec::Compact;
+use sp_core::Pair;
+use sp_runtime::{MultiSignature, MultiSigner};
+
+use crate::extrinsic::balances::Balance;
+use crate::extrinsic::CallIndex;
+use crate::{compose_extrinsic, Api, GenericAddress, RpcClient, UncheckedExtrinsicV4};
+
+const STAKING_MODULE: &str = "Staking";
+const STAKING_BOND: &str = "bond";
+const STAKING_BOND_EXTRA: &str = "bond_extra";
+const STAKING_UNBOND: &str = "unbond";
+const STAKING_REBOND: &str = "rebond";
+const STAKING_WITHDRAW_UNBONDED: &str = "withdraw_unbonded";
+const STAKING_NOMINATE: &str = "nominate";
+const STAKING_CHILL: &str = "chill";
+
+pub type StakingBondFn = (
+    CallIndex,
+    GenericAddress,
+    Compact<Balance>,
+    RewardDestination<GenericAddress>,
+);
+pub type StakingBondExtraFn = (CallIndex, Compact<Balance>);
+pub type StakingUnbondFn = (CallIndex, Compact<Balance>);
+pub type StakingRebondFn = (CallIndex, Compact<Balance>);
+pub type StakingWithdrawUnbondedFn = (CallIndex, u32);
+pub type StakingNominateFn = (CallIndex, Vec<GenericAddress>);
+pub type StakingChillFn = CallIndex;
+
+pub type StakingBondXt = UncheckedExtrinsicV4<StakingBondFn>;
+pub type StakingBondExtraXt = UncheckedExtrinsicV4<StakingBondExtraFn>;
+pub type StakingUnbondXt = UncheckedExtrinsicV4<StakingUnbondFn>;
+pub type StakingRebondXt = UncheckedExtrinsicV4<StakingRebondFn>;
+pub type StakingWithdrawUnbondedXt = UncheckedExtrinsicV4<StakingWithdrawUnbondedFn>;
+pub type StakingNominateXt = UncheckedExtrinsicV4<StakingNominateFn>;
+pub type StakingChillXt = UncheckedExtrinsicV4<StakingChillFn>;
+
+// https://polkadot.js.org/docs/substrate/extrinsics#staking
+impl<P, Client> Api<P, Client>
+where
+    P: Pair,
+    MultiSignature: From<P::Signature>,
+    MultiSigner: From<P::Public>,
+    Client: RpcClient,
+{
+    /// Bond `value` amount to `controller`
+    pub fn staking_bond(
+        &self,
+        controller: GenericAddress,
+        value: Balance,
+        payee: RewardDestination<GenericAddress>,
+    ) -> StakingBondXt {
+        compose_extrinsic!(
+            self,
+            STAKING_MODULE,
+            STAKING_BOND,
+            controller,
+            Compact(value),
+            payee
+        )
+    }
+
+    /// Bonds extra funds from the stash's free balance to the balance for staking.
+    pub fn staking_bond_extra(&self, value: Balance) -> StakingBondExtraXt {
+        compose_extrinsic!(self, STAKING_MODULE, STAKING_BOND_EXTRA, Compact(value))
+    }
+
+    /// Unbond `value` portion of the stash.
+    /// If `value` is less than the minimum required, then the entire amount is unbound.
+    /// Must be signed by the controller of the stash.
+    pub fn staking_unbond(&self, value: Balance) -> StakingUnbondXt {
+        compose_extrinsic!(self, STAKING_MODULE, STAKING_UNBOND, Compact(value))
+    }
+
+    /// Rebond `value` portion of the current amount that is in the process of unbonding.
+    pub fn staking_rebond(&self, value: Balance) -> StakingRebondXt {
+        compose_extrinsic!(self, STAKING_MODULE, STAKING_REBOND, Compact(value))
+    }
+
+    /// Free the balance of the stash so the stash account can do whatever it wants.
+    /// Must be signed by the controller of the stash and called when EraElectionStatus is Closed.
+    /// For most users, `num_slashing_spans` should be 0.
+    pub fn staking_withdraw_unbonded(&self, num_slashing_spans: u32) -> StakingWithdrawUnbondedXt {
+        compose_extrinsic!(
+            self,
+            STAKING_MODULE,
+            STAKING_WITHDRAW_UNBONDED,
+            num_slashing_spans
+        )
+    }
+
+    /// Nominate `targets` as validators.
+    /// Must be signed by the controller of the stash and called when EraElectionStatus is Closed.
+    pub fn staking_nominate(&self, targets: Vec<GenericAddress>) -> StakingNominateXt {
+        compose_extrinsic!(self, STAKING_MODULE, STAKING_NOMINATE, targets)
+    }
+
+    /// Stop nominating por validating. Effects take place in the next era
+    pub fn staking_chill(&self) -> StakingChillXt {
+        compose_extrinsic!(self, STAKING_MODULE, STAKING_CHILL)
+    }
+}

--- a/src/std/mod.rs
+++ b/src/std/mod.rs
@@ -25,7 +25,7 @@ use log::{debug, info};
 use serde::de::DeserializeOwned;
 
 use crate::extrinsic;
-use crate::rpc::json_req;
+use crate::rpc::{json_req, FeeDetails};
 use crate::{AccountData, AccountInfo, Hash};
 
 pub type ApiResult<T> = Result<T, ApiClientError>;
@@ -361,6 +361,19 @@ where
         let k = self.get_request(jsonreq)?;
         match k {
             Some(keys) => Ok(Some(serde_json::from_str(&keys)?)),
+            None => Ok(None),
+        }
+    }
+
+    pub fn get_fee_details(
+        &self,
+        xthex_prefixed: &str,
+        at_block: Option<Hash>,
+    ) -> ApiResult<Option<FeeDetails>> {
+        let jsonreq = json_req::payment_query_fee_details(xthex_prefixed, at_block);
+        let res = self.get_request(jsonreq)?;
+        match res {
+            Some(details) => Ok(Some(serde_json::from_str(&details)?)),
             None => Ok(None),
         }
     }

--- a/src/std/mod.rs
+++ b/src/std/mod.rs
@@ -2,6 +2,7 @@ pub use metadata::RuntimeMetadataPrefixed;
 pub use serde_json::Value;
 pub use sp_core::crypto::Pair;
 pub use sp_core::storage::StorageKey;
+pub use sp_rpc::number::NumberOrHex;
 pub use sp_runtime::traits::{Block, Header};
 pub use sp_runtime::{
     generic::SignedBlock, traits::IdentifyAccount, AccountId32 as AccountId, MultiSignature,
@@ -9,6 +10,7 @@ pub use sp_runtime::{
 };
 pub use sp_std::prelude::*;
 pub use sp_version::RuntimeVersion;
+pub use transaction_payment::FeeDetails;
 
 pub use crate::std::rpc::XtStatus;
 pub use crate::utils::FromHexString;
@@ -25,7 +27,7 @@ use log::{debug, info};
 use serde::de::DeserializeOwned;
 
 use crate::extrinsic;
-use crate::rpc::{json_req, FeeDetails};
+use crate::rpc::json_req;
 use crate::{AccountData, AccountInfo, Hash};
 
 pub type ApiResult<T> = Result<T, ApiClientError>;
@@ -369,7 +371,7 @@ where
         &self,
         xthex_prefixed: &str,
         at_block: Option<Hash>,
-    ) -> ApiResult<Option<FeeDetails>> {
+    ) -> ApiResult<Option<FeeDetails<NumberOrHex>>> {
         let jsonreq = json_req::payment_query_fee_details(xthex_prefixed, at_block);
         let res = self.get_request(jsonreq)?;
         match res {

--- a/src/std/rpc/json_req.rs
+++ b/src/std/rpc/json_req.rs
@@ -50,6 +50,17 @@ pub fn chain_subscribe_finalized_heads() -> Value {
     json_req("chain_subscribeFinalizedHeads", Value::Null, 1)
 }
 
+pub fn payment_query_fee_details(xthex_prefixed: &str, at_block: Option<Hash>) -> Value {
+    json_req(
+        "payment_queryFeeDetails",
+        vec![
+            to_value(xthex_prefixed).unwrap(),
+            to_value(at_block).unwrap(),
+        ],
+        1,
+    )
+}
+
 pub fn state_get_metadata() -> Value {
     state_get_metadata_with_id(1)
 }

--- a/src/std/rpc/mod.rs
+++ b/src/std/rpc/mod.rs
@@ -18,6 +18,8 @@ use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "ws-client")]
 pub use ws_client::{EventsError, WsRpcClient};
+
+use crate::Balance;
 #[cfg(feature = "ws-client")]
 mod ws_client;
 
@@ -54,4 +56,60 @@ pub struct ReadProof<Hash> {
     pub at: Hash,
     /// A proof used to prove that storage entries are included in the storage trie
     pub proof: Vec<sp_core::Bytes>,
+}
+
+// Based on structures here
+// https://github.com/paritytech/substrate/blob/cf086eeb894e61b45c732b3dad2ce4dcc54fa1af/frame/transaction-payment/src/types.rs#L68
+// Would require pallet-transaction-payment and sp-rpc (for NumberOrHex) since the RPC returns either a number or hex string
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FeeDetails {
+    /// The minimum fee for a transaction to be included in a block.
+    pub inclusion_fee: Option<InclusionFee>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InclusionFee {
+    /// This is the minimum amount a user pays for a transaction. It is declared
+    /// as a base _weight_ in the runtime and converted to a fee using `WeightToFee`.
+    #[serde(deserialize_with = "deserialize_number_or_hex")]
+    pub base_fee: Balance,
+    /// The length fee, the amount paid for the encoded length (in bytes) of the transaction.
+    #[serde(deserialize_with = "deserialize_number_or_hex")]
+    pub len_fee: Balance,
+    /// - `targeted_fee_adjustment`: This is a multiplier that can tune the final fee based on
+    ///     the congestion of the network.
+    /// - `weight_fee`: This amount is computed based on the weight of the transaction. Weight
+    /// accounts for the execution time of a transaction.
+    ///
+    /// adjusted_weight_fee = targeted_fee_adjustment * weight_fee
+    #[serde(deserialize_with = "deserialize_number_or_hex")]
+    pub adjusted_weight_fee: Balance,
+}
+
+impl FeeDetails {
+    pub fn final_fee(&self) -> Balance {
+        if let Some(inclusion_fee) = &self.inclusion_fee {
+            inclusion_fee
+                .base_fee
+                .saturating_add(inclusion_fee.len_fee)
+                .saturating_add(inclusion_fee.adjusted_weight_fee)
+        } else {
+            0
+        }
+    }
+}
+
+fn deserialize_number_or_hex<'de, D>(deserializer: D) -> Result<u128, D::Error>
+where
+    D: serde::de::Deserializer<'de>,
+{
+    let s: &str = serde::de::Deserialize::deserialize(deserializer)?;
+    let num = if s.starts_with("0x") {
+        u128::from_str_radix(&s[2..], 16)
+    } else {
+        u128::from_str_radix(s, 10)
+    };
+    num.map_err(|e| serde::de::Error::custom(e.to_string()))
 }

--- a/src/std/rpc/mod.rs
+++ b/src/std/rpc/mod.rs
@@ -106,10 +106,10 @@ where
     D: serde::de::Deserializer<'de>,
 {
     let s: &str = serde::de::Deserialize::deserialize(deserializer)?;
-    let num = if s.starts_with("0x") {
-        u128::from_str_radix(&s[2..], 16)
+    let num = if let Some(hex) = s.strip_prefix("0x") {
+        u128::from_str_radix(hex, 16)
     } else {
-        u128::from_str_radix(s, 10)
+        s.parse::<u128>()
     };
     num.map_err(|e| serde::de::Error::custom(e.to_string()))
 }

--- a/src/std/rpc/mod.rs
+++ b/src/std/rpc/mod.rs
@@ -19,7 +19,6 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "ws-client")]
 pub use ws_client::{EventsError, WsRpcClient};
 
-use crate::Balance;
 #[cfg(feature = "ws-client")]
 mod ws_client;
 
@@ -56,60 +55,4 @@ pub struct ReadProof<Hash> {
     pub at: Hash,
     /// A proof used to prove that storage entries are included in the storage trie
     pub proof: Vec<sp_core::Bytes>,
-}
-
-// Based on structures here
-// https://github.com/paritytech/substrate/blob/cf086eeb894e61b45c732b3dad2ce4dcc54fa1af/frame/transaction-payment/src/types.rs#L68
-// Would require pallet-transaction-payment and sp-rpc (for NumberOrHex) since the RPC returns either a number or hex string
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct FeeDetails {
-    /// The minimum fee for a transaction to be included in a block.
-    pub inclusion_fee: Option<InclusionFee>,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct InclusionFee {
-    /// This is the minimum amount a user pays for a transaction. It is declared
-    /// as a base _weight_ in the runtime and converted to a fee using `WeightToFee`.
-    #[serde(deserialize_with = "deserialize_number_or_hex")]
-    pub base_fee: Balance,
-    /// The length fee, the amount paid for the encoded length (in bytes) of the transaction.
-    #[serde(deserialize_with = "deserialize_number_or_hex")]
-    pub len_fee: Balance,
-    /// - `targeted_fee_adjustment`: This is a multiplier that can tune the final fee based on
-    ///     the congestion of the network.
-    /// - `weight_fee`: This amount is computed based on the weight of the transaction. Weight
-    /// accounts for the execution time of a transaction.
-    ///
-    /// adjusted_weight_fee = targeted_fee_adjustment * weight_fee
-    #[serde(deserialize_with = "deserialize_number_or_hex")]
-    pub adjusted_weight_fee: Balance,
-}
-
-impl FeeDetails {
-    pub fn final_fee(&self) -> Balance {
-        if let Some(inclusion_fee) = &self.inclusion_fee {
-            inclusion_fee
-                .base_fee
-                .saturating_add(inclusion_fee.len_fee)
-                .saturating_add(inclusion_fee.adjusted_weight_fee)
-        } else {
-            0
-        }
-    }
-}
-
-fn deserialize_number_or_hex<'de, D>(deserializer: D) -> Result<u128, D::Error>
-where
-    D: serde::de::Deserializer<'de>,
-{
-    let s: &str = serde::de::Deserialize::deserialize(deserializer)?;
-    let num = if let Some(hex) = s.strip_prefix("0x") {
-        u128::from_str_radix(hex, 16)
-    } else {
-        s.parse::<u128>()
-    };
-    num.map_err(|e| serde::de::Error::custom(e.to_string()))
 }

--- a/src/std/rpc/ws_client/mod.rs
+++ b/src/std/rpc/ws_client/mod.rs
@@ -374,7 +374,7 @@ mod tests {
         let msg = "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32700,\"message\":\"Parse error\"},\"id\":null}";
         assert_eq!(
             parse_status(msg)
-                .map_err(|e| extract_extrinsic_error_msg(e))
+                .map_err(extract_extrinsic_error_msg)
                 .unwrap_err(),
             "extrinsic error code -32700: Parse error: ".to_string()
         );
@@ -382,7 +382,7 @@ mod tests {
         let msg = "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":1010,\"message\":\"Invalid Transaction\",\"data\":\"Bad Signature\"},\"id\":\"4\"}";
         assert_eq!(
             parse_status(msg)
-                .map_err(|e| extract_extrinsic_error_msg(e))
+                .map_err(extract_extrinsic_error_msg)
                 .unwrap_err(),
             "extrinsic error code 1010: Invalid Transaction: Bad Signature".to_string()
         );
@@ -390,7 +390,7 @@ mod tests {
         let msg = "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":1001,\"message\":\"Extrinsic has invalid format.\"},\"id\":\"0\"}";
         assert_eq!(
             parse_status(msg)
-                .map_err(|e| extract_extrinsic_error_msg(e))
+                .map_err(extract_extrinsic_error_msg)
                 .unwrap_err(),
             "extrinsic error code 1001: Extrinsic has invalid format.: ".to_string()
         );
@@ -398,7 +398,7 @@ mod tests {
         let msg = r#"{"jsonrpc":"2.0","error":{"code":1002,"message":"Verification Error: Execution(Wasmi(Trap(Trap { kind: Unreachable })))","data":"RuntimeApi(\"Execution(Wasmi(Trap(Trap { kind: Unreachable })))\")"},"id":"3"}"#;
         assert_eq!(
             parse_status(msg)
-                .map_err(|e| extract_extrinsic_error_msg(e))
+                .map_err(extract_extrinsic_error_msg)
                 .unwrap_err(),
             "extrinsic error code 1002: Verification Error: Execution(Wasmi(Trap(Trap { kind: Unreachable }))): RuntimeApi(\"Execution(Wasmi(Trap(Trap { kind: Unreachable })))\")".to_string()
         );

--- a/test_no_std/Cargo.lock
+++ b/test_no_std/Cargo.lock
@@ -348,9 +348,9 @@ dependencies = [
 
 [[package]]
 name = "hex"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"

--- a/tutorials/api-client-tutorial/Cargo.lock
+++ b/tutorials/api-client-tutorial/Cargo.lock
@@ -230,6 +230,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
+
+[[package]]
 name = "byte-slice-cast"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -554,6 +560,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "frame-election-provider-support"
+version = "3.0.0"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1d7f6e12c651d776fc0dc1adefd007bb60f60b63"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec 2.1.1",
+ "sp-arithmetic",
+ "sp-npos-elections",
+ "sp-std",
+]
+
+[[package]]
 name = "frame-metadata"
 version = "13.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=master#1d7f6e12c651d776fc0dc1adefd007bb60f60b63"
@@ -736,6 +755,12 @@ name = "futures-task"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a16bef9fc1a4dddb5bee51c989e3fbba26569cbb0e31f5b303c184e3dd33dae"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
@@ -988,6 +1013,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "972f5ae5d1cb9c6ae417789196c803205313edde988685da5e3aae0827b9e7fd"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83bdfbace3a0e81a4253f73b49e960b053e396a11012cbd49b9b74d6a2b67062"
+dependencies = [
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1394,6 +1428,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-authorship"
+version = "3.0.0"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1d7f6e12c651d776fc0dc1adefd007bb60f60b63"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "impl-trait-for-tuples",
+ "parity-scale-codec 2.1.1",
+ "sp-authorship",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "pallet-balances"
 version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=master#1d7f6e12c651d776fc0dc1adefd007bb60f60b63"
@@ -1405,6 +1453,64 @@ dependencies = [
  "parity-scale-codec 2.1.1",
  "sp-runtime",
  "sp-std",
+]
+
+[[package]]
+name = "pallet-session"
+version = "3.0.0"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1d7f6e12c651d776fc0dc1adefd007bb60f60b63"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "impl-trait-for-tuples",
+ "pallet-timestamp",
+ "parity-scale-codec 2.1.1",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-session",
+ "sp-staking",
+ "sp-std",
+ "sp-trie",
+]
+
+[[package]]
+name = "pallet-staking"
+version = "3.0.0"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1d7f6e12c651d776fc0dc1adefd007bb60f60b63"
+dependencies = [
+ "frame-election-provider-support",
+ "frame-support",
+ "frame-system",
+ "log",
+ "pallet-authorship",
+ "pallet-session",
+ "parity-scale-codec 2.1.1",
+ "paste",
+ "serde",
+ "sp-application-crypto",
+ "sp-io",
+ "sp-runtime",
+ "sp-staking",
+ "sp-std",
+ "static_assertions",
+]
+
+[[package]]
+name = "pallet-timestamp"
+version = "3.0.0"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1d7f6e12c651d776fc0dc1adefd007bb60f60b63"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "impl-trait-for-tuples",
+ "log",
+ "parity-scale-codec 2.1.1",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-std",
+ "sp-timestamp",
 ]
 
 [[package]]
@@ -2062,6 +2168,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-authorship"
+version = "3.0.0"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1d7f6e12c651d776fc0dc1adefd007bb60f60b63"
+dependencies = [
+ "async-trait",
+ "parity-scale-codec 2.1.1",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "sp-core"
 version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=master#1d7f6e12c651d776fc0dc1adefd007bb60f60b63"
@@ -2202,6 +2320,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-npos-elections"
+version = "3.0.0"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1d7f6e12c651d776fc0dc1adefd007bb60f60b63"
+dependencies = [
+ "parity-scale-codec 2.1.1",
+ "serde",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-npos-elections-compact",
+ "sp-std",
+]
+
+[[package]]
+name = "sp-npos-elections-compact"
+version = "3.0.0"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1d7f6e12c651d776fc0dc1adefd007bb60f60b63"
+dependencies = [
+ "proc-macro-crate 1.0.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "sp-panic-handler"
 version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=master#1d7f6e12c651d776fc0dc1adefd007bb60f60b63"
@@ -2260,6 +2402,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-session"
+version = "3.0.0"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1d7f6e12c651d776fc0dc1adefd007bb60f60b63"
+dependencies = [
+ "parity-scale-codec 2.1.1",
+ "sp-api",
+ "sp-core",
+ "sp-runtime",
+ "sp-staking",
+ "sp-std",
+]
+
+[[package]]
 name = "sp-staking"
 version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=master#1d7f6e12c651d776fc0dc1adefd007bb60f60b63"
@@ -2308,6 +2463,23 @@ dependencies = [
  "serde",
  "sp-debug-derive",
  "sp-std",
+]
+
+[[package]]
+name = "sp-timestamp"
+version = "3.0.0"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1d7f6e12c651d776fc0dc1adefd007bb60f60b63"
+dependencies = [
+ "async-trait",
+ "futures-timer",
+ "log",
+ "parity-scale-codec 2.1.1",
+ "sp-api",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-std",
+ "thiserror",
+ "wasm-timer",
 ]
 
 [[package]]
@@ -2425,6 +2597,7 @@ dependencies = [
  "hex",
  "log",
  "pallet-balances",
+ "pallet-staking",
  "parity-scale-codec 2.1.1",
  "primitive-types 0.6.2",
  "serde",
@@ -2776,6 +2949,87 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d54ee1d4ed486f78874278e63e4069fc1ab9f6a18ca492076ffb90c5eb2997fd"
+dependencies = [
+ "cfg-if 1.0.0",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b33f6a0694ccfea53d94db8b2ed1c3a8a4c86dd936b13b9f0a15ec4a451b900"
+dependencies = [
+ "bumpalo",
+ "lazy_static",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fba7978c679d53ce2d0ac80c8c175840feb849a161664365d1287b41f2e67f1"
+dependencies = [
+ "cfg-if 1.0.0",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "088169ca61430fe1e58b8096c24975251700e7b1f6fd91cc9d59b04fb9b18bd4"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be2241542ff3d9f241f5e2cb6dd09b37efe786df8851c54957683a49f0987a97"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7cff876b8f18eed75a66cf49b65e7f967cb354a7aa16003fb55dbfd25b44b4f"
+
+[[package]]
+name = "wasm-timer"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot 0.11.1",
+ "pin-utils",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmi"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2796,6 +3050,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea78c597064ba73596099281e2f4cfc019075122a65cdda3205af94f0b264d93"
 dependencies = [
  "parity-wasm",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e828417b379f3df7111d3a2a9e5753706cae29c41f7c4029ee9fd77f3e09e582"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/tutorials/api-client-tutorial/Cargo.lock
+++ b/tutorials/api-client-tutorial/Cargo.lock
@@ -230,12 +230,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bumpalo"
-version = "3.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
-
-[[package]]
 name = "byte-slice-cast"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -560,19 +554,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "frame-election-provider-support"
-version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1d7f6e12c651d776fc0dc1adefd007bb60f60b63"
-dependencies = [
- "frame-support",
- "frame-system",
- "parity-scale-codec 2.1.1",
- "sp-arithmetic",
- "sp-npos-elections",
- "sp-std",
-]
-
-[[package]]
 name = "frame-metadata"
 version = "13.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=master#1d7f6e12c651d776fc0dc1adefd007bb60f60b63"
@@ -755,12 +736,6 @@ name = "futures-task"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a16bef9fc1a4dddb5bee51c989e3fbba26569cbb0e31f5b303c184e3dd33dae"
-
-[[package]]
-name = "futures-timer"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
@@ -1013,15 +988,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "972f5ae5d1cb9c6ae417789196c803205313edde988685da5e3aae0827b9e7fd"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "js-sys"
-version = "0.3.51"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83bdfbace3a0e81a4253f73b49e960b053e396a11012cbd49b9b74d6a2b67062"
-dependencies = [
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1428,20 +1394,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pallet-authorship"
-version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1d7f6e12c651d776fc0dc1adefd007bb60f60b63"
-dependencies = [
- "frame-support",
- "frame-system",
- "impl-trait-for-tuples",
- "parity-scale-codec 2.1.1",
- "sp-authorship",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
 name = "pallet-balances"
 version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=master#1d7f6e12c651d776fc0dc1adefd007bb60f60b63"
@@ -1456,61 +1408,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "pallet-session"
+name = "pallet-transaction-payment"
 version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=master#1d7f6e12c651d776fc0dc1adefd007bb60f60b63"
 dependencies = [
  "frame-support",
  "frame-system",
- "impl-trait-for-tuples",
- "pallet-timestamp",
  "parity-scale-codec 2.1.1",
+ "serde",
+ "smallvec",
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-session",
- "sp-staking",
  "sp-std",
- "sp-trie",
-]
-
-[[package]]
-name = "pallet-staking"
-version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1d7f6e12c651d776fc0dc1adefd007bb60f60b63"
-dependencies = [
- "frame-election-provider-support",
- "frame-support",
- "frame-system",
- "log",
- "pallet-authorship",
- "pallet-session",
- "parity-scale-codec 2.1.1",
- "paste",
- "serde",
- "sp-application-crypto",
- "sp-io",
- "sp-runtime",
- "sp-staking",
- "sp-std",
- "static_assertions",
-]
-
-[[package]]
-name = "pallet-timestamp"
-version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1d7f6e12c651d776fc0dc1adefd007bb60f60b63"
-dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "impl-trait-for-tuples",
- "log",
- "parity-scale-codec 2.1.1",
- "sp-inherents",
- "sp-runtime",
- "sp-std",
- "sp-timestamp",
 ]
 
 [[package]]
@@ -2168,18 +2078,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-authorship"
-version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1d7f6e12c651d776fc0dc1adefd007bb60f60b63"
-dependencies = [
- "async-trait",
- "parity-scale-codec 2.1.1",
- "sp-inherents",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
 name = "sp-core"
 version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=master#1d7f6e12c651d776fc0dc1adefd007bb60f60b63"
@@ -2320,35 +2218,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-npos-elections"
-version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1d7f6e12c651d776fc0dc1adefd007bb60f60b63"
-dependencies = [
- "parity-scale-codec 2.1.1",
- "serde",
- "sp-arithmetic",
- "sp-core",
- "sp-npos-elections-compact",
- "sp-std",
-]
-
-[[package]]
-name = "sp-npos-elections-compact"
-version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1d7f6e12c651d776fc0dc1adefd007bb60f60b63"
-dependencies = [
- "proc-macro-crate 1.0.0",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "sp-panic-handler"
 version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=master#1d7f6e12c651d776fc0dc1adefd007bb60f60b63"
 dependencies = [
  "backtrace",
+]
+
+[[package]]
+name = "sp-rpc"
+version = "3.0.0"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1d7f6e12c651d776fc0dc1adefd007bb60f60b63"
+dependencies = [
+ "rustc-hash",
+ "serde",
+ "sp-core",
+ "tracing-core",
 ]
 
 [[package]]
@@ -2402,19 +2287,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-session"
-version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1d7f6e12c651d776fc0dc1adefd007bb60f60b63"
-dependencies = [
- "parity-scale-codec 2.1.1",
- "sp-api",
- "sp-core",
- "sp-runtime",
- "sp-staking",
- "sp-std",
-]
-
-[[package]]
 name = "sp-staking"
 version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=master#1d7f6e12c651d776fc0dc1adefd007bb60f60b63"
@@ -2463,23 +2335,6 @@ dependencies = [
  "serde",
  "sp-debug-derive",
  "sp-std",
-]
-
-[[package]]
-name = "sp-timestamp"
-version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1d7f6e12c651d776fc0dc1adefd007bb60f60b63"
-dependencies = [
- "async-trait",
- "futures-timer",
- "log",
- "parity-scale-codec 2.1.1",
- "sp-api",
- "sp-inherents",
- "sp-runtime",
- "sp-std",
- "thiserror",
- "wasm-timer",
 ]
 
 [[package]]
@@ -2597,12 +2452,13 @@ dependencies = [
  "hex",
  "log",
  "pallet-balances",
- "pallet-staking",
+ "pallet-transaction-payment",
  "parity-scale-codec 2.1.1",
  "primitive-types 0.6.2",
  "serde",
  "serde_json",
  "sp-core",
+ "sp-rpc",
  "sp-runtime",
  "sp-std",
  "sp-version",
@@ -2949,87 +2805,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.74"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54ee1d4ed486f78874278e63e4069fc1ab9f6a18ca492076ffb90c5eb2997fd"
-dependencies = [
- "cfg-if 1.0.0",
- "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.74"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b33f6a0694ccfea53d94db8b2ed1c3a8a4c86dd936b13b9f0a15ec4a451b900"
-dependencies = [
- "bumpalo",
- "lazy_static",
- "log",
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fba7978c679d53ce2d0ac80c8c175840feb849a161664365d1287b41f2e67f1"
-dependencies = [
- "cfg-if 1.0.0",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.74"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "088169ca61430fe1e58b8096c24975251700e7b1f6fd91cc9d59b04fb9b18bd4"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.74"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be2241542ff3d9f241f5e2cb6dd09b37efe786df8851c54957683a49f0987a97"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-backend",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.74"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7cff876b8f18eed75a66cf49b65e7f967cb354a7aa16003fb55dbfd25b44b4f"
-
-[[package]]
-name = "wasm-timer"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
-dependencies = [
- "futures",
- "js-sys",
- "parking_lot 0.11.1",
- "pin-utils",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
 name = "wasmi"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3050,16 +2825,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea78c597064ba73596099281e2f4cfc019075122a65cdda3205af94f0b264d93"
 dependencies = [
  "parity-wasm",
-]
-
-[[package]]
-name = "web-sys"
-version = "0.3.51"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e828417b379f3df7111d3a2a9e5753706cae29c41f7c4029ee9fd77f3e09e582"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
 ]
 
 [[package]]


### PR DESCRIPTION
Overview:
- Added the most common (in my opinion) staking extrinsics
- Added api call for getting fee details (payment_queryFeeDetails)

~~The custom `FeeDetails` and `InclusionFee` are added because we would need both `pallet-transaction-payment` and `sp-rpc` (for `NumberOrHex`), which is quite a lot of extra stuff.~~

~~It also may not be necessary to add the entire `pallet-staking` crate, if we are ok with adding a copy of `RewardDestination`. I'm not sure if this pallet will be useful for anything else in the future. Please let me know and I will remove the import.~~