### PR TITLE
Metadata sgx compatible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,7 +29,7 @@ version = "0.1.0"
 dependencies = [
  "ac-primitives",
  "derive_more",
- "frame-metadata",
+ "frame-metadata 15.0.0 (git+https://github.com/integritee-network/frame-metadata)",
  "frame-support",
  "frame-system",
  "hex",
@@ -767,12 +767,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "frame-metadata"
+version = "15.0.0"
+source = "git+https://github.com/integritee-network/frame-metadata#3b43da9821238681f9431276d55b92a079142083"
+dependencies = [
+ "cfg-if 1.0.0",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+]
+
+[[package]]
 name = "frame-support"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=master#174735ea1bb5fc4513519c45181d8df63d86f613"
 dependencies = [
  "bitflags",
- "frame-metadata",
+ "frame-metadata 15.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "frame-support-procedural",
  "impl-trait-for-tuples",
  "log",
@@ -3195,7 +3206,7 @@ dependencies = [
  "ac-primitives",
  "clap",
  "env_logger",
- "frame-metadata",
+ "frame-metadata 15.0.0 (git+https://github.com/integritee-network/frame-metadata)",
  "frame-support",
  "frame-system",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ sp-runtime-interface = { version = "6.0.0", default-features = false, git = "htt
 
 # local deps
 ac-compose-macros = { path = "compose-macros", default-features = false }
-ac-node-api = { path = "node-api", optional = true }
+ac-node-api = { path = "node-api", default-features = false }
 ac-primitives = { path = "primitives", default-features = false }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,9 @@ members = [
 [dependencies]
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 log = { version = "0.4.14", optional = true }
-metadata = { version = "15.0.0", default-features = false, package = "frame-metadata", features = ["v14"] }
+#TODO get from parity when our changes are accepted
+metadata = { version = "15.0.0", default-features = false, git = "https://github.com/integritee-network/frame-metadata", package = "frame-metadata", features = ["v14", "full_derive"] }
+#metadata = { version = "15.0.0", default-features = false, package = "frame-metadata", features = ["v14"] }
 primitive-types = { version = "0.11.1", optional = true, features = ["codec"] }
 serde = { version = "1.0.136", optional = true, features = ["derive"] }
 serde_json = { version = "1.0.79", optional = true }
@@ -82,7 +84,7 @@ std = [
 	"transaction-payment/std",
 	# local deps
 	"ac-compose-macros/std",
-	"ac-node-api",
+	"ac-node-api/std",
 	"ac-primitives/std",
 ]
 ws-client = ["ws"]

--- a/node-api/Cargo.toml
+++ b/node-api/Cargo.toml
@@ -8,11 +8,13 @@ edition = "2021"
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", features = ['derive'], default-features = false }
 derive_more = { version = "0.99.17" }
-frame-metadata = { version = "15.0.0", features = ["v14"], default-features = false }
+#TODO get from parity when our changes are accepted
+frame-metadata = { version = "15.0.0", default-features = false, git = "https://github.com/integritee-network/frame-metadata", features = ["v14", "full_derive"] }
+#frame-metadata = { version = "15.0.0", features = ["v14"], default-features = false }
 hex = { version = "0.4.3", default-features = false }
 log = { version = "0.4.14", default-features = false }
 scale-info = { version = "2.0.1", features = ["derive", "decode"] , default-features = false }
-serde = { version = "1.0.136", features = ["derive"], default-features = false }
+serde = { version = "1.0.136", features = ["alloc", "derive"], default-features = false }
 serde_json = { version = "1.0.79", default-features = false, features = ["alloc"] }
 
 # local deps

--- a/node-api/Cargo.toml
+++ b/node-api/Cargo.toml
@@ -14,7 +14,7 @@ frame-metadata = { version = "15.0.0", default-features = false, git = "https://
 hex = { version = "0.4.3", default-features = false }
 log = { version = "0.4.14", default-features = false }
 scale-info = { version = "2.0.1", features = ["derive", "decode"] , default-features = false }
-serde = { version = "1.0.136", features = ["alloc", "derive"], default-features = false }
+serde = { version = "1.0.136", features = ["derive"], default-features = false }
 serde_json = { version = "1.0.79", default-features = false, features = ["alloc"] }
 
 # local deps

--- a/node-api/src/events.rs
+++ b/node-api/src/events.rs
@@ -55,8 +55,7 @@ pub struct RawEvent {
 ///
 /// In subxt, this was generic over a `Config` type, but it's sole usage was to derive the
 /// hash type. We omitted this here and use the `ac_primitives::Hash` instead.
-#[derive(Clone)]
-#[cfg_attr(feature = "std", derive(Debug))]
+#[derive(Clone, Debug)]
 pub struct EventsDecoder {
     metadata: Metadata,
     marker: PhantomData<()>,

--- a/node-api/src/lib.rs
+++ b/node-api/src/lib.rs
@@ -22,6 +22,11 @@ use alloc::{borrow::ToOwned, vec::Vec};
 
 use codec::{Decode, Encode};
 
+pub use error::*;
+pub use events::*;
+pub use metadata::*;
+pub use storage::*;
+
 pub mod error;
 pub mod events;
 pub mod metadata;

--- a/node-api/src/metadata.rs
+++ b/node-api/src/metadata.rs
@@ -71,8 +71,7 @@ pub enum MetadataError {
 }
 
 /// Runtime metadata.
-#[derive(Clone)]
-#[cfg_attr(feature = "std", derive(Debug))]
+#[derive(Clone, Debug, Encode, Decode)]
 pub struct Metadata {
     pub metadata: RuntimeMetadataLastVersion,
     pub pallets: BTreeMap<String, PalletMetadata>,
@@ -154,8 +153,7 @@ impl Metadata {
     }
 }
 
-#[derive(Clone)]
-#[cfg_attr(feature = "std", derive(Debug))]
+#[derive(Clone, Debug, Encode, Decode)]
 pub struct PalletMetadata {
     pub index: u8,
     pub name: String,

--- a/node-api/src/storage.rs
+++ b/node-api/src/storage.rs
@@ -39,8 +39,7 @@ impl StorageValue {
     }
 }
 
-#[derive(Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "std", derive(Debug))]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct StorageMap<K> {
     _marker: PhantomData<K>,
     module_prefix: Vec<u8>,
@@ -57,8 +56,7 @@ impl<K: Encode> StorageMap<K> {
     }
 }
 
-#[derive(Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "std", derive(Debug))]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct StorageDoubleMap<K, Q> {
     _marker: PhantomData<K>,
     _marker2: PhantomData<Q>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,8 @@ pub use crate::std::*;
 
 pub use ac_primitives::*;
 
+pub use ac_node_api::*;
+
 #[cfg(feature = "std")]
 pub use ac_compose_macros::compose_extrinsic;
 

--- a/src/std/error.rs
+++ b/src/std/error.rs
@@ -1,5 +1,5 @@
 use crate::std::rpc::XtStatus;
-pub use ac_node_api::metadata::{InvalidMetadataError, MetadataError};
+use ac_node_api::metadata::{InvalidMetadataError, MetadataError};
 
 pub type ApiResult<T> = Result<T, Error>;
 

--- a/src/std/mod.rs
+++ b/src/std/mod.rs
@@ -1,7 +1,7 @@
-pub use crate::error::{ApiResult, Error as ApiClientError};
+pub use crate::std::error::{ApiResult, Error as ApiClientError};
 pub use crate::std::rpc::XtStatus;
 pub use crate::utils::FromHexString;
-pub use ac_node_api::metadata::{InvalidMetadataError, Metadata, MetadataError};
+use ac_node_api::metadata::{Metadata, MetadataError};
 use ac_primitives::{AccountData, AccountInfo, Balance, ExtrinsicParams};
 pub use metadata::RuntimeMetadataPrefixed;
 pub use serde_json::Value;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -18,7 +18,7 @@
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 #[cfg(not(feature = "std"))]
-use alloc::{string::String, string::ToString, vec::Vec};
+use alloc::{string::String, vec::Vec};
 
 use hex::FromHexError;
 use sp_core::storage::StorageKey;


### PR DESCRIPTION
- required for  https://github.com/integritee-network/worker/issues/113
- metadata can be coded and decoded. Use of integritee frame-metadata fork  : https://github.com/integritee-network/frame-metadata

