### PR TITLE
Support Asset payment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Build node-template
         run: |
           cd substrate
-          cargo update
+          cargo update  # // Todo: remove when substrate fix #https://github.com/paritytech/substrate/issues/11402
           cargo build --release -p node-template
 
       - name: Upload node-template

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,7 @@ jobs:
       - name: Build node-template
         run: |
           cd substrate
+          cargo update
           cargo build --release -p node-template
 
       - name: Upload node-template

--- a/compose-macros/src/lib.rs
+++ b/compose-macros/src/lib.rs
@@ -74,18 +74,10 @@ macro_rules! compose_extrinsic_offline {
         use $crate::sp_runtime::{generic::Era, traits::IdentifyAccount, MultiSigner};
 
         let other_params = $extrinsic_params.unwrap_or_default();
-        println!("Extrinsics param : {:?}", other_params);
 
-        let params = BaseExtrinsicParams::new(
-            $runtime_spec_version,
-            $transaction_version,
-            $nonce,
-            $genesis_hash,
-            other_params,
-        );
+        let params = BaseExtrinsicParams::new($nonce, other_params);
 
         let extra = GenericExtra::from(params);
-        println!("Generic extra : {:?}", extra);
         let raw_payload = SignedPayload::from_raw(
             $call.clone(),
             extra.clone(),

--- a/examples/example_benchmark_bulk_xt.rs
+++ b/examples/example_benchmark_bulk_xt.rs
@@ -25,7 +25,10 @@ use sp_core::crypto::Pair;
 use sp_keyring::AccountKeyring;
 
 use substrate_api_client::rpc::WsRpcClient;
-use substrate_api_client::{compose_extrinsic_offline, Api, UncheckedExtrinsicV4, XtStatus};
+use substrate_api_client::ExtrinsicParams;
+use substrate_api_client::{
+    compose_extrinsic_offline, Api, PlainTipExtrinsicParams, UncheckedExtrinsicV4, XtStatus,
+};
 
 fn main() {
     env_logger::init();
@@ -34,7 +37,9 @@ fn main() {
     // initialize api and set the signer (sender) that is used to sign the extrinsics
     let from = AccountKeyring::Alice.pair();
     let client = WsRpcClient::new(&url);
-    let api = Api::new(client).map(|api| api.set_signer(from)).unwrap();
+    let api = Api::<_, _, PlainTipExtrinsicParams>::new(client)
+        .map(|api| api.set_signer(from))
+        .unwrap();
 
     println!(
         "[+] Alice's Account Nonce is {}\n",
@@ -56,11 +61,11 @@ fn main() {
                 value: 1_000_000
             }),
             nonce,
-            Era::Immortal,
             api.genesis_hash,
             api.genesis_hash,
             api.runtime_version.spec_version,
-            api.runtime_version.transaction_version
+            api.runtime_version.transaction_version,
+            api.extrinsic_params
         );
         // send and watch extrinsic until finalized
         println!("sending extrinsic with nonce {}", nonce);

--- a/examples/example_compose_extrinsic_offline.rs
+++ b/examples/example_compose_extrinsic_offline.rs
@@ -18,13 +18,18 @@
 
 use clap::{load_yaml, App};
 
+use ac_primitives::PlainTipExtrinsicParamsBuilder;
 use node_template_runtime::{BalancesCall, Call, Header};
 use sp_core::crypto::Pair;
 use sp_keyring::AccountKeyring;
+use sp_runtime::generic::Era;
 use sp_runtime::MultiAddress;
 
 use substrate_api_client::rpc::WsRpcClient;
-use substrate_api_client::{compose_extrinsic_offline, Api, UncheckedExtrinsicV4, XtStatus};
+use substrate_api_client::ExtrinsicParams;
+use substrate_api_client::{
+    compose_extrinsic_offline, Api, PlainTipExtrinsicParams, UncheckedExtrinsicV4, XtStatus,
+};
 
 fn main() {
     env_logger::init();
@@ -33,7 +38,10 @@ fn main() {
     // initialize api and set the signer (sender) that is used to sign the extrinsics
     let from = AccountKeyring::Alice.pair();
     let client = WsRpcClient::new(&url);
-    let api = Api::new(client).map(|api| api.set_signer(from)).unwrap();
+
+    let api = Api::<_, _, PlainTipExtrinsicParams>::new(client)
+        .map(|api| api.set_signer(from))
+        .unwrap();
 
     // Information for Era for mortal transactions
     let head = api.get_finalized_head().unwrap().unwrap();
@@ -48,26 +56,52 @@ fn main() {
     // define the recipient
     let to = MultiAddress::Id(AccountKeyring::Bob.to_account_id());
 
+    let tx_params = PlainTipExtrinsicParamsBuilder::new()
+        .era(Era::mortal(period, h.number.into()), api.genesis_hash)
+        .tip(0);
+    println!("xt params: {:?}", tx_params);
+    println!("xt spec version: {:?}", api.runtime_version.spec_version);
+    println!(
+        "xt trans version: {:?}",
+        api.runtime_version.transaction_version
+    );
+    println!("xt genesis hash: {:?}", api.genesis_hash);
+
+    let updated_api = api.set_extrinsic_params(tx_params);
+    println!("xt params in api: {:?}", updated_api.extrinsic_params);
+
+    println!(
+        "xt updated spec version: {:?}",
+        updated_api.runtime_version.spec_version
+    );
+    println!(
+        "xt updated trans version: {:?}",
+        updated_api.runtime_version.transaction_version
+    );
+    println!("xt updated  genesis hash: {:?}", updated_api.genesis_hash);
+
     // compose the extrinsic with all the element
     #[allow(clippy::redundant_clone)]
     let xt: UncheckedExtrinsicV4<_> = compose_extrinsic_offline!(
-        api.clone().signer.unwrap(),
+        updated_api.clone().signer.unwrap(),
         Call::Balances(BalancesCall::transfer {
             dest: to.clone(),
             value: 42
         }),
-        api.get_nonce().unwrap(),
-        Era::mortal(period, h.number.into()),
-        api.genesis_hash,
+        updated_api.get_nonce().unwrap(),
+        updated_api.genesis_hash,
         head,
-        api.runtime_version.spec_version,
-        api.runtime_version.transaction_version
+        updated_api.runtime_version.spec_version,
+        updated_api.runtime_version.transaction_version,
+        updated_api.extrinsic_params
     );
 
     println!("[+] Composed Extrinsic:\n {:?}\n", xt);
 
+    //println!("[+] Encode Extrinsic:\n {:?}\n", xt.hex_encode());
+
     // send and watch extrinsic until in block
-    let blockh = api
+    let blockh = updated_api
         .send_extrinsic(xt.hex_encode(), XtStatus::InBlock)
         .unwrap();
     println!("[+] Transaction got included in block {:?}", blockh);

--- a/examples/example_compose_extrinsic_offline.rs
+++ b/examples/example_compose_extrinsic_offline.rs
@@ -59,26 +59,8 @@ fn main() {
     let tx_params = PlainTipExtrinsicParamsBuilder::new()
         .era(Era::mortal(period, h.number.into()), api.genesis_hash)
         .tip(0);
-    println!("xt params: {:?}", tx_params);
-    println!("xt spec version: {:?}", api.runtime_version.spec_version);
-    println!(
-        "xt trans version: {:?}",
-        api.runtime_version.transaction_version
-    );
-    println!("xt genesis hash: {:?}", api.genesis_hash);
 
     let updated_api = api.set_extrinsic_params(tx_params);
-    println!("xt params in api: {:?}", updated_api.extrinsic_params);
-
-    println!(
-        "xt updated spec version: {:?}",
-        updated_api.runtime_version.spec_version
-    );
-    println!(
-        "xt updated trans version: {:?}",
-        updated_api.runtime_version.transaction_version
-    );
-    println!("xt updated  genesis hash: {:?}", updated_api.genesis_hash);
 
     // compose the extrinsic with all the element
     #[allow(clippy::redundant_clone)]

--- a/examples/example_contract_instantiate_with_code.rs
+++ b/examples/example_contract_instantiate_with_code.rs
@@ -20,7 +20,7 @@ use std::sync::mpsc::channel;
 use clap::{load_yaml, App};
 use codec::Decode;
 use sp_keyring::AccountKeyring;
-use substrate_api_client::{rpc::WsRpcClient, AccountId, Api, XtStatus};
+use substrate_api_client::{rpc::WsRpcClient, AccountId, Api, PlainTipExtrinsicParams, XtStatus};
 
 #[allow(unused)]
 #[derive(Decode)]
@@ -36,7 +36,9 @@ fn main() {
     // initialize api and set the signer (sender) that is used to sign the extrinsics
     let from = AccountKeyring::Alice.pair();
     let client = WsRpcClient::new(&url);
-    let api = Api::new(client).map(|api| api.set_signer(from)).unwrap();
+    let api = Api::<_, _, PlainTipExtrinsicParams>::new(client)
+        .map(|api| api.set_signer(from))
+        .unwrap();
     println!("[+] Alice's Account Nonce is {}", api.get_nonce().unwrap());
 
     // contract to be deployed on the chain

--- a/examples/example_event_callback.rs
+++ b/examples/example_event_callback.rs
@@ -29,14 +29,14 @@ use node_template_runtime::Event;
 
 use substrate_api_client::rpc::WsRpcClient;
 use substrate_api_client::utils::FromHexString;
-use substrate_api_client::Api;
+use substrate_api_client::{Api, PlainTipExtrinsicParams};
 
 fn main() {
     env_logger::init();
     let url = get_node_url_from_cli();
 
     let client = WsRpcClient::new(&url);
-    let api = Api::<sr25519::Pair, _>::new(client).unwrap();
+    let api = Api::<sr25519::Pair, _, PlainTipExtrinsicParams>::new(client).unwrap();
 
     println!("Subscribe to events");
     let (events_in, events_out) = channel();

--- a/examples/example_event_error_details.rs
+++ b/examples/example_event_error_details.rs
@@ -23,7 +23,7 @@ use sp_runtime::app_crypto::sp_core::sr25519;
 use sp_runtime::AccountId32 as AccountId;
 use sp_runtime::MultiAddress;
 use substrate_api_client::rpc::WsRpcClient;
-use substrate_api_client::{Api, ApiResult, XtStatus};
+use substrate_api_client::{Api, ApiResult, PlainTipExtrinsicParams, XtStatus};
 
 // Look at the how the transfer event looks like in in the metadata
 #[derive(Decode)]
@@ -41,7 +41,7 @@ fn main() {
     let from = AccountKeyring::Alice.pair();
 
     let client = WsRpcClient::new(&url);
-    let api = Api::<sr25519::Pair, _>::new(client)
+    let api = Api::<sr25519::Pair, _, PlainTipExtrinsicParams>::new(client)
         .map(|api| api.set_signer(from.clone()))
         .unwrap();
 

--- a/examples/example_generic_event_callback.rs
+++ b/examples/example_generic_event_callback.rs
@@ -22,7 +22,7 @@ use codec::Decode;
 use sp_core::sr25519;
 use sp_runtime::AccountId32 as AccountId;
 use substrate_api_client::rpc::WsRpcClient;
-use substrate_api_client::Api;
+use substrate_api_client::{Api, PlainTipExtrinsicParams};
 
 // Look at the how the transfer event looks like in in the metadata
 #[derive(Decode)]
@@ -37,7 +37,7 @@ fn main() {
     let url = get_node_url_from_cli();
 
     let client = WsRpcClient::new(&url);
-    let api = Api::<sr25519::Pair, _>::new(client).unwrap();
+    let api = Api::<sr25519::Pair, _, PlainTipExtrinsicParams>::new(client).unwrap();
 
     println!("Subscribe to events");
     let (events_in, events_out) = channel();

--- a/examples/example_generic_extrinsic.rs
+++ b/examples/example_generic_extrinsic.rs
@@ -21,8 +21,9 @@ use sp_core::crypto::Pair;
 use sp_keyring::AccountKeyring;
 
 use substrate_api_client::rpc::WsRpcClient;
+use substrate_api_client::ExtrinsicParams;
 use substrate_api_client::{
-    compose_extrinsic, Api, GenericAddress, UncheckedExtrinsicV4, XtStatus,
+    compose_extrinsic, Api, GenericAddress, PlainTipExtrinsicParams, UncheckedExtrinsicV4, XtStatus,
 };
 
 fn main() {
@@ -32,7 +33,9 @@ fn main() {
     // initialize api and set the signer (sender) that is used to sign the extrinsics
     let from = AccountKeyring::Alice.pair();
     let client = WsRpcClient::new(&url);
-    let api = Api::new(client).map(|api| api.set_signer(from)).unwrap();
+    let api = Api::<_, _, PlainTipExtrinsicParams>::new(client)
+        .map(|api| api.set_signer(from))
+        .unwrap();
 
     // set the recipient
     let to = AccountKeyring::Bob.to_account_id();

--- a/examples/example_get_blocks.rs
+++ b/examples/example_get_blocks.rs
@@ -26,7 +26,7 @@ use sp_core::sr25519;
 use sp_runtime::generic::SignedBlock as SignedBlockG;
 use std::sync::mpsc::channel;
 use substrate_api_client::rpc::WsRpcClient;
-use substrate_api_client::Api;
+use substrate_api_client::{Api, PlainTipExtrinsicParams};
 
 type SignedBlock = SignedBlockG<Block>;
 
@@ -35,7 +35,7 @@ fn main() {
     let url = get_node_url_from_cli();
 
     let client = WsRpcClient::new(&url);
-    let api = Api::<sr25519::Pair, _>::new(client).unwrap();
+    let api = Api::<sr25519::Pair, _, PlainTipExtrinsicParams>::new(client).unwrap();
 
     let head = api.get_finalized_head().unwrap().unwrap();
 

--- a/examples/example_get_existential_deposit.rs
+++ b/examples/example_get_existential_deposit.rs
@@ -17,14 +17,14 @@ limitations under the License.
 use clap::{load_yaml, App};
 use sp_runtime::app_crypto::sp_core::sr25519;
 use substrate_api_client::rpc::WsRpcClient;
-use substrate_api_client::Api;
+use substrate_api_client::{Api, PlainTipExtrinsicParams};
 
 fn main() {
     env_logger::init();
     let url = get_node_url_from_cli();
 
     let client = WsRpcClient::new(&url);
-    let api = Api::<sr25519::Pair, _>::new(client).unwrap();
+    let api = Api::<sr25519::Pair, _, PlainTipExtrinsicParams>::new(client).unwrap();
 
     // get existential deposit
     let min_balance = api.get_existential_deposit().unwrap();

--- a/examples/example_get_storage.rs
+++ b/examples/example_get_storage.rs
@@ -18,15 +18,15 @@ use clap::{load_yaml, App};
 
 use sp_keyring::AccountKeyring;
 use substrate_api_client::rpc::WsRpcClient;
-use substrate_api_client::AccountInfo;
 use substrate_api_client::Api;
+use substrate_api_client::{AccountInfo, PlainTipExtrinsicParams};
 
 fn main() {
     env_logger::init();
     let url = get_node_url_from_cli();
 
     let client = WsRpcClient::new(&url);
-    let mut api = Api::new(client).unwrap();
+    let mut api = Api::<_, _, PlainTipExtrinsicParams>::new(client).unwrap();
 
     // get some plain storage value
     let result: u128 = api

--- a/examples/example_print_metadata.rs
+++ b/examples/example_print_metadata.rs
@@ -25,14 +25,14 @@ use sp_core::sr25519;
 
 use std::convert::TryFrom;
 use substrate_api_client::rpc::WsRpcClient;
-use substrate_api_client::{Api, Metadata};
+use substrate_api_client::{Api, Metadata, PlainTipExtrinsicParams};
 
 fn main() {
     env_logger::init();
     let url = get_node_url_from_cli();
 
     let client = WsRpcClient::new(&url);
-    let api = Api::<sr25519::Pair, _>::new(client).unwrap();
+    let api = Api::<sr25519::Pair, _, PlainTipExtrinsicParams>::new(client).unwrap();
 
     let meta = Metadata::try_from(api.get_metadata().unwrap()).unwrap();
 

--- a/examples/example_sudo.rs
+++ b/examples/example_sudo.rs
@@ -24,6 +24,7 @@ use substrate_api_client::rpc::WsRpcClient;
 use substrate_api_client::{
     compose_call, compose_extrinsic, Api, GenericAddress, UncheckedExtrinsicV4, XtStatus,
 };
+use substrate_api_client::{ExtrinsicParams, PlainTipExtrinsicParams};
 
 fn main() {
     env_logger::init();
@@ -32,7 +33,9 @@ fn main() {
     // initialize api and set the signer (sender) that is used to sign the extrinsics
     let sudoer = AccountKeyring::Alice.pair();
     let client = WsRpcClient::new(&url);
-    let api = Api::new(client).map(|api| api.set_signer(sudoer)).unwrap();
+    let api = Api::<_, _, PlainTipExtrinsicParams>::new(client)
+        .map(|api| api.set_signer(sudoer))
+        .unwrap();
 
     // set the recipient of newly issued funds
     let to = AccountKeyring::Bob.to_account_id();

--- a/examples/example_transfer.rs
+++ b/examples/example_transfer.rs
@@ -20,7 +20,7 @@ use sp_keyring::AccountKeyring;
 use sp_runtime::MultiAddress;
 
 use substrate_api_client::rpc::WsRpcClient;
-use substrate_api_client::{Api, XtStatus};
+use substrate_api_client::{Api, PlainTipExtrinsicParams, XtStatus};
 
 fn main() {
     env_logger::init();
@@ -29,7 +29,7 @@ fn main() {
     // initialize api and set the signer (sender) that is used to sign the extrinsics
     let from = AccountKeyring::Alice.pair();
     let client = WsRpcClient::new(&url);
-    let api = Api::new(client)
+    let api = Api::<_, _, PlainTipExtrinsicParams>::new(client)
         .map(|api| api.set_signer(from.clone()))
         .unwrap();
 
@@ -39,6 +39,8 @@ fn main() {
         Some(bob) => println!("[+] Bob's Free Balance is is {}\n", bob.free),
         None => println!("[+] Bob's Free Balance is is 0\n"),
     }
+    println!("sending extrinsic with nonce {}", api.get_nonce().unwrap());
+
     // generate extrinsic
     let xt = api.balance_transfer(MultiAddress::Id(to.clone()), 1000);
 

--- a/examples/example_transfer.rs
+++ b/examples/example_transfer.rs
@@ -39,7 +39,6 @@ fn main() {
         Some(bob) => println!("[+] Bob's Free Balance is is {}\n", bob.free),
         None => println!("[+] Bob's Free Balance is is 0\n"),
     }
-    println!("sending extrinsic with nonce {}", api.get_nonce().unwrap());
 
     // generate extrinsic
     let xt = api.balance_transfer(MultiAddress::Id(to.clone()), 1000);

--- a/primitives/src/extrinsic_params.rs
+++ b/primitives/src/extrinsic_params.rs
@@ -1,0 +1,266 @@
+use codec::{Compact, Decode, Encode};
+use core::marker::PhantomData;
+use sp_core::{blake2_256, H256};
+use sp_runtime::generic::Era;
+use sp_std::prelude::*;
+
+/// Simple generic extra mirroring the SignedExtra currently used in extrinsics. Does not implement
+/// the SignedExtension trait. It simply encodes to the same bytes as the real SignedExtra. The
+/// Order is (CheckVersion, CheckGenesis, Check::Era, CheckNonce, CheckWeight, transactionPayment::ChargeTransactionPayment).
+/// This can be locked up in the System module. Fields that are merely PhantomData are not encoded and are
+/// therefore omitted here.
+#[derive(Decode, Encode, Clone, Eq, PartialEq, Debug)]
+pub struct GenericExtra(pub Era, pub Compact<u32>, pub Compact<u128>);
+
+/// This trait allows you to configure the "signed extra" and
+/// "additional" parameters that are signed and used in transactions.
+/// see [`BaseExtrinsicParams`] for an implementation that is compatible with
+/// a Polkadot node.
+pub trait ExtrinsicParams {
+    /// These parameters can be provided to the constructor along with
+    /// some default parameters that `subxt` understands, in order to
+    /// help construct your [`ExtrinsicParams`] object.
+    type OtherParams;
+
+    /// Construct a new instance of our [`ExtrinsicParams`]
+    fn new(
+        spec_version: u32,
+        tx_version: u32,
+        nonce: u32,
+        genesis_hash: H256,
+        other_params: Self::OtherParams,
+    ) -> Self;
+
+    /// This is expected to SCALE encode the "signed extra" parameters
+    /// to some buffer that has been provided. These are the parameters
+    /// which are sent along with the transaction, as well as taken into
+    /// account when signing the transaction.
+    fn encode_extra_to(&self, v: &mut Vec<u8>);
+
+    /// This is expected to SCALE encode the "additional" parameters
+    /// to some buffer that has been provided. These parameters are _not_
+    /// sent along with the transaction, but are taken into account when
+    /// signing it, meaning the client and node must agree on their values.
+    fn encode_additional_to(&self, v: &mut Vec<u8>);
+}
+
+/// A struct representing the signed extra and additional parameters required
+/// to construct a transaction and pay in asset fees
+pub type AssetTipExtrinsicParams = BaseExtrinsicParams<AssetTip>;
+/// A builder which leads to [`AssetTipExtrinsicParams`] being constructed.
+/// This is what you provide to methods like `sign_and_submit()`.
+pub type AssetTipExtrinsicParamsBuilder = BaseExtrinsicParamsBuilder<AssetTip>;
+
+/// A struct representing the signed extra and additional parameters required
+/// to construct a transaction and pay in token fees
+pub type PlainTipExtrinsicParams = BaseExtrinsicParams<PlainTip>;
+/// A builder which leads to [`PlainTipExtrinsicParams`] being constructed.
+/// This is what you provide to methods like `sign_and_submit()`.
+pub type PlainTipExtrinsicParamsBuilder = BaseExtrinsicParamsBuilder<PlainTip>;
+
+#[derive(Decode, Encode, Clone, Eq, PartialEq, Debug)]
+pub struct BaseExtrinsicParams<Tip> {
+    era: Era,
+    nonce: u32,
+    tip: Tip,
+    spec_version: u32,
+    transaction_version: u32,
+    genesis_hash: H256,
+    mortality_checkpoint: H256,
+    marker: PhantomData<()>,
+}
+
+/// This builder allows you to provide the parameters that can be configured in order to
+/// construct a [`BaseExtrinsicParams`] value.
+#[derive(Decode, Encode, Copy, Clone, Eq, PartialEq, Debug)]
+pub struct BaseExtrinsicParamsBuilder<Tip> {
+    era: Era,
+    mortality_checkpoint: Option<H256>,
+    tip: Tip,
+}
+
+impl<Tip: Default> BaseExtrinsicParamsBuilder<Tip> {
+    /// Instantiate the default set of [`BaseExtrinsicParamsBuilder`]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the [`Era`], which defines how long the transaction will be valid for
+    /// (it can be either immortal, or it can be mortal and expire after a certain amount
+    /// of time). The second argument is the block hash after which the transaction
+    /// becomes valid, and must align with the era phase (see the [`Era::Mortal`] docs
+    /// for more detail on that).
+    pub fn era(mut self, era: Era, checkpoint: H256) -> Self {
+        self.era = era;
+        self.mortality_checkpoint = Some(checkpoint);
+        self
+    }
+
+    /// Set the tip you'd like to give to the block author
+    /// for this transaction.
+    pub fn tip(mut self, tip: impl Into<Tip>) -> Self {
+        self.tip = tip.into();
+        self
+    }
+}
+
+impl<Tip: Default> Default for BaseExtrinsicParamsBuilder<Tip> {
+    fn default() -> Self {
+        Self {
+            era: Era::Immortal,
+            mortality_checkpoint: None,
+            tip: Tip::default(),
+        }
+    }
+}
+
+/// Get the generic extra from the BaseExtrinsicParams.
+impl<Tip> From<BaseExtrinsicParams<Tip>> for GenericExtra
+where
+    u128: From<Tip>,
+{
+    fn from(p: BaseExtrinsicParams<Tip>) -> GenericExtra {
+        let BaseExtrinsicParams {
+            era,
+            nonce,
+            tip,
+            spec_version,
+            transaction_version,
+            genesis_hash,
+            mortality_checkpoint,
+            marker,
+        } = p;
+        GenericExtra(era, Compact(nonce), Compact(tip.into()))
+    }
+}
+
+impl<Tip: Encode> ExtrinsicParams for BaseExtrinsicParams<Tip> {
+    type OtherParams = BaseExtrinsicParamsBuilder<Tip>;
+
+    fn new(
+        spec_version: u32,
+        transaction_version: u32,
+        nonce: u32,
+        genesis_hash: H256,
+        other_params: Self::OtherParams,
+    ) -> Self {
+        BaseExtrinsicParams {
+            era: other_params.era,
+            mortality_checkpoint: other_params.mortality_checkpoint.unwrap_or(genesis_hash),
+            tip: other_params.tip,
+            nonce,
+            spec_version,
+            transaction_version,
+            genesis_hash,
+            marker: PhantomData,
+        }
+    }
+
+    fn encode_extra_to(&self, v: &mut Vec<u8>) {
+        let nonce: u64 = self.nonce.into();
+        let tip = self.tip.encode(); //?
+        (self.era, Compact(nonce), tip).encode_to(v);
+    }
+
+    fn encode_additional_to(&self, v: &mut Vec<u8>) {
+        (
+            self.spec_version,
+            self.transaction_version,
+            self.genesis_hash,
+            self.mortality_checkpoint,
+        )
+            .encode_to(v);
+    }
+}
+
+/// additionalSigned fields of the respective SignedExtra fields.
+/// Order is the same as declared in the extra.
+pub type AdditionalSigned = (u32, u32, H256, H256, (), (), ());
+
+#[derive(Decode, Encode, Clone, Eq, PartialEq, Debug)]
+pub struct SignedPayload<Call>((Call, GenericExtra, AdditionalSigned));
+
+impl<Call> SignedPayload<Call>
+where
+    Call: Encode,
+{
+    pub fn from_raw(call: Call, extra: GenericExtra, additional_signed: AdditionalSigned) -> Self {
+        Self((call, extra, additional_signed))
+    }
+
+    /// Get an encoded version of this payload.
+    ///
+    /// Payloads longer than 256 bytes are going to be `blake2_256`-hashed.
+    pub fn using_encoded<R, F: FnOnce(&[u8]) -> R>(&self, f: F) -> R {
+        self.0.using_encoded(|payload| {
+            if payload.len() > 256 {
+                f(&blake2_256(payload)[..])
+            } else {
+                f(payload)
+            }
+        })
+    }
+}
+
+/// A tip payment.
+#[derive(Copy, Clone, Debug, Default, Decode, Encode, Eq, PartialEq)]
+pub struct PlainTip {
+    #[codec(compact)]
+    tip: u128,
+}
+
+impl PlainTip {
+    /// Create a new tip of the amount provided.
+    pub fn new(amount: u128) -> Self {
+        PlainTip { tip: amount }
+    }
+}
+
+impl From<u128> for PlainTip {
+    fn from(n: u128) -> Self {
+        PlainTip::new(n)
+    }
+}
+
+impl From<PlainTip> for u128 {
+    fn from(tip: PlainTip) -> Self {
+        tip.tip
+    }
+}
+
+/// A tip payment made in the form of a specific asset.
+#[derive(Copy, Clone, Debug, Default, Decode, Encode, Eq, PartialEq)]
+pub struct AssetTip {
+    #[codec(compact)]
+    tip: u128,
+    asset: Option<u32>,
+}
+
+impl AssetTip {
+    /// Create a new tip of the amount provided.
+    pub fn new(amount: u128) -> Self {
+        AssetTip {
+            tip: amount,
+            asset: None,
+        }
+    }
+
+    /// Designate the tip as being of a particular asset class.
+    /// If this is not set, then the native currency is used.
+    pub fn of_asset(mut self, asset: u32) -> Self {
+        self.asset = Some(asset);
+        self
+    }
+}
+
+impl From<u128> for AssetTip {
+    fn from(n: u128) -> Self {
+        AssetTip::new(n)
+    }
+}
+
+impl From<AssetTip> for u128 {
+    fn from(tip: AssetTip) -> Self {
+        tip.tip
+    }
+}

--- a/primitives/src/extrinsics.rs
+++ b/primitives/src/extrinsics.rs
@@ -19,13 +19,12 @@
 
 extern crate alloc;
 
-use codec::{Compact, Decode, Encode, Error, Input};
-use sp_core::blake2_256;
-use sp_core::H256;
-use sp_runtime::{generic::Era, MultiSignature};
+use codec::{Decode, Encode, Error, Input};
+use sp_runtime::MultiSignature;
 use sp_std::fmt;
 use sp_std::prelude::*;
 
+use crate::GenericExtra;
 pub use sp_runtime::{AccountId32 as AccountId, MultiAddress};
 
 pub type AccountIndex = u64;
@@ -33,55 +32,6 @@ pub type AccountIndex = u64;
 pub type GenericAddress = sp_runtime::MultiAddress<AccountId, ()>;
 
 pub type CallIndex = [u8; 2];
-
-/// Simple generic extra mirroring the SignedExtra currently used in extrinsics. Does not implement
-/// the SignedExtension trait. It simply encodes to the same bytes as the real SignedExtra. The
-/// Order is (CheckVersion, CheckGenesis, Check::Era, CheckNonce, CheckWeight, transactionPayment::ChargeTransactionPayment).
-/// This can be locked up in the System module. Fields that are merely PhantomData are not encoded and are
-/// therefore omitted here.
-#[derive(Decode, Encode, Clone, Eq, PartialEq, Debug)]
-pub struct GenericExtra(pub Era, pub Compact<u32>, pub Compact<u128>);
-
-impl GenericExtra {
-    pub fn new(era: Era, nonce: u32) -> GenericExtra {
-        GenericExtra(era, Compact(nonce), Compact(0_u128))
-    }
-}
-
-impl Default for GenericExtra {
-    fn default() -> Self {
-        Self::new(Era::Immortal, 0)
-    }
-}
-
-/// additionalSigned fields of the respective SignedExtra fields.
-/// Order is the same as declared in the extra.
-pub type AdditionalSigned = (u32, u32, H256, H256, (), (), ());
-
-#[derive(Decode, Encode, Clone, Eq, PartialEq, Debug)]
-pub struct SignedPayload<Call>((Call, GenericExtra, AdditionalSigned));
-
-impl<Call> SignedPayload<Call>
-where
-    Call: Encode,
-{
-    pub fn from_raw(call: Call, extra: GenericExtra, additional_signed: AdditionalSigned) -> Self {
-        Self((call, extra, additional_signed))
-    }
-
-    /// Get an encoded version of this payload.
-    ///
-    /// Payloads longer than 256 bytes are going to be `blake2_256`-hashed.
-    pub fn using_encoded<R, F: FnOnce(&[u8]) -> R>(&self, f: F) -> R {
-        self.0.using_encoded(|payload| {
-            if payload.len() > 256 {
-                f(&blake2_256(payload)[..])
-            } else {
-                f(payload)
-            }
-        })
-    }
-}
 
 /// Mirrors the currently used Extrinsic format (V4) from substrate. Has less traits and methods though.
 /// The SingedExtra used does not need to implement SingedExtension here.
@@ -206,7 +156,10 @@ fn encode_with_vec_prefix<T: Encode, F: Fn(&mut Vec<u8>)>(encoder: F) -> Vec<u8>
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{BaseExtrinsicParams, ExtrinsicParams, PlainTipExtrinsicParamsBuilder};
     use sp_core::Pair;
+    use sp_core::H256 as Hash;
+    use sp_runtime::generic::Era;
     use sp_runtime::testing::sr25519;
     use sp_runtime::MultiSignature;
 
@@ -217,14 +170,16 @@ mod tests {
         let signature = pair.sign(&msg);
         let multi_sig = MultiSignature::from(signature);
         let account: AccountId = pair.public().into();
+        let tx_params =
+            PlainTipExtrinsicParamsBuilder::new().era(Era::mortal(8, 0), Hash::from([0u8; 32]));
 
+        let default_extra = BaseExtrinsicParams::new(0, 0, 0, Hash::from([0u8; 32]), tx_params);
         let xt = UncheckedExtrinsicV4::new_signed(
             vec![1, 1, 1],
             account.into(),
             multi_sig,
-            GenericExtra::default(),
+            GenericExtra::from(default_extra),
         );
-
         let xt_enc = xt.encode();
         assert_eq!(xt, Decode::decode(&mut xt_enc.as_slice()).unwrap())
     }

--- a/primitives/src/extrinsics.rs
+++ b/primitives/src/extrinsics.rs
@@ -173,7 +173,7 @@ mod tests {
         let tx_params =
             PlainTipExtrinsicParamsBuilder::new().era(Era::mortal(8, 0), Hash::from([0u8; 32]));
 
-        let default_extra = BaseExtrinsicParams::new(0, 0, 0, Hash::from([0u8; 32]), tx_params);
+        let default_extra = BaseExtrinsicParams::new(0, tx_params);
         let xt = UncheckedExtrinsicV4::new_signed(
             vec![1, 1, 1],
             account.into(),

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -2,8 +2,10 @@
 
 use codec::{Decode, Encode};
 
+pub use extrinsic_params::*;
 pub use extrinsics::*;
 
+pub mod extrinsic_params;
 pub mod extrinsics;
 
 /// The block number type used in this runtime.

--- a/src/extrinsic/balances.rs
+++ b/src/extrinsic/balances.rs
@@ -19,7 +19,10 @@
 
 use crate::std::{Api, RpcClient};
 use ac_compose_macros::compose_extrinsic;
-use ac_primitives::{Balance, CallIndex, GenericAddress, UncheckedExtrinsicV4};
+use ac_primitives::{
+    Balance, CallIndex, ExtrinsicParams, GenericAddress, PlainTipExtrinsicParams,
+    PlainTipExtrinsicParamsBuilder, UncheckedExtrinsicV4,
+};
 use codec::Compact;
 use sp_core::crypto::Pair;
 use sp_runtime::{MultiSignature, MultiSigner};
@@ -36,18 +39,23 @@ pub type BalanceSetBalanceFn = (
     Compact<Balance>,
 );
 
+pub type BalancesExtrinsicParamsBuilder = PlainTipExtrinsicParamsBuilder;
 pub type BalanceTransferXt = UncheckedExtrinsicV4<BalanceTransferFn>;
 pub type BalanceSetBalanceXt = UncheckedExtrinsicV4<BalanceSetBalanceFn>;
 
 #[cfg(feature = "std")]
-impl<P, Client> Api<P, Client>
+impl<P, Client, Params> Api<P, Client, Params>
 where
     P: Pair,
     MultiSignature: From<P::Signature>,
     MultiSigner: From<P::Public>,
     Client: RpcClient,
+    Params: ExtrinsicParams,
 {
-    pub fn balance_transfer(&self, to: GenericAddress, amount: Balance) -> BalanceTransferXt {
+    pub fn balance_transfer(&self, to: GenericAddress, amount: Balance) -> BalanceTransferXt
+    where
+        Params: ExtrinsicParams<OtherParams = BalancesExtrinsicParamsBuilder>,
+    {
         compose_extrinsic!(
             self,
             BALANCES_MODULE,
@@ -62,7 +70,10 @@ where
         who: GenericAddress,
         free_balance: Balance,
         reserved_balance: Balance,
-    ) -> BalanceSetBalanceXt {
+    ) -> BalanceSetBalanceXt
+    where
+        Params: ExtrinsicParams<OtherParams = BalancesExtrinsicParamsBuilder>,
+    {
         compose_extrinsic!(
             self,
             BALANCES_MODULE,

--- a/src/extrinsic/balances.rs
+++ b/src/extrinsic/balances.rs
@@ -49,7 +49,6 @@ where
     MultiSignature: From<P::Signature>,
     MultiSigner: From<P::Public>,
     Client: RpcClient,
-    Params: ExtrinsicParams,
     Params: ExtrinsicParams<OtherParams = BaseExtrinsicParamsBuilder<Tip>>,
     Tip: Default + Encode + Copy,
     u128: From<Tip>,

--- a/src/extrinsic/balances.rs
+++ b/src/extrinsic/balances.rs
@@ -20,8 +20,8 @@
 use crate::std::{Api, RpcClient};
 use ac_compose_macros::compose_extrinsic;
 use ac_primitives::{
-    Balance, CallIndex, ExtrinsicParams, GenericAddress, PlainTipExtrinsicParams,
-    PlainTipExtrinsicParamsBuilder, UncheckedExtrinsicV4,
+    Balance, CallIndex, ExtrinsicParams, GenericAddress, PlainTipExtrinsicParamsBuilder,
+    UncheckedExtrinsicV4,
 };
 use codec::Compact;
 use sp_core::crypto::Pair;

--- a/src/extrinsic/contract.rs
+++ b/src/extrinsic/contract.rs
@@ -21,8 +21,8 @@
 use crate::std::{Api, RpcClient};
 use ac_compose_macros::compose_extrinsic;
 use ac_primitives::{
-    Balance, CallIndex, ExtrinsicParams, GenericAddress, PlainTipExtrinsicParams,
-    PlainTipExtrinsicParamsBuilder, UncheckedExtrinsicV4,
+    Balance, CallIndex, ExtrinsicParams, GenericAddress, PlainTipExtrinsicParamsBuilder,
+    UncheckedExtrinsicV4,
 };
 use codec::Compact;
 use sp_core::crypto::Pair;

--- a/src/extrinsic/contract.rs
+++ b/src/extrinsic/contract.rs
@@ -21,10 +21,10 @@
 use crate::std::{Api, RpcClient};
 use ac_compose_macros::compose_extrinsic;
 use ac_primitives::{
-    Balance, CallIndex, ExtrinsicParams, GenericAddress, PlainTipExtrinsicParamsBuilder,
+    Balance, BaseExtrinsicParamsBuilder, CallIndex, ExtrinsicParams, GenericAddress,
     UncheckedExtrinsicV4,
 };
-use codec::Compact;
+use codec::{Compact, Encode};
 use sp_core::crypto::Pair;
 use sp_core::H256 as Hash;
 use sp_runtime::{MultiSignature, MultiSigner};
@@ -51,26 +51,24 @@ pub type ContractInstantiateFn = (CallIndex, Endowment, GasLimit, Hash, Data);
 pub type ContractInstantiateWithCodeFn = (CallIndex, Endowment, GasLimit, Code, Data, Salt);
 pub type ContractCallFn = (CallIndex, Destination, Value, GasLimit, Data);
 
-pub type ContractExtrinsicParamsBuilder = PlainTipExtrinsicParamsBuilder;
-
 pub type ContractPutCodeXt = UncheckedExtrinsicV4<ContractPutCodeFn>;
 pub type ContractInstantiateXt = UncheckedExtrinsicV4<ContractInstantiateFn>;
 pub type ContractInstantiateWithCodeXt = UncheckedExtrinsicV4<ContractInstantiateWithCodeFn>;
 pub type ContractCallXt = UncheckedExtrinsicV4<ContractCallFn>;
 
 #[cfg(feature = "std")]
-impl<P, Client, Params> Api<P, Client, Params>
+impl<P, Client, Params, Tip> Api<P, Client, Params>
 where
     P: Pair,
     MultiSignature: From<P::Signature>,
     MultiSigner: From<P::Public>,
     Client: RpcClient,
     Params: ExtrinsicParams,
+    Params: ExtrinsicParams<OtherParams = BaseExtrinsicParamsBuilder<Tip>>,
+    Tip: Default + Encode + Copy,
+    u128: From<Tip>,
 {
-    pub fn contract_put_code(&self, gas_limit: Gas, code: Data) -> ContractPutCodeXt
-    where
-        Params: ExtrinsicParams<OtherParams = ContractExtrinsicParamsBuilder>,
-    {
+    pub fn contract_put_code(&self, gas_limit: Gas, code: Data) -> ContractPutCodeXt {
         compose_extrinsic!(
             self,
             CONTRACTS_MODULE,
@@ -86,10 +84,7 @@ where
         gas_limit: Gas,
         code_hash: Hash,
         data: Data,
-    ) -> ContractInstantiateXt
-    where
-        Params: ExtrinsicParams<OtherParams = ContractExtrinsicParamsBuilder>,
-    {
+    ) -> ContractInstantiateXt {
         compose_extrinsic!(
             self,
             CONTRACTS_MODULE,
@@ -108,10 +103,7 @@ where
         code: Data,
         data: Data,
         salt: Data,
-    ) -> ContractInstantiateWithCodeXt
-    where
-        Params: ExtrinsicParams<OtherParams = ContractExtrinsicParamsBuilder>,
-    {
+    ) -> ContractInstantiateWithCodeXt {
         compose_extrinsic!(
             self,
             CONTRACTS_MODULE,
@@ -130,10 +122,7 @@ where
         value: Balance,
         gas_limit: Gas,
         data: Data,
-    ) -> ContractCallXt
-    where
-        Params: ExtrinsicParams<OtherParams = ContractExtrinsicParamsBuilder>,
-    {
+    ) -> ContractCallXt {
         compose_extrinsic!(
             self,
             CONTRACTS_MODULE,

--- a/src/extrinsic/contract.rs
+++ b/src/extrinsic/contract.rs
@@ -20,7 +20,10 @@
 
 use crate::std::{Api, RpcClient};
 use ac_compose_macros::compose_extrinsic;
-use ac_primitives::{Balance, CallIndex, GenericAddress, UncheckedExtrinsicV4};
+use ac_primitives::{
+    Balance, CallIndex, ExtrinsicParams, GenericAddress, PlainTipExtrinsicParams,
+    PlainTipExtrinsicParamsBuilder, UncheckedExtrinsicV4,
+};
 use codec::Compact;
 use sp_core::crypto::Pair;
 use sp_core::H256 as Hash;
@@ -48,20 +51,26 @@ pub type ContractInstantiateFn = (CallIndex, Endowment, GasLimit, Hash, Data);
 pub type ContractInstantiateWithCodeFn = (CallIndex, Endowment, GasLimit, Code, Data, Salt);
 pub type ContractCallFn = (CallIndex, Destination, Value, GasLimit, Data);
 
+pub type ContractExtrinsicParamsBuilder = PlainTipExtrinsicParamsBuilder;
+
 pub type ContractPutCodeXt = UncheckedExtrinsicV4<ContractPutCodeFn>;
 pub type ContractInstantiateXt = UncheckedExtrinsicV4<ContractInstantiateFn>;
 pub type ContractInstantiateWithCodeXt = UncheckedExtrinsicV4<ContractInstantiateWithCodeFn>;
 pub type ContractCallXt = UncheckedExtrinsicV4<ContractCallFn>;
 
 #[cfg(feature = "std")]
-impl<P, Client> Api<P, Client>
+impl<P, Client, Params> Api<P, Client, Params>
 where
     P: Pair,
     MultiSignature: From<P::Signature>,
     MultiSigner: From<P::Public>,
     Client: RpcClient,
+    Params: ExtrinsicParams,
 {
-    pub fn contract_put_code(&self, gas_limit: Gas, code: Data) -> ContractPutCodeXt {
+    pub fn contract_put_code(&self, gas_limit: Gas, code: Data) -> ContractPutCodeXt
+    where
+        Params: ExtrinsicParams<OtherParams = ContractExtrinsicParamsBuilder>,
+    {
         compose_extrinsic!(
             self,
             CONTRACTS_MODULE,
@@ -77,7 +86,10 @@ where
         gas_limit: Gas,
         code_hash: Hash,
         data: Data,
-    ) -> ContractInstantiateXt {
+    ) -> ContractInstantiateXt
+    where
+        Params: ExtrinsicParams<OtherParams = ContractExtrinsicParamsBuilder>,
+    {
         compose_extrinsic!(
             self,
             CONTRACTS_MODULE,
@@ -96,7 +108,10 @@ where
         code: Data,
         data: Data,
         salt: Data,
-    ) -> ContractInstantiateWithCodeXt {
+    ) -> ContractInstantiateWithCodeXt
+    where
+        Params: ExtrinsicParams<OtherParams = ContractExtrinsicParamsBuilder>,
+    {
         compose_extrinsic!(
             self,
             CONTRACTS_MODULE,
@@ -115,7 +130,10 @@ where
         value: Balance,
         gas_limit: Gas,
         data: Data,
-    ) -> ContractCallXt {
+    ) -> ContractCallXt
+    where
+        Params: ExtrinsicParams<OtherParams = ContractExtrinsicParamsBuilder>,
+    {
         compose_extrinsic!(
             self,
             CONTRACTS_MODULE,

--- a/src/extrinsic/contract.rs
+++ b/src/extrinsic/contract.rs
@@ -63,7 +63,6 @@ where
     MultiSignature: From<P::Signature>,
     MultiSigner: From<P::Public>,
     Client: RpcClient,
-    Params: ExtrinsicParams,
     Params: ExtrinsicParams<OtherParams = BaseExtrinsicParamsBuilder<Tip>>,
     Tip: Default + Encode + Copy,
     u128: From<Tip>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,8 +29,9 @@ pub mod utils;
 pub use crate::std::*;
 
 pub use ac_primitives::{
-    AccountData, AccountDataGen, AccountInfo, AccountInfoGen, Balance, BlockNumber, GenericAddress,
-    GenericExtra, Hash, Index, Moment, RefCount, UncheckedExtrinsicV4,
+    AccountData, AccountDataGen, AccountInfo, AccountInfoGen, Balance, BaseExtrinsicParams,
+    BlockNumber, ExtrinsicParams, GenericAddress, Hash, Index, Moment, PlainTipExtrinsicParams,
+    RefCount, UncheckedExtrinsicV4,
 };
 
 #[cfg(feature = "std")]

--- a/src/std/mod.rs
+++ b/src/std/mod.rs
@@ -2,7 +2,7 @@ pub use crate::error::{ApiResult, Error as ApiClientError};
 pub use crate::std::rpc::XtStatus;
 pub use crate::utils::FromHexString;
 pub use ac_node_api::metadata::{InvalidMetadataError, Metadata, MetadataError};
-use ac_primitives::{AccountData, AccountInfo, Balance};
+use ac_primitives::{AccountData, AccountInfo, Balance, ExtrinsicParams};
 pub use metadata::RuntimeMetadataPrefixed;
 pub use serde_json::Value;
 pub use sp_core::crypto::Pair;
@@ -47,7 +47,7 @@ pub trait RpcClient {
 /// ```no_run
 /// use substrate_api_client::rpc::json_req::author_submit_extrinsic;
 /// use substrate_api_client::{
-///     Api, ApiClientError, ApiResult, FromHexString, Hash, RpcClient, Value, XtStatus,
+///     Api, ApiClientError, ApiResult, FromHexString, Hash, RpcClient, Value, XtStatus, PlainTipExtrinsicParams
 /// };
 /// struct MyClient {
 ///     // pick any request crate, such as ureq::Agent
@@ -93,27 +93,30 @@ pub trait RpcClient {
 /// }
 ///
 /// let client = MyClient::new();
-/// let _api = Api::<(), _>::new(client);
+/// let _api = Api::<(), _, PlainTipExtrinsicParams>::new(client);
 ///
 /// ```
 #[derive(Clone)]
-pub struct Api<P, Client>
+pub struct Api<P, Client, Params>
 where
     Client: RpcClient,
+    Params: ExtrinsicParams,
 {
     pub signer: Option<P>,
     pub genesis_hash: Hash,
     pub metadata: Metadata,
     pub runtime_version: RuntimeVersion,
     client: Client,
+    pub extrinsic_params: Option<Params::OtherParams>,
 }
 
-impl<P, Client> Api<P, Client>
+impl<P, Client, Params> Api<P, Client, Params>
 where
     P: Pair,
     MultiSignature: From<P::Signature>,
     MultiSigner: From<P::Public>,
     Client: RpcClient,
+    Params: ExtrinsicParams,
 {
     pub fn signer_account(&self) -> Option<AccountId> {
         let pair = self.signer.as_ref()?;
@@ -131,9 +134,10 @@ where
     }
 }
 
-impl<P, Client> Api<P, Client>
+impl<P, Client, Params> Api<P, Client, Params>
 where
     Client: RpcClient,
+    Params: ExtrinsicParams,
 {
     pub fn new(client: Client) -> ApiResult<Self> {
         let genesis_hash = Self::_get_genesis_hash(&client)?;
@@ -151,12 +155,18 @@ where
             metadata,
             runtime_version,
             client,
+            extrinsic_params: None,
         })
     }
 
     #[must_use]
     pub fn set_signer(mut self, signer: P) -> Self {
         self.signer = Some(signer);
+        self
+    }
+
+    pub fn set_extrinsic_params(mut self, extrinsic_params: Params::OtherParams) -> Self {
+        self.extrinsic_params = Some(extrinsic_params);
         self
     }
 
@@ -508,7 +518,7 @@ where
         xthex_prefixed: String,
         exit_on: XtStatus,
     ) -> ApiResult<Option<Hash>> {
-        debug!("sending extrinsic: {:?}", xthex_prefixed);
+        //println!("sending extrinsic: {:?}", xthex_prefixed);
         self.client.send_extrinsic(xthex_prefixed, exit_on)
     }
 

--- a/src/std/mod.rs
+++ b/src/std/mod.rs
@@ -518,7 +518,7 @@ where
         xthex_prefixed: String,
         exit_on: XtStatus,
     ) -> ApiResult<Option<Hash>> {
-        //println!("sending extrinsic: {:?}", xthex_prefixed);
+        debug!("sending extrinsic: {:?}", xthex_prefixed);
         self.client.send_extrinsic(xthex_prefixed, exit_on)
     }
 

--- a/src/std/rpc/ws_client/mod.rs
+++ b/src/std/rpc/ws_client/mod.rs
@@ -17,6 +17,7 @@
 use std::sync::mpsc::{Receiver, SendError, Sender as ThreadOut};
 
 use ac_node_api::events::{EventsDecoder, Raw, RawEvent};
+use ac_primitives::ExtrinsicParams;
 use codec::Decode;
 use log::{debug, error, info, warn};
 use serde_json::Value;
@@ -61,18 +62,22 @@ pub trait Subscriber {
         -> Result<(), Error>;
 }
 
-impl<P> Api<P, WsRpcClient> {
+impl<P, Params> Api<P, WsRpcClient, Params>
+where
+    Params: ExtrinsicParams,
+{
     pub fn default_with_url(url: &str) -> ApiResult<Self> {
         let client = WsRpcClient::new(url);
         Self::new(client)
     }
 }
 
-impl<P, Client> Api<P, Client>
+impl<P, Client, Params> Api<P, Client, Params>
 where
     P: Pair,
     MultiSignature: From<P::Signature>,
     Client: RpcClientTrait + Subscriber,
+    Params: ExtrinsicParams,
 {
     pub fn subscribe_events(&self, sender: ThreadOut<String>) -> ApiResult<()> {
         debug!("subscribing to events");

--- a/tutorials/api-client-tutorial/src/main.rs
+++ b/tutorials/api-client-tutorial/src/main.rs
@@ -18,7 +18,8 @@ use sp_core::crypto::Pair;
 use sp_keyring::AccountKeyring;
 
 use substrate_api_client::{
-    compose_extrinsic, rpc::WsRpcClient, utils::FromHexString, Api, UncheckedExtrinsicV4, XtStatus,
+    compose_extrinsic, rpc::WsRpcClient, utils::FromHexString, Api, ExtrinsicParams,
+    PlainTipExtrinsicParams, UncheckedExtrinsicV4, XtStatus,
 };
 
 #[derive(Encode, Decode, Debug)]
@@ -34,7 +35,7 @@ fn main() {
     let client = WsRpcClient::new(url);
 
     let api = Api::new(client)
-        .map(|api| api.set_signer(signer.clone()))
+        .map(|api: Api<_, _, PlainTipExtrinsicParams>| api.set_signer(signer.clone()))
         .unwrap();
 
     let xt: UncheckedExtrinsicV4<_> =


### PR DESCRIPTION
- According to subxt, add ExtrinsicParams and BaseExtrinsicParamsBuilder to configure the signed extra. The tip type can be defined for the API.
- If no extra params are defined, the default one will be used. Default values are defined as in subxt
- Let the GenericExtras as it was.
- Some examples don't run locally: get_blocks, benchmark and compose xt offline. These don't run in master too