### PR TITLE
Add querying for payment info

### DIFF
--- a/src/std/mod.rs
+++ b/src/std/mod.rs
@@ -25,7 +25,7 @@ use codec::{Decode, Encode};
 use log::{debug, info};
 use serde::de::DeserializeOwned;
 use sp_rpc::number::NumberOrHex;
-use transaction_payment::InclusionFee;
+use transaction_payment::{InclusionFee, RuntimeDispatchInfo};
 
 use crate::rpc::json_req;
 use crate::{extrinsic, Balance};
@@ -383,6 +383,23 @@ where
             None => Ok(None),
         }
     }
+
+    pub fn get_payment_info(
+        &self,
+        xthex_prefixed: &str,
+        at_block: Option<Hash>,
+    ) -> ApiResult<Option<RuntimeDispatchInfo<Balance>>> {
+        let jsonreq = json_req::payment_query_info(xthex_prefixed, at_block);
+        let res = self.get_request(jsonreq)?;
+        match res {
+            Some(info) => {
+                let info: RuntimeDispatchInfo<Balance> = serde_json::from_str(&info)?;
+                Ok(Some(info))
+            }
+            None => Ok(None),
+        }
+    }
+
     pub fn get_existential_deposit(&self) -> ApiResult<Balance> {
         let module = self.metadata.module_with_constants_by_name("Balances")?;
         let constant_metadata = module.constant_by_name("ExistentialDeposit")?;

--- a/src/std/rpc/json_req.rs
+++ b/src/std/rpc/json_req.rs
@@ -61,6 +61,17 @@ pub fn payment_query_fee_details(xthex_prefixed: &str, at_block: Option<Hash>) -
     )
 }
 
+pub fn payment_query_info(xthex_prefixed: &str, at_block: Option<Hash>) -> Value {
+    json_req(
+        "payment_queryInfo",
+        vec![
+            to_value(xthex_prefixed).unwrap(),
+            to_value(at_block).unwrap(),
+        ],
+        1,
+    )
+}
+
 pub fn state_get_metadata() -> Value {
     state_get_metadata_with_id(1)
 }


### PR DESCRIPTION
Extending API with `get_payment_info`. Thanks to that it is possible to know the `unadjusted_fee` for transaction, i.e. a raw fee before applying configurable multipliers. Useful for testing fee adaptation in e2e tests.