### PR TITLE
GHA: update `rust-cache` to v2, as v1 contains deprecated commands (`save-state` and `set-output`)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       - name: init-rust-target
         run: rustup show
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.check }}
 
@@ -87,7 +87,7 @@ jobs:
           repository: paritytech/substrate
           path: substrate
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
         with:
           working-directory: substrate
 
@@ -129,7 +129,7 @@ jobs:
       - name: init-rust-target
         run: rustup show
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.example }}
 


### PR DESCRIPTION
>Starting today runner version 2.298.2 will begin to warn you if you use the save-state or set-output commands via stdout. We are monitoring telemetry for the usage of these commands and plan to fully disable them on 31st May 2023. Starting 1st June 2023 workflows using save-state or set-output commands via stdout will fail with an error.
---


See https://github.com/Swatinem/rust-cache/issues/80 and https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/