### PR TITLE
update to polkadot version v0.9.30

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,6 +127,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "array-bytes"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a913633b0c922e6b745072795f50d90ebea78ba31a57e2ac8c2fc7b50950949"
+
+[[package]]
 name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -859,7 +865,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -882,7 +888,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -893,7 +899,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -909,7 +915,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -948,7 +954,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "bitflags",
  "frame-metadata 15.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -980,7 +986,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -994,7 +1000,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -1006,7 +1012,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1016,7 +1022,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "frame-support",
  "log",
@@ -1034,7 +1040,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -1049,7 +1055,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -1058,7 +1064,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -1493,7 +1499,7 @@ dependencies = [
 [[package]]
 name = "kitchensink-runtime"
 version = "3.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -1524,6 +1530,7 @@ dependencies = [
  "pallet-election-provider-multi-phase",
  "pallet-election-provider-support-benchmarking",
  "pallet-elections-phragmen",
+ "pallet-fast-unstake",
  "pallet-gilt",
  "pallet-grandpa",
  "pallet-identity",
@@ -1851,7 +1858,7 @@ dependencies = [
 [[package]]
 name = "node-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "frame-system",
  "parity-scale-codec",
@@ -2008,7 +2015,7 @@ dependencies = [
 [[package]]
 name = "pallet-alliance"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2027,7 +2034,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-tx-payment"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2044,7 +2051,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2058,7 +2065,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2074,7 +2081,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2089,7 +2096,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2113,7 +2120,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -2133,7 +2140,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2148,7 +2155,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2166,7 +2173,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2185,7 +2192,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2202,7 +2209,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "bitflags",
  "frame-benchmarking",
@@ -2229,7 +2236,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-primitives"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "bitflags",
  "parity-scale-codec",
@@ -2244,7 +2251,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2254,7 +2261,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "pallet-contracts-primitives",
  "parity-scale-codec",
@@ -2267,7 +2274,7 @@ dependencies = [
 [[package]]
 name = "pallet-conviction-voting"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -2284,7 +2291,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2300,7 +2307,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -2324,7 +2331,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -2337,7 +2344,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "5.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2353,9 +2360,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-fast-unstake"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+dependencies = [
+ "frame-benchmarking",
+ "frame-election-provider-support",
+ "frame-support",
+ "frame-system",
+ "log",
+ "pallet-balances",
+ "pallet-staking",
+ "pallet-timestamp",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-io",
+ "sp-runtime",
+ "sp-staking",
+ "sp-std",
+]
+
+[[package]]
 name = "pallet-gilt"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2370,7 +2398,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2393,7 +2421,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -2409,7 +2437,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2429,7 +2457,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2446,7 +2474,7 @@ dependencies = [
 [[package]]
 name = "pallet-lottery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2460,7 +2488,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2477,7 +2505,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "ckb-merkle-mountain-range",
  "frame-benchmarking",
@@ -2495,7 +2523,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2510,7 +2538,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2527,7 +2555,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -2547,7 +2575,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
 version = "1.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -2557,7 +2585,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2574,7 +2602,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -2597,7 +2625,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2613,7 +2641,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2628,7 +2656,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2642,7 +2670,7 @@ dependencies = [
 [[package]]
 name = "pallet-ranked-collective"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2660,7 +2688,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2675,7 +2703,7 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2692,7 +2720,7 @@ dependencies = [
 [[package]]
 name = "pallet-remark"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2709,7 +2737,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2725,7 +2753,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2746,7 +2774,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2762,7 +2790,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2776,7 +2804,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -2798,7 +2826,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2809,7 +2837,7 @@ dependencies = [
 [[package]]
 name = "pallet-state-trie-migration"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2826,7 +2854,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2840,7 +2868,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2858,7 +2886,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2877,7 +2905,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2893,7 +2921,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -2904,7 +2932,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-storage"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2924,7 +2952,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2941,7 +2969,7 @@ dependencies = [
 [[package]]
 name = "pallet-uniques"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2956,7 +2984,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2972,7 +3000,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2987,7 +3015,7 @@ dependencies = [
 [[package]]
 name = "pallet-whitelist"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3444,10 +3472,10 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
+ "array-bytes",
  "async-trait",
- "hex",
  "parking_lot",
  "serde_json",
  "sp-application-crypto",
@@ -3723,7 +3751,7 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 [[package]]
 name = "sp-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "hash-db",
  "log",
@@ -3741,7 +3769,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "blake2",
  "proc-macro-crate",
@@ -3753,7 +3781,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -3766,7 +3794,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -3781,7 +3809,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -3794,7 +3822,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -3806,7 +3834,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -3818,7 +3846,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "async-trait",
  "futures",
@@ -3837,7 +3865,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "async-trait",
  "merlin",
@@ -3860,7 +3888,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -3874,7 +3902,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -3887,8 +3915,9 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
+ "array-bytes",
  "base58",
  "bitflags",
  "blake2",
@@ -3898,7 +3927,6 @@ dependencies = [
  "futures",
  "hash-db",
  "hash256-std-hasher",
- "hex",
  "impl-serde",
  "lazy_static",
  "libsecp256k1",
@@ -3933,7 +3961,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "blake2",
  "byteorder",
@@ -3947,7 +3975,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3958,7 +3986,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3968,7 +3996,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.12.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -3979,7 +4007,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -3997,7 +4025,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -4011,7 +4039,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "bytes 1.2.1",
  "futures",
@@ -4037,7 +4065,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -4048,7 +4076,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.12.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "async-trait",
  "futures",
@@ -4065,7 +4093,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "4.1.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "thiserror",
  "zstd",
@@ -4074,7 +4102,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -4089,7 +4117,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -4103,7 +4131,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -4113,7 +4141,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -4123,7 +4151,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -4133,7 +4161,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -4156,7 +4184,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "bytes 1.2.1",
  "impl-trait-for-tuples",
@@ -4174,7 +4202,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -4186,7 +4214,7 @@ dependencies = [
 [[package]]
 name = "sp-sandbox"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -4200,7 +4228,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -4214,7 +4242,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -4225,7 +4253,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.12.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "hash-db",
  "log",
@@ -4247,12 +4275,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 
 [[package]]
 name = "sp-storage"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -4265,7 +4293,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "async-trait",
  "futures-timer",
@@ -4281,7 +4309,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "parity-scale-codec",
  "sp-std",
@@ -4293,7 +4321,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -4302,7 +4330,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "async-trait",
  "log",
@@ -4318,7 +4346,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "ahash",
  "hash-db",
@@ -4341,7 +4369,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -4358,7 +4386,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -4369,7 +4397,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "impl-trait-for-tuples",
  "log",
@@ -4381,7 +4409,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -4532,7 +4560,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "5.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#c24431eb6a95197550b30715a4c124be1aea79de"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
 dependencies = [
  "ansi_term",
  "build-helper",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -839,6 +839,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fixed-hash"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
+dependencies = [
+ "byteorder",
+ "rand 0.8.5",
+ "rustc-hex",
+ "static_assertions",
+]
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3065,7 +3077,7 @@ dependencies = [
  "impl-trait-for-tuples",
  "parity-util-mem-derive",
  "parking_lot",
- "primitive-types",
+ "primitive-types 0.11.1",
  "winapi 0.3.9",
 ]
 
@@ -3189,10 +3201,21 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e28720988bff275df1f51b171e1b2a18c30d194c4d2b61defdacecd625a5d94a"
 dependencies = [
- "fixed-hash",
+ "fixed-hash 0.7.0",
  "impl-codec",
  "impl-serde",
  "scale-info",
+ "uint",
+]
+
+[[package]]
+name = "primitive-types"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f3486ccba82358b11a77516035647c34ba167dfa53312630de83b12bd4f3d66"
+dependencies = [
+ "fixed-hash 0.8.0",
+ "impl-codec",
  "uint",
 ]
 
@@ -3936,7 +3959,7 @@ dependencies = [
  "parity-scale-codec",
  "parity-util-mem",
  "parking_lot",
- "primitive-types",
+ "primitive-types 0.11.1",
  "rand 0.7.3",
  "regex",
  "scale-info",
@@ -4189,7 +4212,7 @@ dependencies = [
  "bytes 1.2.1",
  "impl-trait-for-tuples",
  "parity-scale-codec",
- "primitive-types",
+ "primitive-types 0.11.1",
  "sp-externalities",
  "sp-runtime-interface-proc-macro",
  "sp-std",
@@ -4513,7 +4536,7 @@ dependencies = [
  "pallet-staking",
  "pallet-transaction-payment",
  "parity-scale-codec",
- "primitive-types",
+ "primitive-types 0.12.1",
  "serde",
  "serde_json",
  "sp-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ log = { version = "0.4.14", optional = true }
 metadata = { version = "15.0.0", default-features = false, git = "https://github.com/integritee-network/frame-metadata", package = "frame-metadata", features = ["v14", "full_derive"] }
 #metadata = { version = "15.0.0", default-features = false, package = "frame-metadata", features = ["v14"] }
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ['derive'] }
-primitive-types = { version = "0.11.1", optional = true, features = ["codec"] }
+primitive-types = { version = "0.12.1", optional = true, features = ["codec"] }
 serde = { version = "1.0.136", optional = true, features = ["derive"] }
 serde_json = { version = "1.0.79", optional = true }
 thiserror = { version = "1.0.30", optional = true }

--- a/client-keystore/src/lib.rs
+++ b/client-keystore/src/lib.rs
@@ -551,7 +551,7 @@ impl KeystoreInner {
 			.collect();
 
 		if let Some(path) = &self.path {
-			for entry in fs::read_dir(&path)? {
+			for entry in fs::read_dir(path)? {
 				let entry = entry?;
 				let path = entry.path();
 

--- a/node-api/Cargo.toml
+++ b/node-api/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", features = ['derive'], default-features = false }
 derive_more = { version = "0.99.17" }
-#TODO get from parity when our changes are accepted
+#TODO get from parity when our changes are accepted https://github.com/scs/substrate-api-client/issues/304
 frame-metadata = { version = "15.0.0", default-features = false, git = "https://github.com/integritee-network/frame-metadata", features = ["v14", "full_derive"] }
 #frame-metadata = { version = "15.0.0", features = ["v14"], default-features = false }
 hex = { version = "0.4.3", default-features = false }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2022-08-18"
+channel = "nightly-2022-11-05"
 targets = ["wasm32-unknown-unknown"]
 profile = "default" # include rustfmt, clippy

--- a/src/std/rpc/ws_client/client.rs
+++ b/src/std/rpc/ws_client/client.rs
@@ -92,6 +92,7 @@ impl Subscriber for WsRpcClient {
 	}
 }
 
+#[allow(clippy::result_large_err)]
 impl WsRpcClient {
 	pub fn get(&self, json_req: String, result_in: ThreadOut<String>) -> WsResult<()> {
 		self.start_rpc_client_thread(json_req, result_in, on_get_request_msg)

--- a/src/std/rpc/ws_client/mod.rs
+++ b/src/std/rpc/ws_client/mod.rs
@@ -60,6 +60,7 @@ impl Handler for RpcClient {
 	}
 }
 
+#[allow(clippy::result_large_err)]
 pub trait Subscriber {
 	fn start_subscriber(&self, json_req: String, result_in: ThreadOut<String>)
 		-> Result<(), Error>;
@@ -141,6 +142,7 @@ where
 	}
 }
 
+#[allow(clippy::result_large_err)]
 pub fn on_get_request_msg(msg: Message, out: Sender, result: ThreadOut<String>) -> WsResult<()> {
 	out.close(CloseCode::Normal)
 		.unwrap_or_else(|_| warn!("Could not close Websocket normally"));
@@ -153,6 +155,7 @@ pub fn on_get_request_msg(msg: Message, out: Sender, result: ThreadOut<String>) 
 	result.send(result_str).map_err(|e| Box::new(RpcClientError::Send(e)).into())
 }
 
+#[allow(clippy::result_large_err)]
 pub fn on_subscription_msg(msg: Message, out: Sender, result: ThreadOut<String>) -> WsResult<()> {
 	info!("got on_subscription_msg {}", msg);
 	let value: serde_json::Value =
@@ -193,6 +196,7 @@ pub fn on_subscription_msg(msg: Message, out: Sender, result: ThreadOut<String>)
 	Ok(())
 }
 
+#[allow(clippy::result_large_err)]
 pub fn on_extrinsic_msg_until_finalized(
 	msg: Message,
 	out: Sender,
@@ -214,6 +218,7 @@ pub fn on_extrinsic_msg_until_finalized(
 	}
 }
 
+#[allow(clippy::result_large_err)]
 pub fn on_extrinsic_msg_until_in_block(
 	msg: Message,
 	out: Sender,
@@ -233,6 +238,7 @@ pub fn on_extrinsic_msg_until_in_block(
 	}
 }
 
+#[allow(clippy::result_large_err)]
 pub fn on_extrinsic_msg_until_broadcast(
 	msg: Message,
 	out: Sender,
@@ -252,6 +258,7 @@ pub fn on_extrinsic_msg_until_broadcast(
 	}
 }
 
+#[allow(clippy::result_large_err)]
 pub fn on_extrinsic_msg_until_ready(
 	msg: Message,
 	out: Sender,
@@ -271,6 +278,7 @@ pub fn on_extrinsic_msg_until_ready(
 	}
 }
 
+#[allow(clippy::result_large_err)]
 pub fn on_extrinsic_msg_submit_only(
 	msg: Message,
 	out: Sender,
@@ -287,10 +295,11 @@ pub fn on_extrinsic_msg_submit_only(
 	}
 }
 
+#[allow(clippy::result_large_err)]
 fn end_process(out: Sender, result: ThreadOut<String>, value: Option<String>) -> WsResult<()> {
 	// return result to calling thread
 	debug!("Thread end result :{:?} value:{:?}", result, value);
-	let val = value.unwrap_or_else(|| "".to_string());
+	let val = value.unwrap_or_default();
 
 	out.close(CloseCode::Normal)
 		.unwrap_or_else(|_| warn!("Could not close WebSocket normally"));

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -25,7 +25,7 @@ use sp_core::{storage::StorageKey, twox_128, H256 as Hash};
 
 pub fn storage_key(module: &str, storage_key_name: &str) -> StorageKey {
 	let mut key = twox_128(module.as_bytes()).to_vec();
-	key.extend(&twox_128(storage_key_name.as_bytes()));
+	key.extend(twox_128(storage_key_name.as_bytes()));
 	StorageKey(key)
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -39,7 +39,7 @@ impl FromHexString for Vec<u8> {
 	fn from_hex(hex: String) -> Result<Self, hex::FromHexError> {
 		let hexstr = hex.trim_matches('\"').trim_start_matches("0x");
 
-		hex::decode(&hexstr)
+		hex::decode(hexstr)
 	}
 }
 


### PR DESCRIPTION
- update polkadot version to master of v0.9.30
- update rust toolchain to 2022-11-05
- fix clippy lints

closes #300 

Follow up issue due to the clippy warnings: https://github.com/scs/substrate-api-client/issues/303 or https://github.com/scs/substrate-api-client/issues/267.

Didn't want to introduce any breaking interface changes in this PR.