### PR TITLE
Change return type of Api::get_fee_details()

### DIFF
--- a/src/std/mod.rs
+++ b/src/std/mod.rs
@@ -405,7 +405,11 @@ where
 }
 
 fn convert_fee_details(details: FeeDetails<NumberOrHex>) -> ApiResult<FeeDetails<u128>> {
-    let inclusion_fee = inclusion_fee_with_balance(details.inclusion_fee)?;
+    let inclusion_fee = if let Some(inclusion_fee) = details.inclusion_fee {
+        Some(inclusion_fee_with_balance(inclusion_fee)?)
+    } else {
+        None
+    };
     let tip = details
         .tip
         .try_into()
@@ -414,27 +418,22 @@ fn convert_fee_details(details: FeeDetails<NumberOrHex>) -> ApiResult<FeeDetails
 }
 
 fn inclusion_fee_with_balance(
-    inclusion_fee: Option<InclusionFee<NumberOrHex>>,
-) -> ApiResult<Option<InclusionFee<Balance>>> {
-    let inclusion_fee = if let Some(inclusion_fee) = inclusion_fee {
-        Some(InclusionFee {
-            base_fee: inclusion_fee
-                .base_fee
-                .try_into()
-                .map_err(|_| ApiClientError::TryFromIntError)?,
-            len_fee: inclusion_fee
-                .base_fee
-                .try_into()
-                .map_err(|_| ApiClientError::TryFromIntError)?,
-            adjusted_weight_fee: inclusion_fee
-                .base_fee
-                .try_into()
-                .map_err(|_| ApiClientError::TryFromIntError)?,
-        })
-    } else {
-        None
-    };
-    Ok(inclusion_fee)
+    inclusion_fee: InclusionFee<NumberOrHex>,
+) -> ApiResult<InclusionFee<Balance>> {
+    Ok(InclusionFee {
+        base_fee: inclusion_fee
+            .base_fee
+            .try_into()
+            .map_err(|_| ApiClientError::TryFromIntError)?,
+        len_fee: inclusion_fee
+            .base_fee
+            .try_into()
+            .map_err(|_| ApiClientError::TryFromIntError)?,
+        adjusted_weight_fee: inclusion_fee
+            .base_fee
+            .try_into()
+            .map_err(|_| ApiClientError::TryFromIntError)?,
+    })
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/src/std/mod.rs
+++ b/src/std/mod.rs
@@ -2,7 +2,6 @@ pub use metadata::RuntimeMetadataPrefixed;
 pub use serde_json::Value;
 pub use sp_core::crypto::Pair;
 pub use sp_core::storage::StorageKey;
-pub use sp_rpc::number::NumberOrHex;
 pub use sp_runtime::traits::{Block, Header};
 pub use sp_runtime::{
     generic::SignedBlock, traits::IdentifyAccount, AccountId32 as AccountId, MultiSignature,
@@ -20,14 +19,16 @@ pub mod rpc;
 
 mod node_metadata;
 
-use std::convert::TryFrom;
+use std::convert::{TryFrom, TryInto};
 
 use codec::{Decode, Encode};
 use log::{debug, info};
 use serde::de::DeserializeOwned;
+use sp_rpc::number::NumberOrHex;
+use transaction_payment::InclusionFee;
 
-use crate::extrinsic;
 use crate::rpc::json_req;
+use crate::{extrinsic, Balance};
 use crate::{AccountData, AccountInfo, Hash};
 
 pub type ApiResult<T> = Result<T, ApiClientError>;
@@ -371,11 +372,15 @@ where
         &self,
         xthex_prefixed: &str,
         at_block: Option<Hash>,
-    ) -> ApiResult<Option<FeeDetails<NumberOrHex>>> {
+    ) -> ApiResult<Option<FeeDetails<Balance>>> {
         let jsonreq = json_req::payment_query_fee_details(xthex_prefixed, at_block);
         let res = self.get_request(jsonreq)?;
         match res {
-            Some(details) => Ok(Some(serde_json::from_str(&details)?)),
+            Some(details) => {
+                let details: FeeDetails<NumberOrHex> = serde_json::from_str(&details)?;
+                let details = convert_fee_details(details)?;
+                Ok(Some(details))
+            }
             None => Ok(None),
         }
     }
@@ -397,6 +402,39 @@ where
         self.client
             .send_extrinsic(xthex_prefixed, XtStatus::Broadcast)
     }
+}
+
+fn convert_fee_details(details: FeeDetails<NumberOrHex>) -> ApiResult<FeeDetails<u128>> {
+    let inclusion_fee = inclusion_fee_with_balance(details.inclusion_fee)?;
+    let tip = details
+        .tip
+        .try_into()
+        .map_err(|_| ApiClientError::TryFromIntError)?;
+    Ok(FeeDetails { inclusion_fee, tip })
+}
+
+fn inclusion_fee_with_balance(
+    inclusion_fee: Option<InclusionFee<NumberOrHex>>,
+) -> ApiResult<Option<InclusionFee<Balance>>> {
+    let inclusion_fee = if let Some(inclusion_fee) = inclusion_fee {
+        Some(InclusionFee {
+            base_fee: inclusion_fee
+                .base_fee
+                .try_into()
+                .map_err(|_| ApiClientError::TryFromIntError)?,
+            len_fee: inclusion_fee
+                .base_fee
+                .try_into()
+                .map_err(|_| ApiClientError::TryFromIntError)?,
+            adjusted_weight_fee: inclusion_fee
+                .base_fee
+                .try_into()
+                .map_err(|_| ApiClientError::TryFromIntError)?,
+        })
+    } else {
+        None
+    };
+    Ok(inclusion_fee)
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -430,4 +468,6 @@ pub enum ApiClientError {
     Deserializing(#[from] serde_json::Error),
     #[error("UnsupportedXtStatus Error: Can only wait for finalized, in block, broadcast and ready. Waited for: {0:?}")]
     UnsupportedXtStatus(XtStatus),
+    #[error("Error converting NumberOrHex to Balance")]
+    TryFromIntError,
 }


### PR DESCRIPTION
Changed return type of get_fee_details() from FeeDetails<NumberOrHex> to
FeeDetails<Balance> to make it more usable.