### PR TITLE
remove scs node-template dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1395,7 +1395,7 @@ dependencies = [
 [[package]]
 name = "node-template-runtime"
 version = "3.0.0"
-source = "git+https://github.com/scs/substrate-api-client-test-node?branch=master#6a895252740429526485a4eb1aa12d521521c97b"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#558a68f8328a004f153496a192c3ac9723c763c3"
 dependencies = [
  "frame-executive",
  "frame-support",
@@ -1695,7 +1695,7 @@ dependencies = [
 [[package]]
 name = "pallet-template"
 version = "3.0.0"
-source = "git+https://github.com/scs/substrate-api-client-test-node?branch=master#6a895252740429526485a4eb1aa12d521521c97b"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#558a68f8328a004f153496a192c3ac9723c763c3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ sp-application-crypto = { version = "4.0.0-dev", default-features = false, git =
 
 [dev-dependencies]
 env_logger = "0.9"
-node-template-runtime = { git = "https://github.com/scs/substrate-api-client-test-node", branch = "master" }
+node-template-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
 keyring = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "master", package = "sp-keyring" }
 clap = { version = "2.33", features = ["yaml"] }
 

--- a/src/examples/example_get_blocks.rs
+++ b/src/examples/example_get_blocks.rs
@@ -21,12 +21,14 @@ extern crate clap;
 
 use clap::App;
 
+use node_template_runtime::{Block, Header};
 use sp_core::sr25519;
-
-use node_template_runtime::{Block, Header, SignedBlock};
+use sp_runtime::generic::SignedBlock as SignedBlockG;
 use std::sync::mpsc::channel;
 use substrate_api_client::rpc::WsRpcClient;
 use substrate_api_client::Api;
+
+type SignedBlock = SignedBlockG<Block>;
 
 fn main() {
     env_logger::init();


### PR DESCRIPTION
Closes #165.

This was such a low-hanging fruit that I just needed to tackle it.

@haerdib can you update jenkins to use the node-template from substrate instead?