### PR TITLE
Fixed two JsonRPC request params

### DIFF
--- a/src/std/rpc/json_req.rs
+++ b/src/std/rpc/json_req.rs
@@ -66,7 +66,7 @@ pub fn state_get_metadata() -> Value {
 }
 
 pub fn state_get_metadata_with_id(id: u32) -> Value {
-    json_req("state_getMetadata", Value::Null, id)
+    json_req("state_getMetadata", vec![Value::Null], id)
 }
 
 pub fn state_get_runtime_version() -> Value {
@@ -74,7 +74,7 @@ pub fn state_get_runtime_version() -> Value {
 }
 
 pub fn state_get_runtime_version_with_id(id: u32) -> Value {
-    json_req("state_getRuntimeVersion", Value::Null, id)
+    json_req("state_getRuntimeVersion", vec![Value::Null], id)
 }
 
 pub fn state_subscribe_storage(key: Vec<StorageKey>) -> Value {


### PR DESCRIPTION
Apparently, non-paritylabs JsonRPC endpoints (ex. [Elara](https://docs.elara.patract.io/01.JSON-RPC%20Methods--nc,d2/01%20Polkadot&Kusama.html#_5-9-state-getmetadata)) cannot handle
 the params field without it being in an array. The paritylabs rpc
 handles either way.