### PR TITLE
Set license explicitly to Apache-2.0 and set SCS as author

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "substrate-api-client"
 version = "0.6.0"
 authors = ["Supercomputing Systems AG <info@scs.ch>"]
+license = "Apache-2.0"
 edition = "2021"
 
 [workspace]

--- a/client-keystore/Cargo.toml
+++ b/client-keystore/Cargo.toml
@@ -2,6 +2,7 @@
 name = "substrate-client-keystore"
 version = "0.6.0"
 authors = ["Supercomputing Systems AG <info@scs.ch>"]
+license = "Apache-2.0"
 edition = "2021"
 
 [dependencies]

--- a/compose-macros/Cargo.toml
+++ b/compose-macros/Cargo.toml
@@ -1,6 +1,8 @@
 [package]
 name = "ac-compose-macros"
 version = "0.1.0"
+authors = ["Supercomputing Systems AG <info@scs.ch>"]
+license = "Apache-2.0"
 edition = "2021"
 
 [dependencies]

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -1,6 +1,8 @@
 [package]
 name = "ac-primitives"
 version = "0.1.0"
+authors = ["Supercomputing Systems AG <info@scs.ch>"]
+license = "Apache-2.0"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Set the license in all `Cargo.toml` files except for `node-api` (see #274 ). This will improve the license check in our other repos downstream (worker, ...)