### PR TITLE
Use substrate latest docker image to run node in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
 
       - name: Run latest node
         run: |
-          docker run -p 127.0.0.1:9944:9944 parity/substrate:latest --dev &
+          docker run -p 127.0.0.1:9944:9944 parity/substrate:latest --dev --ws-external &
 
       - name: Run Examples
         timeout-minutes: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,4 @@ jobs:
       - name: Run Examples
         timeout-minutes: 5
         run: |
-          docker ps
-          apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y net-tools
-          nc -z -v 127.0.0.1 9944
           ./target/release/examples/${{ matrix.example }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,6 @@ jobs:
         run: ${{ matrix.check }}
 
   examples:
-    needs: build-node-template
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
 
       - name: Run latest node
         run: |
-          docker run -p 127.0.0.1:9944:9944 parity/substrate:latest --dev --ws-external &
+          docker run -p 9944:9944 parity/substrate:latest --dev --ws-external &
 
       - name: Run Examples
         timeout-minutes: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,7 @@ jobs:
       - name: Run latest node
         run: |
           docker run -p 9944:9944 -p 9933:9933 -p 30333:30333 parity/substrate:latest --dev --ws-external --rpc-external &
+          sleep 150
 
       - name: Run Examples
         timeout-minutes: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,10 +56,11 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     services:
-      image: parity/substrate:latest
-      ports:
+      latest_node:
+        image: parity/substrate:latest
+        ports:
         - 9944:9944
-      options: --dev --ws-external
+        options: --dev --ws-external
 
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,11 +84,13 @@ jobs:
       - name: Build examples
         run: cargo build --release --examples
 
-      - name: Run latest node
-        run: |
-          docker run -p 9944:9944 parity/substrate:latest --dev --ws-external &
-
-      - name: Run Examples
+      - name: Run latest node & example
         timeout-minutes: 5
         run: |
+          docker run -p 127.0.0.1:9944:9944 -p 127.0.0.1:9933:9933 -p 127.0.0.1:30333:30333 parity/substrate:latest --dev --ws-external &
           ./target/release/examples/${{ matrix.example }}
+
+#      - name: Run Examples
+#        timeout-minutes: 5
+#        run: |
+#          ./target/release/examples/${{ matrix.example }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
 
       - name: Run latest node
         run: |
-          docker run -p 9944:9944 parity/substrate:latest --dev &
+          docker run -p 127.0.0.1:9944:9944 parity/substrate:latest --dev &
 
       - name: Run Examples
         timeout-minutes: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
 
       - name: Run latest node
         run: |
-          docker run -p 127.0.0.1:9944:9944 -p 127.0.0.1:9933:9933 -p 127.0.0.1:30333:30333 parity/substrate:latest --dev --ws-external --rpc-external &
+          docker run -p 9944:9944 -p 9933:9933 -p 30333:30333 parity/substrate:latest --dev --ws-external --rpc-external &
 
       - name: Run Examples
         timeout-minutes: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,4 +100,6 @@ jobs:
         timeout-minutes: 5
         run: |
           docker ps
+          apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y net-tools
+          nc -z -v 127.0.0.1 9944
           ./target/release/examples/${{ matrix.example }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,4 +99,6 @@ jobs:
       - name: Run Examples
         timeout-minutes: 5
         run: |
+          docker ps
+          nc -z -v 127.0.0.1 9944
           ./target/release/examples/${{ matrix.example }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,12 +55,12 @@ jobs:
   examples:
     runs-on: ${{ matrix.os }}
 
-    services:
-      latest_node:
-        image: parity/substrate:latest
-        ports:
-        - 9944:9944
-        options: --dev --ws-external
+#    services:
+#      latest_node:
+#        image: parity/substrate:latest
+#        ports:
+#        - 9944:9944
+#        options: --dev --ws-external
 
     strategy:
       fail-fast: false
@@ -92,9 +92,9 @@ jobs:
       - name: Build examples
         run: cargo build --release --examples
 
-#      - name: Run latest node
-#        run: |
-#          docker run -p 127.0.0.1:9944:9944 -p 127.0.0.1:9933:9933 -p 127.0.0.1:30333:30333 parity/substrate:latest --dev --ws-external &
+      - name: Run latest node
+        run: |
+          docker run -p 127.0.0.1:9944:9944 -p 127.0.0.1:9933:9933 -p 127.0.0.1:30333:30333 parity/substrate:latest --dev --ws-external --rpc-external &
 
       - name: Run Examples
         timeout-minutes: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,39 +52,6 @@ jobs:
       - name: ${{ matrix.check }}
         run: ${{ matrix.check }}
 
-  build-node-template:
-    runs-on: ubuntu-latest
-    steps:
-      - name: init-rust-target
-        # need to set rust nightly as substrate does not have a rust-toolchain.toml
-        # The newest is currently not compatible
-        run: |
-          rustup default nightly-2021-12-10
-          rustup target add wasm32-unknown-unknown --toolchain nightly-2021-12-10
-          rustup show
-
-      - name: Checkout substrate
-        uses: actions/checkout@v2
-        with:
-          repository: paritytech/substrate
-          path: substrate
-
-      - uses: Swatinem/rust-cache@v1
-        with:
-          working-directory: substrate
-
-      - name: Build node-template
-        run: |
-          cd substrate
-          cargo build --release -p node-template
-
-      - name: Upload node-template
-        uses: actions/upload-artifact@v2
-        with:
-          name: node-template
-          path: substrate/target/release/node-template
-
-
   examples:
     needs: build-node-template
     runs-on: ${{ matrix.os }}
@@ -118,16 +85,9 @@ jobs:
       - name: Build examples
         run: cargo build --release --examples
 
-      - name: Download node-template
-        uses: actions/download-artifact@v2
-        with:
-          name: node-template
-          path: node
-
-      - name: Run node-template
+      - name: Run latest node
         run: |
-          chmod +x node/node-template
-          ./node/node-template --dev &
+          docker run -p 9944:9944 parity/substrate:latest --dev &
 
       - name: Run Examples
         timeout-minutes: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,4 +99,5 @@ jobs:
       - name: Run Examples
         timeout-minutes: 5
         run: |
+          docker ps
           ./target/release/examples/${{ matrix.example }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,13 @@ jobs:
 
   examples:
     runs-on: ${{ matrix.os }}
+
+    services:
+      image: parity/substrate:latest
+      ports:
+        - 9944:9944
+      options: --dev --ws-external
+
     strategy:
       fail-fast: false
       matrix:
@@ -84,13 +91,11 @@ jobs:
       - name: Build examples
         run: cargo build --release --examples
 
-      - name: Run latest node & example
+#      - name: Run latest node
+#        run: |
+#          docker run -p 127.0.0.1:9944:9944 -p 127.0.0.1:9933:9933 -p 127.0.0.1:30333:30333 parity/substrate:latest --dev --ws-external &
+
+      - name: Run Examples
         timeout-minutes: 5
         run: |
-          docker run -p 127.0.0.1:9944:9944 -p 127.0.0.1:9933:9933 -p 127.0.0.1:30333:30333 parity/substrate:latest --dev --ws-external &
           ./target/release/examples/${{ matrix.example }}
-
-#      - name: Run Examples
-#        timeout-minutes: 5
-#        run: |
-#          ./target/release/examples/${{ matrix.example }}

--- a/examples/example_event_callback.rs
+++ b/examples/example_event_callback.rs
@@ -80,7 +80,7 @@ pub fn get_node_url_from_cli() -> String {
     let yml = load_yaml!("cli.yml");
     let matches = App::from_yaml(yml).get_matches();
 
-    let node_ip = matches.value_of("node-server").unwrap_or("ws://127.0.0.1");
+    let node_ip = matches.value_of("node-server").unwrap_or("ws://localhost");
     let node_port = matches.value_of("node-port").unwrap_or("9944");
     let url = format!("{}:{}", node_ip, node_port);
     println!("Interacting with node on {}", url);

--- a/examples/example_generic_event_callback.rs
+++ b/examples/example_generic_event_callback.rs
@@ -56,7 +56,7 @@ pub fn get_node_url_from_cli() -> String {
     let yml = load_yaml!("cli.yml");
     let matches = App::from_yaml(yml).get_matches();
 
-    let node_ip = matches.value_of("node-server").unwrap_or("ws://127.0.0.1");
+    let node_ip = matches.value_of("node-server").unwrap_or("ws://localhost");
     let node_port = matches.value_of("node-port").unwrap_or("9944");
     let url = format!("{}:{}", node_ip, node_port);
     println!("Interacting with node on {}", url);


### PR DESCRIPTION
Use `parity/substrate:latest` to run a node for the examples. Remove the build step where we build our own node template.

Closes #204