### PR TITLE
Future status returns Future error instead of HexError

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,7 @@ jobs:
         example: [
           example_benchmark_bulk_xt,
           example_compose_extrinsic_offline,
+          example_custom_nonce,
           example_event_callback,
           example_event_error_details,
           example_generic_event_callback,

--- a/examples/example_event_callback.rs
+++ b/examples/example_event_callback.rs
@@ -40,7 +40,7 @@ fn main() {
 	api.subscribe_events(events_in).unwrap();
 
 	for _ in 0..5 {
-		let event_str = events_out.recv().unwrap().unwrap().unwrap();
+		let event_str = events_out.recv().unwrap();
 
 		let _unhex = Vec::from_hex(event_str).unwrap();
 		let mut _er_enc = _unhex.as_slice();

--- a/examples/example_event_callback.rs
+++ b/examples/example_event_callback.rs
@@ -40,7 +40,7 @@ fn main() {
 	api.subscribe_events(events_in).unwrap();
 
 	for _ in 0..5 {
-		let event_str = events_out.recv().unwrap();
+		let event_str = events_out.recv().unwrap().unwrap().unwrap();
 
 		let _unhex = Vec::from_hex(event_str).unwrap();
 		let mut _er_enc = _unhex.as_slice();

--- a/examples/example_get_blocks.rs
+++ b/examples/example_get_blocks.rs
@@ -57,8 +57,12 @@ fn main() {
 	api.subscribe_finalized_heads(sender).unwrap();
 
 	for _ in 0..5 {
-		let head: Header =
-			receiver.recv().map(|header| serde_json::from_str(&header).unwrap()).unwrap();
+		let head: Header = receiver
+			.recv()
+			.unwrap()
+			.unwrap()
+			.map(|header| serde_json::from_str(&header).unwrap())
+			.unwrap();
 		println!("Got new Block {:?}", head);
 	}
 }

--- a/examples/example_get_blocks.rs
+++ b/examples/example_get_blocks.rs
@@ -57,12 +57,8 @@ fn main() {
 	api.subscribe_finalized_heads(sender).unwrap();
 
 	for _ in 0..5 {
-		let head: Header = receiver
-			.recv()
-			.unwrap()
-			.unwrap()
-			.map(|header| serde_json::from_str(&header).unwrap())
-			.unwrap();
+		let head: Header =
+			receiver.recv().map(|header| serde_json::from_str(&header).unwrap()).unwrap();
 		println!("Got new Block {:?}", head);
 	}
 }

--- a/src/std/error.rs
+++ b/src/std/error.rs
@@ -1,4 +1,4 @@
-use crate::std::rpc::XtStatus;
+use crate::{rpc::RpcClientError, std::rpc::XtStatus};
 use ac_node_api::{
 	metadata::{InvalidMetadataError, MetadataError},
 	DispatchError,
@@ -19,8 +19,8 @@ pub enum Error {
 	#[cfg(feature = "ws-client")]
 	#[error("WebSocket Error: {0}")]
 	WebSocket(#[from] ws::Error),
-	#[error("RpcClient error: {0}")]
-	RpcClient(String),
+	#[error("RpcClient error: {0:?}")]
+	RpcClient(#[from] RpcClientError),
 	#[error("ChannelReceiveError, sender is disconnected: {0}")]
 	Disconnected(#[from] sp_std::sync::mpsc::RecvError),
 	#[error("Metadata Error: {0:?}")]

--- a/src/std/mod.rs
+++ b/src/std/mod.rs
@@ -50,7 +50,7 @@ pub trait RpcClient {
 /// ```no_run
 /// use substrate_api_client::rpc::json_req::author_submit_extrinsic;
 /// use substrate_api_client::{
-///     Api, ApiClientError, ApiResult, FromHexString, Hash, RpcClient, XtStatus, PlainTipExtrinsicParams
+///     Api, ApiClientError, ApiResult, FromHexString, Hash, RpcClient, rpc::RpcClientError, Value, XtStatus, PlainTipExtrinsicParams
 /// };
 /// use serde_json::Value;
 /// struct MyClient {
@@ -70,7 +70,7 @@ pub trait RpcClient {
 ///         &self,
 ///         _path: String,
 ///         _json: Value,
-///     ) -> Result<R, Box<dyn std::error::Error>> {
+///     ) -> Result<R, RpcClientError> {
 ///         // you can figure this out...self.inner...send_json...
 ///         todo!()
 ///     }
@@ -80,7 +80,7 @@ pub trait RpcClient {
 ///     fn get_request(&self, jsonreq: Value) -> ApiResult<String> {
 ///         self.send_json::<Value>("".into(), jsonreq)
 ///             .map(|v| v.to_string())
-///             .map_err(|err| ApiClientError::RpcClient(err.to_string()))
+///             .map_err(|err| ApiClientError::RpcClient(err))
 ///     }
 ///
 ///     fn send_extrinsic(
@@ -91,7 +91,7 @@ pub trait RpcClient {
 ///         let jsonreq = author_submit_extrinsic(&xthex_prefixed);
 ///         let res: String = self
 ///             .send_json("".into(), jsonreq)
-///             .map_err(|err| ApiClientError::RpcClient(err.to_string()))?;
+///             .map_err(|err| ApiClientError::RpcClient(err))?;
 ///         Ok(Some(Hash::from_hex(res)?))
 ///     }
 /// }

--- a/src/std/mod.rs
+++ b/src/std/mod.rs
@@ -50,7 +50,7 @@ pub trait RpcClient {
 /// ```no_run
 /// use substrate_api_client::rpc::json_req::author_submit_extrinsic;
 /// use substrate_api_client::{
-///     Api, ApiClientError, ApiResult, FromHexString, Hash, RpcClient, rpc::RpcClientError, Value, XtStatus, PlainTipExtrinsicParams
+///     Api, ApiClientError, ApiResult, FromHexString, Hash, RpcClient, rpc::RpcClientError,  XtStatus, PlainTipExtrinsicParams
 /// };
 /// use serde_json::Value;
 /// struct MyClient {

--- a/src/std/rpc/mod.rs
+++ b/src/std/rpc/mod.rs
@@ -31,9 +31,11 @@ pub enum RpcClientError {
 	#[error("Extrinsic Error: {0}")]
 	Extrinsic(String),
 	#[error("mpsc send Error: {0}")]
-	Send(#[from] std::sync::mpsc::SendError<String>),
+	Send(String),
 	#[error("Expected some error information, but nothing was found: {0}")]
 	NoErrorInformationFound(String),
+	#[error(transparent)]
+	Other(#[from] Box<dyn std::error::Error + Send + Sync + 'static>),
 }
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]

--- a/src/std/rpc/ws_client/mod.rs
+++ b/src/std/rpc/ws_client/mod.rs
@@ -124,7 +124,7 @@ where
 		receiver: &Receiver<ThreadMessage>,
 	) -> ApiResult<EventDetails> {
 		loop {
-			let events_str = receiver.recv().unwrap().unwrap()?;
+			let events_str = receiver.recv()?.unwrap_or_default().unwrap_or_default();
 			let event_bytes = Vec::from_hex(events_str)?;
 			let events = Events::new(self.metadata.clone(), Default::default(), event_bytes);
 


### PR DESCRIPTION
- Adds a custom nonce example which additionally checks the future return error
- The `ThreadOut Message` is now more generic and is defined by the struct implementing the `HandleMessage` struct.
- ⚡ `GetRequestHandler`, `SubmitOnlyHandler` and `SubmitAndWatchHandler`, e.g. all `WsRpcClient` functions except for the `start_subscriber` are now returning an `Result<Option<String>>` instead of just a `String`. This way, a RpcClientError can be forwarded to the receiving thread. Additionally, a `None` is now allowed, which is quite commonly used in substrate. Most notable result: `send_extrinsic` can now forward the received result and does not depend on the "expected" xt_status any more (making it effectively unable to handle unexpected results, such as Future status).
- `Error::RpcClient()` now expects an `RpcClientError`, not a `String` any more. To not lose any flexibility regarding user-implementation, `RpcClientError` now implements an `Other(#[from] Box<dyn std::error::Error + Send + Sync + 'static>)`.

example_custom_nonce now prints the following error:

```Retrieved error RpcClient(Extrinsic("Unexpected extrinsic status: Future, stopped watch process prematurely."))```

closes #157
closes #202 (added a specific custom nonce example)