### PR TITLE
Remove unnecessary calls to to_string() to improve performance.

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -41,9 +41,7 @@ impl FromHexString for Vec<u8> {
     fn from_hex(hex: String) -> Result<Self, hex::FromHexError> {
         let hexstr = hex
             .trim_matches('\"')
-            .to_string()
-            .trim_start_matches("0x")
-            .to_string();
+            .trim_start_matches("0x");
 
         hex::decode(&hexstr)
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -39,9 +39,7 @@ pub trait FromHexString {
 
 impl FromHexString for Vec<u8> {
     fn from_hex(hex: String) -> Result<Self, hex::FromHexError> {
-        let hexstr = hex
-            .trim_matches('\"')
-            .trim_start_matches("0x");
+        let hexstr = hex.trim_matches('\"').trim_start_matches("0x");
 
         hex::decode(&hexstr)
     }


### PR DESCRIPTION
The function showed up on some of my benchmarks therefore it is at least somewhat relevant to performance.
We could also change the API to use &str but that would be a breaking API change