### PR TITLE
[exrinsics] make generic over signed extra

### DIFF
--- a/examples/example_benchmark_bulk_xt.rs
+++ b/examples/example_benchmark_bulk_xt.rs
@@ -54,7 +54,7 @@ fn main() {
     while nonce < first_nonce + 500 {
         // compose the extrinsic with all the element
         #[allow(clippy::redundant_clone)]
-        let xt: UncheckedExtrinsicV4<_> = compose_extrinsic_offline!(
+        let xt: UncheckedExtrinsicV4<_, _> = compose_extrinsic_offline!(
             api.clone().signer.unwrap(),
             Call::Balances(BalancesCall::transfer {
                 dest: GenericAddress::Id(to.clone()),

--- a/examples/example_compose_extrinsic_offline.rs
+++ b/examples/example_compose_extrinsic_offline.rs
@@ -64,7 +64,7 @@ fn main() {
     let nonce = updated_api.get_nonce().unwrap();
     // compose the extrinsic with all the element
     #[allow(clippy::redundant_clone)]
-    let xt: UncheckedExtrinsicV4<_> = compose_extrinsic_offline!(
+    let xt: UncheckedExtrinsicV4<_, _> = compose_extrinsic_offline!(
         updated_api.clone().signer.unwrap(),
         Call::Balances(BalancesCall::transfer {
             dest: to.clone(),

--- a/examples/example_generic_extrinsic.rs
+++ b/examples/example_generic_extrinsic.rs
@@ -43,7 +43,7 @@ fn main() {
     // call Balances::transfer
     // the names are given as strings
     #[allow(clippy::redundant_clone)]
-    let xt: UncheckedExtrinsicV4<_> = compose_extrinsic!(
+    let xt: UncheckedExtrinsicV4<_, _> = compose_extrinsic!(
         api.clone(),
         "Balances",
         "transfer",

--- a/examples/example_sudo.rs
+++ b/examples/example_sudo.rs
@@ -51,7 +51,7 @@ fn main() {
         Compact(42_u128)
     );
     #[allow(clippy::redundant_clone)]
-    let xt: UncheckedExtrinsicV4<_> = compose_extrinsic!(api.clone(), "Sudo", "sudo", call);
+    let xt: UncheckedExtrinsicV4<_, _> = compose_extrinsic!(api.clone(), "Sudo", "sudo", call);
 
     // send and watch extrinsic until finalized
     let tx_hash = api

--- a/primitives/src/extrinsic_params.rs
+++ b/primitives/src/extrinsic_params.rs
@@ -23,7 +23,7 @@ pub trait ExtrinsicParams {
     type OtherParams: Default + Clone;
 
     /// SignedExtra format of the node.
-    type SignedExtra;
+    type SignedExtra: Copy + Encode;
 
     /// Additional Signed format of the node
     type AdditionalSigned: Encode;

--- a/primitives/src/extrinsics.rs
+++ b/primitives/src/extrinsics.rs
@@ -24,7 +24,6 @@ use sp_runtime::MultiSignature;
 use sp_std::fmt;
 use sp_std::prelude::*;
 
-use crate::SubstrateDefaultSignedExtra;
 pub use sp_runtime::{AccountId32 as AccountId, MultiAddress};
 
 pub type AccountIndex = u64;
@@ -36,20 +35,21 @@ pub type CallIndex = [u8; 2];
 /// Mirrors the currently used Extrinsic format (V4) from substrate. Has less traits and methods though.
 /// The SingedExtra used does not need to implement SingedExtension here.
 #[derive(Clone, Eq, PartialEq)]
-pub struct UncheckedExtrinsicV4<Call> {
-    pub signature: Option<(GenericAddress, MultiSignature, SubstrateDefaultSignedExtra)>,
+pub struct UncheckedExtrinsicV4<Call, SignedExtra> {
+    pub signature: Option<(GenericAddress, MultiSignature, SignedExtra)>,
     pub function: Call,
 }
 
-impl<Call> UncheckedExtrinsicV4<Call>
+impl<Call, SignedExtra> UncheckedExtrinsicV4<Call, SignedExtra>
 where
     Call: Encode,
+    SignedExtra: Encode,
 {
     pub fn new_signed(
         function: Call,
         signed: GenericAddress,
         signature: MultiSignature,
-        extra: SubstrateDefaultSignedExtra,
+        extra: SignedExtra,
     ) -> Self {
         UncheckedExtrinsicV4 {
             signature: Some((signed, signature, extra)),
@@ -64,9 +64,10 @@ where
     }
 }
 
-impl<Call> fmt::Debug for UncheckedExtrinsicV4<Call>
+impl<Call, SignedExtra> fmt::Debug for UncheckedExtrinsicV4<Call, SignedExtra>
 where
     Call: fmt::Debug,
+    SignedExtra: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
@@ -80,9 +81,10 @@ where
 
 const V4: u8 = 4;
 
-impl<Call> Encode for UncheckedExtrinsicV4<Call>
+impl<Call, SignedExtra> Encode for UncheckedExtrinsicV4<Call, SignedExtra>
 where
     Call: Encode,
+    SignedExtra: Encode,
 {
     fn encode(&self) -> Vec<u8> {
         encode_with_vec_prefix::<Self, _>(|v| {
@@ -100,9 +102,10 @@ where
     }
 }
 
-impl<Call> Decode for UncheckedExtrinsicV4<Call>
+impl<Call, SignedExtra> Decode for UncheckedExtrinsicV4<Call, SignedExtra>
 where
     Call: Decode + Encode,
+    SignedExtra: Decode + Encode,
 {
     fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
         // This is a little more complicated than usual since the binary format must be compatible

--- a/src/extrinsic/balances.rs
+++ b/src/extrinsic/balances.rs
@@ -19,10 +19,7 @@
 
 use crate::std::{Api, RpcClient};
 use ac_compose_macros::compose_extrinsic;
-use ac_primitives::{
-    Balance, CallIndex, ExtrinsicParams, GenericAddress, SubstrateDefaultSignedExtra,
-    UncheckedExtrinsicV4,
-};
+use ac_primitives::{Balance, CallIndex, ExtrinsicParams, GenericAddress, UncheckedExtrinsicV4};
 use codec::Compact;
 use sp_core::crypto::Pair;
 use sp_runtime::{MultiSignature, MultiSigner};
@@ -39,8 +36,8 @@ pub type BalanceSetBalanceFn = (
     Compact<Balance>,
 );
 
-pub type BalanceTransferXt = UncheckedExtrinsicV4<BalanceTransferFn>;
-pub type BalanceSetBalanceXt = UncheckedExtrinsicV4<BalanceSetBalanceFn>;
+pub type BalanceTransferXt<SignedExtra> = UncheckedExtrinsicV4<BalanceTransferFn, SignedExtra>;
+pub type BalanceSetBalanceXt<SignedExtra> = UncheckedExtrinsicV4<BalanceSetBalanceFn, SignedExtra>;
 
 #[cfg(feature = "std")]
 impl<P, Client, Params> Api<P, Client, Params>
@@ -49,9 +46,13 @@ where
     MultiSignature: From<P::Signature>,
     MultiSigner: From<P::Public>,
     Client: RpcClient,
-    Params: ExtrinsicParams<SignedExtra = SubstrateDefaultSignedExtra>,
+    Params: ExtrinsicParams,
 {
-    pub fn balance_transfer(&self, to: GenericAddress, amount: Balance) -> BalanceTransferXt {
+    pub fn balance_transfer(
+        &self,
+        to: GenericAddress,
+        amount: Balance,
+    ) -> BalanceTransferXt<Params::SignedExtra> {
         compose_extrinsic!(
             self,
             BALANCES_MODULE,
@@ -66,7 +67,7 @@ where
         who: GenericAddress,
         free_balance: Balance,
         reserved_balance: Balance,
-    ) -> BalanceSetBalanceXt {
+    ) -> BalanceSetBalanceXt<Params::SignedExtra> {
         compose_extrinsic!(
             self,
             BALANCES_MODULE,

--- a/src/extrinsic/contract.rs
+++ b/src/extrinsic/contract.rs
@@ -20,10 +20,7 @@
 
 use crate::std::{Api, RpcClient};
 use ac_compose_macros::compose_extrinsic;
-use ac_primitives::{
-    Balance, CallIndex, ExtrinsicParams, GenericAddress, SubstrateDefaultSignedExtra,
-    UncheckedExtrinsicV4,
-};
+use ac_primitives::{Balance, CallIndex, ExtrinsicParams, GenericAddress, UncheckedExtrinsicV4};
 use codec::Compact;
 use sp_core::crypto::Pair;
 use sp_core::H256 as Hash;
@@ -51,10 +48,12 @@ pub type ContractInstantiateFn = (CallIndex, Endowment, GasLimit, Hash, Data);
 pub type ContractInstantiateWithCodeFn = (CallIndex, Endowment, GasLimit, Code, Data, Salt);
 pub type ContractCallFn = (CallIndex, Destination, Value, GasLimit, Data);
 
-pub type ContractPutCodeXt = UncheckedExtrinsicV4<ContractPutCodeFn>;
-pub type ContractInstantiateXt = UncheckedExtrinsicV4<ContractInstantiateFn>;
-pub type ContractInstantiateWithCodeXt = UncheckedExtrinsicV4<ContractInstantiateWithCodeFn>;
-pub type ContractCallXt = UncheckedExtrinsicV4<ContractCallFn>;
+pub type ContractPutCodeXt<SignedExtra> = UncheckedExtrinsicV4<ContractPutCodeFn, SignedExtra>;
+pub type ContractInstantiateXt<SignedExtra> =
+    UncheckedExtrinsicV4<ContractInstantiateFn, SignedExtra>;
+pub type ContractInstantiateWithCodeXt<SignedExtra> =
+    UncheckedExtrinsicV4<ContractInstantiateWithCodeFn, SignedExtra>;
+pub type ContractCallXt<SignedExtra> = UncheckedExtrinsicV4<ContractCallFn, SignedExtra>;
 
 #[cfg(feature = "std")]
 impl<P, Client, Params> Api<P, Client, Params>
@@ -63,9 +62,13 @@ where
     MultiSignature: From<P::Signature>,
     MultiSigner: From<P::Public>,
     Client: RpcClient,
-    Params: ExtrinsicParams<SignedExtra = SubstrateDefaultSignedExtra>,
+    Params: ExtrinsicParams,
 {
-    pub fn contract_put_code(&self, gas_limit: Gas, code: Data) -> ContractPutCodeXt {
+    pub fn contract_put_code(
+        &self,
+        gas_limit: Gas,
+        code: Data,
+    ) -> ContractPutCodeXt<Params::SignedExtra> {
         compose_extrinsic!(
             self,
             CONTRACTS_MODULE,
@@ -81,7 +84,7 @@ where
         gas_limit: Gas,
         code_hash: Hash,
         data: Data,
-    ) -> ContractInstantiateXt {
+    ) -> ContractInstantiateXt<Params::SignedExtra> {
         compose_extrinsic!(
             self,
             CONTRACTS_MODULE,
@@ -100,7 +103,7 @@ where
         code: Data,
         data: Data,
         salt: Data,
-    ) -> ContractInstantiateWithCodeXt {
+    ) -> ContractInstantiateWithCodeXt<Params::SignedExtra> {
         compose_extrinsic!(
             self,
             CONTRACTS_MODULE,
@@ -119,7 +122,7 @@ where
         value: Balance,
         gas_limit: Gas,
         data: Data,
-    ) -> ContractCallXt {
+    ) -> ContractCallXt<Params::SignedExtra> {
         compose_extrinsic!(
             self,
             CONTRACTS_MODULE,


### PR DESCRIPTION
This is to make the extrinsics truly generic over the signed extra, which can now be completely configured outside this crate if needed