### PR TITLE
Become generic over SignedExtra and AdditionalSigned

### DIFF
--- a/compose-macros/src/lib.rs
+++ b/compose-macros/src/lib.rs
@@ -110,7 +110,7 @@ macro_rules! compose_extrinsic {
                 $crate::compose_extrinsic_offline!(
                     signer,
                     call.clone(),
-                    $api.extrinsic_params( $api.get_nonce().unwrap())
+                    $api.extrinsic_params($api.get_nonce().unwrap())
                 )
             } else {
                 UncheckedExtrinsicV4 {

--- a/compose-macros/src/lib.rs
+++ b/compose-macros/src/lib.rs
@@ -63,34 +63,16 @@ macro_rules! compose_extrinsic_offline {
     $call: expr,
     $nonce: expr,
     $genesis_hash: expr,
-    $genesis_or_current_hash: expr,
+    $genesis_or_current_hash: expr, ///Todo remove
     $runtime_spec_version: expr,
     $transaction_version: expr,
-    $extrinsic_params: expr) => {{
-        use $crate::primitives::{
-            BaseExtrinsicParams, BaseExtrinsicParamsBuilder, GenericAddress, GenericExtra,
-            SignedPayload, UncheckedExtrinsicV4,
-        };
+    $params: expr) => {{
+        use $crate::primitives::{GenericAddress, SignedPayload, UncheckedExtrinsicV4};
         use $crate::sp_runtime::{generic::Era, traits::IdentifyAccount, MultiSigner};
 
-        let other_params = $extrinsic_params.unwrap_or_default();
-
-        let params = BaseExtrinsicParams::new($nonce, other_params);
-
-        let extra = GenericExtra::from(params);
-        let raw_payload = SignedPayload::from_raw(
-            $call.clone(),
-            extra.clone(),
-            (
-                $runtime_spec_version,
-                $transaction_version,
-                $genesis_hash,
-                $genesis_or_current_hash,
-                (),
-                (),
-                (),
-            ),
-        );
+        let extra = $params.signed_extra();
+        let raw_payload =
+            SignedPayload::from_raw($call.clone(), extra, $params.additional_signed());
 
         let signature = raw_payload.using_encoded(|payload| $signer.sign(payload));
 
@@ -126,20 +108,20 @@ macro_rules! compose_extrinsic {
             use $crate::log::debug;
             use $crate::primitives::UncheckedExtrinsicV4;
             use $crate::sp_runtime::generic::Era;
-            use $crate::primitives::BaseExtrinsicParamsBuilder;
 
             debug!("Composing generic extrinsic for module {:?} and call {:?}", $module, $call);
             let call = $crate::compose_call!($api.metadata.clone(), $module, $call $(, ($args)) *);
+            let nonce = $api.get_nonce().unwrap();
             if let Some(signer) = $api.signer.clone() {
                 $crate::compose_extrinsic_offline!(
                     signer,
                     call.clone(),
-                    $api.get_nonce().unwrap(),
+                    nonce,
                     $api.genesis_hash,
                     $api.genesis_hash,
                     $api.runtime_version.spec_version,
                     $api.runtime_version.transaction_version,
-                    $api.extrinsic_params
+                    $api.extrinsic_params(nonce)
                 )
             } else {
                 UncheckedExtrinsicV4 {

--- a/compose-macros/src/lib.rs
+++ b/compose-macros/src/lib.rs
@@ -61,11 +61,6 @@ macro_rules! compose_call {
 macro_rules! compose_extrinsic_offline {
     ($signer: expr,
     $call: expr,
-    $nonce: expr,
-    $genesis_hash: expr,
-    $genesis_or_current_hash: expr, ///Todo remove
-    $runtime_spec_version: expr,
-    $transaction_version: expr,
     $params: expr) => {{
         use $crate::primitives::{GenericAddress, SignedPayload, UncheckedExtrinsicV4};
         use $crate::sp_runtime::{generic::Era, traits::IdentifyAccount, MultiSigner};
@@ -111,17 +106,11 @@ macro_rules! compose_extrinsic {
 
             debug!("Composing generic extrinsic for module {:?} and call {:?}", $module, $call);
             let call = $crate::compose_call!($api.metadata.clone(), $module, $call $(, ($args)) *);
-            let nonce = $api.get_nonce().unwrap();
             if let Some(signer) = $api.signer.clone() {
                 $crate::compose_extrinsic_offline!(
                     signer,
                     call.clone(),
-                    nonce,
-                    $api.genesis_hash,
-                    $api.genesis_hash,
-                    $api.runtime_version.spec_version,
-                    $api.runtime_version.transaction_version,
-                    $api.extrinsic_params(nonce)
+                    $api.extrinsic_params( $api.get_nonce().unwrap())
                 )
             } else {
                 UncheckedExtrinsicV4 {

--- a/examples/example_benchmark_bulk_xt.rs
+++ b/examples/example_benchmark_bulk_xt.rs
@@ -65,7 +65,7 @@ fn main() {
             api.genesis_hash,
             api.runtime_version.spec_version,
             api.runtime_version.transaction_version,
-            api.extrinsic_params
+            api.extrinsic_params(nonce)
         );
         // send and watch extrinsic until finalized
         println!("sending extrinsic with nonce {}", nonce);

--- a/examples/example_benchmark_bulk_xt.rs
+++ b/examples/example_benchmark_bulk_xt.rs
@@ -54,7 +54,7 @@ fn main() {
     while nonce < first_nonce + 500 {
         // compose the extrinsic with all the element
         #[allow(clippy::redundant_clone)]
-        let xt: UncheckedExtrinsicV4<_> = compose_extrinsic_offline!(
+        let xt: UncheckedExtrinsicV4<_, _> = compose_extrinsic_offline!(
             api.clone().signer.unwrap(),
             Call::Balances(BalancesCall::transfer {
                 dest: GenericAddress::Id(to.clone()),

--- a/examples/example_benchmark_bulk_xt.rs
+++ b/examples/example_benchmark_bulk_xt.rs
@@ -60,11 +60,6 @@ fn main() {
                 dest: GenericAddress::Id(to.clone()),
                 value: 1_000_000
             }),
-            nonce,
-            api.genesis_hash,
-            api.genesis_hash,
-            api.runtime_version.spec_version,
-            api.runtime_version.transaction_version,
             api.extrinsic_params(nonce)
         );
         // send and watch extrinsic until finalized

--- a/examples/example_compose_extrinsic_offline.rs
+++ b/examples/example_compose_extrinsic_offline.rs
@@ -57,7 +57,7 @@ fn main() {
     let to = MultiAddress::Id(AccountKeyring::Bob.to_account_id());
 
     let tx_params = PlainTipExtrinsicParamsBuilder::new()
-        .era(Era::mortal(period, h.number.into()), api.genesis_hash)
+        .era(Era::mortal(period, h.number.into()), head)
         .tip(0);
 
     let updated_api = api.set_extrinsic_params_builder(tx_params);
@@ -70,11 +70,6 @@ fn main() {
             dest: to.clone(),
             value: 42
         }),
-        nonce,
-        updated_api.genesis_hash,
-        head,
-        updated_api.runtime_version.spec_version,
-        updated_api.runtime_version.transaction_version,
         updated_api.extrinsic_params(nonce)
     );
 

--- a/examples/example_compose_extrinsic_offline.rs
+++ b/examples/example_compose_extrinsic_offline.rs
@@ -60,8 +60,8 @@ fn main() {
         .era(Era::mortal(period, h.number.into()), api.genesis_hash)
         .tip(0);
 
-    let updated_api = api.set_extrinsic_params(tx_params);
-
+    let updated_api = api.set_extrinsic_params_builder(tx_params);
+    let nonce = updated_api.get_nonce().unwrap();
     // compose the extrinsic with all the element
     #[allow(clippy::redundant_clone)]
     let xt: UncheckedExtrinsicV4<_> = compose_extrinsic_offline!(
@@ -70,12 +70,12 @@ fn main() {
             dest: to.clone(),
             value: 42
         }),
-        updated_api.get_nonce().unwrap(),
+        nonce,
         updated_api.genesis_hash,
         head,
         updated_api.runtime_version.spec_version,
         updated_api.runtime_version.transaction_version,
-        updated_api.extrinsic_params
+        updated_api.extrinsic_params(nonce)
     );
 
     println!("[+] Composed Extrinsic:\n {:?}\n", xt);

--- a/examples/example_compose_extrinsic_offline.rs
+++ b/examples/example_compose_extrinsic_offline.rs
@@ -64,7 +64,7 @@ fn main() {
     let nonce = updated_api.get_nonce().unwrap();
     // compose the extrinsic with all the element
     #[allow(clippy::redundant_clone)]
-    let xt: UncheckedExtrinsicV4<_> = compose_extrinsic_offline!(
+    let xt: UncheckedExtrinsicV4<_, _> = compose_extrinsic_offline!(
         updated_api.clone().signer.unwrap(),
         Call::Balances(BalancesCall::transfer {
             dest: to.clone(),

--- a/examples/example_generic_extrinsic.rs
+++ b/examples/example_generic_extrinsic.rs
@@ -43,7 +43,7 @@ fn main() {
     // call Balances::transfer
     // the names are given as strings
     #[allow(clippy::redundant_clone)]
-    let xt: UncheckedExtrinsicV4<_> = compose_extrinsic!(
+    let xt: UncheckedExtrinsicV4<_, _> = compose_extrinsic!(
         api.clone(),
         "Balances",
         "transfer",

--- a/examples/example_sudo.rs
+++ b/examples/example_sudo.rs
@@ -51,7 +51,7 @@ fn main() {
         Compact(42_u128)
     );
     #[allow(clippy::redundant_clone)]
-    let xt: UncheckedExtrinsicV4<_> = compose_extrinsic!(api.clone(), "Sudo", "sudo", call);
+    let xt: UncheckedExtrinsicV4<_, _> = compose_extrinsic!(api.clone(), "Sudo", "sudo", call);
 
     // send and watch extrinsic until finalized
     let tx_hash = api

--- a/primitives/src/extrinsic_params.rs
+++ b/primitives/src/extrinsic_params.rs
@@ -1,15 +1,17 @@
 use codec::{Compact, Decode, Encode};
+use core::marker::PhantomData;
 use sp_core::{blake2_256, H256};
 use sp_runtime::generic::Era;
 use sp_std::prelude::*;
 
-/// Simple generic extra mirroring the SignedExtra currently used in extrinsics. Does not implement
-/// the SignedExtension trait. It simply encodes to the same bytes as the real SignedExtra. The
-/// Order is (CheckVersion, CheckGenesis, Check::Era, CheckNonce, CheckWeight, transactionPayment::ChargeTransactionPayment).
-/// This can be locked up in the System module. Fields that are merely PhantomData are not encoded and are
-/// therefore omitted here.
-#[derive(Decode, Encode, Clone, Eq, PartialEq, Debug)]
-pub struct GenericExtra(pub Era, pub Compact<u32>, pub Compact<u128>);
+/// Default SignedExtra.
+/// Simple generic extra mirroring the SignedExtra currently used in extrinsics.
+#[derive(Decode, Encode, Copy, Clone, Eq, PartialEq, Debug)]
+pub struct SubstrateDefaultSignedExtra(pub Era, pub Compact<u32>, pub Compact<u128>);
+
+/// Default AdditionalSigned fields of the respective SignedExtra fields.
+/// The Order is (CheckSpecVersion, CheckTxVersion, CheckGenesis, Check::Era, CheckNonce, CheckWeight, transactionPayment::ChargeTransactionPayment).
+pub type SubstrateDefaultAdditionalSigned = (u32, u32, H256, H256, (), (), ());
 
 /// This trait allows you to configure the "signed extra" and
 /// "additional" parameters that are signed and used in transactions.
@@ -17,18 +19,32 @@ pub struct GenericExtra(pub Era, pub Compact<u32>, pub Compact<u128>);
 /// a Polkadot node.
 pub trait ExtrinsicParams {
     /// These parameters can be provided to the constructor along with
-    /// some default parameters that `subxt` understands, in order to
-    /// help construct your [`ExtrinsicParams`] object.
-    type OtherParams;
+    /// some default parameters in order to help construct your [`ExtrinsicParams`] object.
+    type OtherParams: Default + Clone;
+
+    /// SignedExtra format of the node.
+    type SignedExtra;
+
+    /// Additional Signed format of the node
+    type AdditionalSigned: Encode;
 
     /// Construct a new instance of our [`ExtrinsicParams`]
-    fn new(nonce: u32, other_params: Self::OtherParams) -> Self;
+    fn new(
+        spec_version: u32,
+        transaction_version: u32,
+        nonce: u32,
+        genesis_hash: H256,
+        other_params: Self::OtherParams,
+    ) -> Self;
 
-    /// This is expected to SCALE encode the "signed extra" parameters
-    /// to some buffer that has been provided. These are the parameters
-    /// which are sent along with the transaction, as well as taken into
-    /// account when signing the transaction.
-    fn encode_extra_to(&self, v: &mut Vec<u8>);
+    /// These are the parameters which are sent along with the transaction,
+    /// as well as taken into account when signing the transaction.
+    fn signed_extra(&self) -> Self::SignedExtra;
+
+    /// These parameters are not sent along with the transaction, but are
+    /// taken into account when signing it, meaning the client and node must agree
+    /// on their values.
+    fn additional_signed(&self) -> Self::AdditionalSigned;
 }
 
 /// A struct representing the signed extra and additional parameters required
@@ -45,11 +61,19 @@ pub type PlainTipExtrinsicParams = BaseExtrinsicParams<PlainTip>;
 /// This is what you provide to methods like `sign_and_submit()`.
 pub type PlainTipExtrinsicParamsBuilder = BaseExtrinsicParamsBuilder<PlainTip>;
 
+/// An implementation of [`ExtrinsicParams`] that is suitable for constructing
+/// extrinsics that can be sent to a node with the same signed extra and additional
+/// parameters as a Polkadot/Substrate node.
 #[derive(Decode, Encode, Clone, Eq, PartialEq, Debug)]
 pub struct BaseExtrinsicParams<Tip> {
     era: Era,
     nonce: u32,
     tip: Tip,
+    spec_version: u32,
+    transaction_version: u32,
+    genesis_hash: H256,
+    mortality_checkpoint: H256,
+    marker: PhantomData<()>,
 }
 
 /// This builder allows you to provide the parameters that can be configured in order to
@@ -96,47 +120,63 @@ impl<Tip: Default> Default for BaseExtrinsicParamsBuilder<Tip> {
     }
 }
 
-/// Get the generic extra from the BaseExtrinsicParams.
-impl<Tip> From<BaseExtrinsicParams<Tip>> for GenericExtra
+impl<Tip: Encode> ExtrinsicParams for BaseExtrinsicParams<Tip>
 where
     u128: From<Tip>,
+    Tip: Copy + Default,
 {
-    fn from(p: BaseExtrinsicParams<Tip>) -> GenericExtra {
-        let BaseExtrinsicParams { era, nonce, tip } = p;
-        GenericExtra(era, Compact(nonce), Compact(tip.into()))
-    }
-}
-
-impl<Tip: Encode> ExtrinsicParams for BaseExtrinsicParams<Tip> {
     type OtherParams = BaseExtrinsicParamsBuilder<Tip>;
+    type SignedExtra = SubstrateDefaultSignedExtra;
+    type AdditionalSigned = SubstrateDefaultAdditionalSigned;
 
-    fn new(nonce: u32, other_params: Self::OtherParams) -> Self {
+    fn new(
+        spec_version: u32,
+        transaction_version: u32,
+        nonce: u32,
+        genesis_hash: H256,
+        other_params: Self::OtherParams,
+    ) -> Self {
         BaseExtrinsicParams {
             era: other_params.era,
             tip: other_params.tip,
+            spec_version,
+            transaction_version,
+            genesis_hash,
+            mortality_checkpoint: other_params.mortality_checkpoint.unwrap_or(genesis_hash),
             nonce,
+            marker: Default::default(),
         }
     }
 
-    fn encode_extra_to(&self, v: &mut Vec<u8>) {
-        let nonce: u64 = self.nonce.into();
-        let tip = self.tip.encode(); //?
-        (self.era, Compact(nonce), tip).encode_to(v);
+    fn signed_extra(&self) -> Self::SignedExtra {
+        SubstrateDefaultSignedExtra(self.era, Compact(self.nonce), Compact(self.tip.into()))
+    }
+
+    fn additional_signed(&self) -> Self::AdditionalSigned {
+        (
+            self.spec_version,
+            self.transaction_version,
+            self.genesis_hash,
+            self.mortality_checkpoint,
+            (),
+            (),
+            (),
+        )
     }
 }
 
-/// additionalSigned fields of the respective SignedExtra fields.
-/// Order is the same as declared in the extra.
-pub type AdditionalSigned = (u32, u32, H256, H256, (), (), ());
-
 #[derive(Decode, Encode, Clone, Eq, PartialEq, Debug)]
-pub struct SignedPayload<Call>((Call, GenericExtra, AdditionalSigned));
+pub struct SignedPayload<Call, SignedExtra, AdditionalSigned>(
+    (Call, SignedExtra, AdditionalSigned),
+);
 
-impl<Call> SignedPayload<Call>
+impl<Call, SignedExtra, AdditionalSigned> SignedPayload<Call, SignedExtra, AdditionalSigned>
 where
     Call: Encode,
+    SignedExtra: Encode,
+    AdditionalSigned: Encode,
 {
-    pub fn from_raw(call: Call, extra: GenericExtra, additional_signed: AdditionalSigned) -> Self {
+    pub fn from_raw(call: Call, extra: SignedExtra, additional_signed: AdditionalSigned) -> Self {
         Self((call, extra, additional_signed))
     }
 

--- a/primitives/src/extrinsic_params.rs
+++ b/primitives/src/extrinsic_params.rs
@@ -23,7 +23,7 @@ pub trait ExtrinsicParams {
     type OtherParams: Default + Clone;
 
     /// SignedExtra format of the node.
-    type SignedExtra;
+    type SignedExtra: Copy + Encode;
 
     /// Additional Signed format of the node
     type AdditionalSigned: Encode;

--- a/primitives/src/extrinsics.rs
+++ b/primitives/src/extrinsics.rs
@@ -24,7 +24,7 @@ use sp_runtime::MultiSignature;
 use sp_std::fmt;
 use sp_std::prelude::*;
 
-use crate::GenericExtra;
+use crate::SubstrateDefaultSignedExtra;
 pub use sp_runtime::{AccountId32 as AccountId, MultiAddress};
 
 pub type AccountIndex = u64;
@@ -37,7 +37,7 @@ pub type CallIndex = [u8; 2];
 /// The SingedExtra used does not need to implement SingedExtension here.
 #[derive(Clone, Eq, PartialEq)]
 pub struct UncheckedExtrinsicV4<Call> {
-    pub signature: Option<(GenericAddress, MultiSignature, GenericExtra)>,
+    pub signature: Option<(GenericAddress, MultiSignature, SubstrateDefaultSignedExtra)>,
     pub function: Call,
 }
 
@@ -49,7 +49,7 @@ where
         function: Call,
         signed: GenericAddress,
         signature: MultiSignature,
-        extra: GenericExtra,
+        extra: SubstrateDefaultSignedExtra,
     ) -> Self {
         UncheckedExtrinsicV4 {
             signature: Some((signed, signature, extra)),
@@ -173,12 +173,12 @@ mod tests {
         let tx_params =
             PlainTipExtrinsicParamsBuilder::new().era(Era::mortal(8, 0), Hash::from([0u8; 32]));
 
-        let default_extra = BaseExtrinsicParams::new(0, tx_params);
+        let default_extra = BaseExtrinsicParams::new(0, 0, 0, Hash::from([0u8; 32]), tx_params);
         let xt = UncheckedExtrinsicV4::new_signed(
             vec![1, 1, 1],
             account.into(),
             multi_sig,
-            GenericExtra::from(default_extra),
+            default_extra.signed_extra(),
         );
         let xt_enc = xt.encode();
         assert_eq!(xt, Decode::decode(&mut xt_enc.as_slice()).unwrap())

--- a/primitives/src/extrinsics.rs
+++ b/primitives/src/extrinsics.rs
@@ -24,7 +24,6 @@ use sp_runtime::MultiSignature;
 use sp_std::fmt;
 use sp_std::prelude::*;
 
-use crate::SubstrateDefaultSignedExtra;
 pub use sp_runtime::{AccountId32 as AccountId, MultiAddress};
 
 pub type AccountIndex = u64;
@@ -36,20 +35,21 @@ pub type CallIndex = [u8; 2];
 /// Mirrors the currently used Extrinsic format (V4) from substrate. Has less traits and methods though.
 /// The SingedExtra used does not need to implement SingedExtension here.
 #[derive(Clone, Eq, PartialEq)]
-pub struct UncheckedExtrinsicV4<Call> {
-    pub signature: Option<(GenericAddress, MultiSignature, SubstrateDefaultSignedExtra)>,
+pub struct UncheckedExtrinsicV4<Call, SignedExtra> {
+    pub signature: Option<(GenericAddress, MultiSignature, SignedExtra)>,
     pub function: Call,
 }
 
-impl<Call> UncheckedExtrinsicV4<Call>
+impl<Call, SignedExtra> UncheckedExtrinsicV4<Call, SignedExtra>
 where
     Call: Encode,
+    SignedExtra: Encode,
 {
     pub fn new_signed(
         function: Call,
         signed: GenericAddress,
         signature: MultiSignature,
-        extra: SubstrateDefaultSignedExtra,
+        extra: SignedExtra,
     ) -> Self {
         UncheckedExtrinsicV4 {
             signature: Some((signed, signature, extra)),
@@ -64,9 +64,10 @@ where
     }
 }
 
-impl<Call> fmt::Debug for UncheckedExtrinsicV4<Call>
+impl<Call, SignedExtra> fmt::Debug for UncheckedExtrinsicV4<Call, SignedExtra>
 where
     Call: fmt::Debug,
+    SignedExtra: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
@@ -80,9 +81,10 @@ where
 
 const V4: u8 = 4;
 
-impl<Call> Encode for UncheckedExtrinsicV4<Call>
+impl<Call, SignedExtra> Encode for UncheckedExtrinsicV4<Call, SignedExtra>
 where
     Call: Encode,
+    SignedExtra: Encode,
 {
     fn encode(&self) -> Vec<u8> {
         encode_with_vec_prefix::<Self, _>(|v| {
@@ -100,9 +102,10 @@ where
     }
 }
 
-impl<Call> Decode for UncheckedExtrinsicV4<Call>
+impl<Call, SignedExtra> Decode for UncheckedExtrinsicV4<Call, SignedExtra>
 where
     Call: Decode + Encode,
+    SignedExtra: Decode + Encode,
 {
     fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
         // This is a little more complicated than usual since the binary format must be compatible

--- a/src/extrinsic/balances.rs
+++ b/src/extrinsic/balances.rs
@@ -19,10 +19,7 @@
 
 use crate::std::{Api, RpcClient};
 use ac_compose_macros::compose_extrinsic;
-use ac_primitives::{
-    Balance, CallIndex, ExtrinsicParams, GenericAddress, SubstrateDefaultSignedExtra,
-    UncheckedExtrinsicV4,
-};
+use ac_primitives::{Balance, CallIndex, ExtrinsicParams, GenericAddress, UncheckedExtrinsicV4};
 use codec::Compact;
 use sp_core::crypto::Pair;
 use sp_runtime::{MultiSignature, MultiSigner};
@@ -39,8 +36,8 @@ pub type BalanceSetBalanceFn = (
     Compact<Balance>,
 );
 
-pub type BalanceTransferXt = UncheckedExtrinsicV4<BalanceTransferFn>;
-pub type BalanceSetBalanceXt = UncheckedExtrinsicV4<BalanceSetBalanceFn>;
+pub type BalanceTransferXt<SignedExtra> = UncheckedExtrinsicV4<BalanceTransferFn, SignedExtra>;
+pub type BalanceSetBalanceXt<SignedExtra> = UncheckedExtrinsicV4<BalanceSetBalanceFn, SignedExtra>;
 
 #[cfg(feature = "std")]
 impl<P, Client, Params> Api<P, Client, Params>
@@ -49,9 +46,13 @@ where
     MultiSignature: From<P::Signature>,
     MultiSigner: From<P::Public>,
     Client: RpcClient,
-    Params: ExtrinsicParams<SignedExtra = SubstrateDefaultSignedExtra>,
+    Params: ExtrinsicParams,
 {
-    pub fn balance_transfer(&self, to: GenericAddress, amount: Balance) -> BalanceTransferXt {
+    pub fn balance_transfer(
+        &self,
+        to: GenericAddress,
+        amount: Balance,
+    ) -> BalanceTransferXt<Params::SignedExtra> {
         compose_extrinsic!(
             self,
             BALANCES_MODULE,
@@ -66,7 +67,7 @@ where
         who: GenericAddress,
         free_balance: Balance,
         reserved_balance: Balance,
-    ) -> BalanceSetBalanceXt {
+    ) -> BalanceSetBalanceXt<Params::SignedExtra> {
         compose_extrinsic!(
             self,
             BALANCES_MODULE,

--- a/src/extrinsic/balances.rs
+++ b/src/extrinsic/balances.rs
@@ -20,10 +20,10 @@
 use crate::std::{Api, RpcClient};
 use ac_compose_macros::compose_extrinsic;
 use ac_primitives::{
-    Balance, BaseExtrinsicParamsBuilder, CallIndex, ExtrinsicParams, GenericAddress,
+    Balance, CallIndex, ExtrinsicParams, GenericAddress, SubstrateDefaultSignedExtra,
     UncheckedExtrinsicV4,
 };
-use codec::{Compact, Encode};
+use codec::Compact;
 use sp_core::crypto::Pair;
 use sp_runtime::{MultiSignature, MultiSigner};
 
@@ -43,15 +43,13 @@ pub type BalanceTransferXt = UncheckedExtrinsicV4<BalanceTransferFn>;
 pub type BalanceSetBalanceXt = UncheckedExtrinsicV4<BalanceSetBalanceFn>;
 
 #[cfg(feature = "std")]
-impl<P, Client, Params, Tip> Api<P, Client, Params>
+impl<P, Client, Params> Api<P, Client, Params>
 where
     P: Pair,
     MultiSignature: From<P::Signature>,
     MultiSigner: From<P::Public>,
     Client: RpcClient,
-    Params: ExtrinsicParams<OtherParams = BaseExtrinsicParamsBuilder<Tip>>,
-    Tip: Default + Encode + Copy,
-    u128: From<Tip>,
+    Params: ExtrinsicParams<SignedExtra = SubstrateDefaultSignedExtra>,
 {
     pub fn balance_transfer(&self, to: GenericAddress, amount: Balance) -> BalanceTransferXt {
         compose_extrinsic!(

--- a/src/extrinsic/contract.rs
+++ b/src/extrinsic/contract.rs
@@ -20,10 +20,7 @@
 
 use crate::std::{Api, RpcClient};
 use ac_compose_macros::compose_extrinsic;
-use ac_primitives::{
-    Balance, CallIndex, ExtrinsicParams, GenericAddress, SubstrateDefaultSignedExtra,
-    UncheckedExtrinsicV4,
-};
+use ac_primitives::{Balance, CallIndex, ExtrinsicParams, GenericAddress, UncheckedExtrinsicV4};
 use codec::Compact;
 use sp_core::crypto::Pair;
 use sp_core::H256 as Hash;
@@ -51,10 +48,12 @@ pub type ContractInstantiateFn = (CallIndex, Endowment, GasLimit, Hash, Data);
 pub type ContractInstantiateWithCodeFn = (CallIndex, Endowment, GasLimit, Code, Data, Salt);
 pub type ContractCallFn = (CallIndex, Destination, Value, GasLimit, Data);
 
-pub type ContractPutCodeXt = UncheckedExtrinsicV4<ContractPutCodeFn>;
-pub type ContractInstantiateXt = UncheckedExtrinsicV4<ContractInstantiateFn>;
-pub type ContractInstantiateWithCodeXt = UncheckedExtrinsicV4<ContractInstantiateWithCodeFn>;
-pub type ContractCallXt = UncheckedExtrinsicV4<ContractCallFn>;
+pub type ContractPutCodeXt<SignedExtra> = UncheckedExtrinsicV4<ContractPutCodeFn, SignedExtra>;
+pub type ContractInstantiateXt<SignedExtra> =
+    UncheckedExtrinsicV4<ContractInstantiateFn, SignedExtra>;
+pub type ContractInstantiateWithCodeXt<SignedExtra> =
+    UncheckedExtrinsicV4<ContractInstantiateWithCodeFn, SignedExtra>;
+pub type ContractCallXt<SignedExtra> = UncheckedExtrinsicV4<ContractCallFn, SignedExtra>;
 
 #[cfg(feature = "std")]
 impl<P, Client, Params> Api<P, Client, Params>
@@ -63,9 +62,13 @@ where
     MultiSignature: From<P::Signature>,
     MultiSigner: From<P::Public>,
     Client: RpcClient,
-    Params: ExtrinsicParams<SignedExtra = SubstrateDefaultSignedExtra>,
+    Params: ExtrinsicParams,
 {
-    pub fn contract_put_code(&self, gas_limit: Gas, code: Data) -> ContractPutCodeXt {
+    pub fn contract_put_code(
+        &self,
+        gas_limit: Gas,
+        code: Data,
+    ) -> ContractPutCodeXt<Params::SignedExtra> {
         compose_extrinsic!(
             self,
             CONTRACTS_MODULE,
@@ -81,7 +84,7 @@ where
         gas_limit: Gas,
         code_hash: Hash,
         data: Data,
-    ) -> ContractInstantiateXt {
+    ) -> ContractInstantiateXt<Params::SignedExtra> {
         compose_extrinsic!(
             self,
             CONTRACTS_MODULE,
@@ -100,7 +103,7 @@ where
         code: Data,
         data: Data,
         salt: Data,
-    ) -> ContractInstantiateWithCodeXt {
+    ) -> ContractInstantiateWithCodeXt<Params::SignedExtra> {
         compose_extrinsic!(
             self,
             CONTRACTS_MODULE,
@@ -119,7 +122,7 @@ where
         value: Balance,
         gas_limit: Gas,
         data: Data,
-    ) -> ContractCallXt {
+    ) -> ContractCallXt<Params::SignedExtra> {
         compose_extrinsic!(
             self,
             CONTRACTS_MODULE,

--- a/src/extrinsic/contract.rs
+++ b/src/extrinsic/contract.rs
@@ -21,10 +21,10 @@
 use crate::std::{Api, RpcClient};
 use ac_compose_macros::compose_extrinsic;
 use ac_primitives::{
-    Balance, BaseExtrinsicParamsBuilder, CallIndex, ExtrinsicParams, GenericAddress,
+    Balance, CallIndex, ExtrinsicParams, GenericAddress, SubstrateDefaultSignedExtra,
     UncheckedExtrinsicV4,
 };
-use codec::{Compact, Encode};
+use codec::Compact;
 use sp_core::crypto::Pair;
 use sp_core::H256 as Hash;
 use sp_runtime::{MultiSignature, MultiSigner};
@@ -57,15 +57,13 @@ pub type ContractInstantiateWithCodeXt = UncheckedExtrinsicV4<ContractInstantiat
 pub type ContractCallXt = UncheckedExtrinsicV4<ContractCallFn>;
 
 #[cfg(feature = "std")]
-impl<P, Client, Params, Tip> Api<P, Client, Params>
+impl<P, Client, Params> Api<P, Client, Params>
 where
     P: Pair,
     MultiSignature: From<P::Signature>,
     MultiSigner: From<P::Public>,
     Client: RpcClient,
-    Params: ExtrinsicParams<OtherParams = BaseExtrinsicParamsBuilder<Tip>>,
-    Tip: Default + Encode + Copy,
-    u128: From<Tip>,
+    Params: ExtrinsicParams<SignedExtra = SubstrateDefaultSignedExtra>,
 {
     pub fn contract_put_code(&self, gas_limit: Gas, code: Data) -> ContractPutCodeXt {
         compose_extrinsic!(

--- a/src/std/mod.rs
+++ b/src/std/mod.rs
@@ -107,7 +107,7 @@ where
     pub metadata: Metadata,
     pub runtime_version: RuntimeVersion,
     client: Client,
-    pub extrinsic_params: Option<Params::OtherParams>,
+    pub extrinsic_params_builder: Option<Params::OtherParams>,
 }
 
 impl<P, Client, Params> Api<P, Client, Params>
@@ -155,7 +155,7 @@ where
             metadata,
             runtime_version,
             client,
-            extrinsic_params: None,
+            extrinsic_params_builder: None,
         })
     }
 
@@ -165,8 +165,8 @@ where
         self
     }
 
-    pub fn set_extrinsic_params(mut self, extrinsic_params: Params::OtherParams) -> Self {
-        self.extrinsic_params = Some(extrinsic_params);
+    pub fn set_extrinsic_params_builder(mut self, extrinsic_params: Params::OtherParams) -> Self {
+        self.extrinsic_params_builder = Some(extrinsic_params);
         self
     }
 
@@ -211,6 +211,16 @@ where
         }
     }
 
+    pub fn extrinsic_params(&self, nonce: u32) -> Params {
+        let extrinsic_params_builder = self.extrinsic_params_builder.clone().unwrap_or_default();
+        <Params as ExtrinsicParams>::new(
+            self.runtime_version.spec_version,
+            self.runtime_version.transaction_version,
+            nonce,
+            self.genesis_hash,
+            extrinsic_params_builder,
+        )
+    }
     pub fn get_metadata(&self) -> ApiResult<RuntimeMetadataPrefixed> {
         Self::_get_metadata(&self.client)
     }

--- a/tutorials/api-client-tutorial/src/main.rs
+++ b/tutorials/api-client-tutorial/src/main.rs
@@ -38,7 +38,7 @@ fn main() {
         .map(|api: Api<_, _, PlainTipExtrinsicParams>| api.set_signer(signer.clone()))
         .unwrap();
 
-    let xt: UncheckedExtrinsicV4<_> =
+    let xt: UncheckedExtrinsicV4<_, _> =
         compose_extrinsic!(api, "KittyModule", "create_kitty", 10_u128);
 
     println!("[+] Extrinsic: {:?}\n", xt);


### PR DESCRIPTION
Fix issue #233
- add generic type in ExtrinsicParams for the Signed Extra and the AdditionalSigned
- SignedPayload is generic over SignedExtra and AdditionalSigned
- UncheckedExtrinsicV4  is generic over SignedExtra
- Define default SignedExtra and AdditionalSigned (previously GenericExtra and AdditionalSigned)
- Add function to api client to get the ExtrinsicParams to make the macro compose_extrinsic_offline generic
- compose_extrinsic_offline generic interface change !!! The Signed Extra and the AdditionalSigned are build before