### PR TITLE
update to polkadot-v0.9.31

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -830,18 +830,6 @@ dependencies = [
 
 [[package]]
 name = "fixed-hash"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
-dependencies = [
- "byteorder",
- "rand 0.8.5",
- "rustc-hex",
- "static_assertions",
-]
-
-[[package]]
-name = "fixed-hash"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
@@ -879,7 +867,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -902,7 +890,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -913,7 +901,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -929,7 +917,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -968,7 +956,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "bitflags",
  "frame-metadata 15.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1000,7 +988,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -1014,7 +1002,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -1026,7 +1014,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1036,7 +1024,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "frame-support",
  "log",
@@ -1054,7 +1042,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -1069,7 +1057,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -1078,7 +1066,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -1404,9 +1392,9 @@ dependencies = [
 
 [[package]]
 name = "impl-serde"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4551f042f3438e64dbd6226b20527fc84a6e1fe65688b58746a2f53623f25f5c"
+checksum = "ebc88fc67028ae3db0c853baa36269d398d5f45b6982f95549ff5def78c935cd"
 dependencies = [
  "serde",
 ]
@@ -1513,7 +1501,7 @@ dependencies = [
 [[package]]
 name = "kitchensink-runtime"
 version = "3.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -1538,7 +1526,6 @@ dependencies = [
  "pallet-collective",
  "pallet-contracts",
  "pallet-contracts-primitives",
- "pallet-contracts-rpc-runtime-api",
  "pallet-conviction-voting",
  "pallet-democracy",
  "pallet-election-provider-multi-phase",
@@ -1750,9 +1737,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memory-db"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6566c70c1016f525ced45d7b7f97730a2bafb037c788211d0c186ef5b2189f0a"
+checksum = "34ac11bb793c28fa095b7554466f53b3a60a2cd002afdac01bcf135cbd73a269"
 dependencies = [
  "hash-db",
  "hashbrown",
@@ -1872,7 +1859,7 @@ dependencies = [
 [[package]]
 name = "node-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "frame-system",
  "parity-scale-codec",
@@ -2029,7 +2016,7 @@ dependencies = [
 [[package]]
 name = "pallet-alliance"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2048,7 +2035,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-tx-payment"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2065,7 +2052,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2079,7 +2066,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2095,7 +2082,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2110,7 +2097,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2134,7 +2121,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -2154,7 +2141,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2169,7 +2156,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2187,7 +2174,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2206,7 +2193,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2223,7 +2210,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "bitflags",
  "frame-benchmarking",
@@ -2238,6 +2225,7 @@ dependencies = [
  "scale-info",
  "serde",
  "smallvec",
+ "sp-api",
  "sp-core",
  "sp-io",
  "sp-runtime",
@@ -2250,22 +2238,19 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-primitives"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "bitflags",
  "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core",
- "sp-rpc",
  "sp-runtime",
  "sp-std",
+ "sp-weights",
 ]
 
 [[package]]
 name = "pallet-contracts-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2273,22 +2258,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "pallet-contracts-rpc-runtime-api"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
-dependencies = [
- "pallet-contracts-primitives",
- "parity-scale-codec",
- "scale-info",
- "sp-api",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
 name = "pallet-conviction-voting"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -2305,14 +2277,16 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
+ "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
+ "sp-core",
  "sp-io",
  "sp-runtime",
  "sp-std",
@@ -2321,7 +2295,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -2345,7 +2319,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -2358,7 +2332,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "5.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2376,7 +2350,7 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -2397,7 +2371,7 @@ dependencies = [
 [[package]]
 name = "pallet-gilt"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2412,7 +2386,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2435,7 +2409,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -2451,7 +2425,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2471,7 +2445,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2488,7 +2462,7 @@ dependencies = [
 [[package]]
 name = "pallet-lottery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2502,7 +2476,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2519,7 +2493,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "ckb-merkle-mountain-range",
  "frame-benchmarking",
@@ -2537,11 +2511,12 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
+ "log",
  "parity-scale-codec",
  "scale-info",
  "sp-io",
@@ -2552,7 +2527,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2569,7 +2544,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -2589,7 +2564,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
 version = "1.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -2599,7 +2574,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2616,7 +2591,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -2639,11 +2614,12 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
+ "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
@@ -2655,7 +2631,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2670,7 +2646,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2684,7 +2660,7 @@ dependencies = [
 [[package]]
 name = "pallet-ranked-collective"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2702,7 +2678,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2717,7 +2693,7 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2734,7 +2710,7 @@ dependencies = [
 [[package]]
 name = "pallet-remark"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2751,7 +2727,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2767,7 +2743,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2788,7 +2764,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2804,7 +2780,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2818,7 +2794,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -2840,7 +2816,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2851,7 +2827,7 @@ dependencies = [
 [[package]]
 name = "pallet-state-trie-migration"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2868,7 +2844,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2882,7 +2858,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2900,7 +2876,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2919,7 +2895,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2935,7 +2911,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -2946,7 +2922,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-storage"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2966,7 +2942,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2983,7 +2959,7 @@ dependencies = [
 [[package]]
 name = "pallet-uniques"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2998,7 +2974,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3014,7 +2990,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3029,7 +3005,7 @@ dependencies = [
 [[package]]
 name = "pallet-whitelist"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3070,16 +3046,16 @@ dependencies = [
 
 [[package]]
 name = "parity-util-mem"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c32561d248d352148124f036cac253a644685a21dc9fea383eb4907d7bd35a8f"
+checksum = "0d32c34f4f5ca7f9196001c0aba5a1f9a5a12382c8944b8b0f90233282d1e8f8"
 dependencies = [
  "cfg-if 1.0.0",
  "hashbrown",
  "impl-trait-for-tuples",
  "parity-util-mem-derive",
  "parking_lot",
- "primitive-types 0.11.1",
+ "primitive-types",
  "winapi 0.3.9",
 ]
 
@@ -3199,25 +3175,14 @@ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "primitive-types"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28720988bff275df1f51b171e1b2a18c30d194c4d2b61defdacecd625a5d94a"
-dependencies = [
- "fixed-hash 0.7.0",
- "impl-codec",
- "impl-serde",
- "scale-info",
- "uint",
-]
-
-[[package]]
-name = "primitive-types"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f3486ccba82358b11a77516035647c34ba167dfa53312630de83b12bd4f3d66"
 dependencies = [
- "fixed-hash 0.8.0",
+ "fixed-hash",
  "impl-codec",
+ "impl-serde",
+ "scale-info",
  "uint",
 ]
 
@@ -3497,7 +3462,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -3776,7 +3741,7 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 [[package]]
 name = "sp-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "hash-db",
  "log",
@@ -3794,7 +3759,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "blake2",
  "proc-macro-crate",
@@ -3806,7 +3771,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -3819,7 +3784,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -3834,7 +3799,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -3847,7 +3812,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -3859,7 +3824,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -3871,7 +3836,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "async-trait",
  "futures",
@@ -3890,7 +3855,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "async-trait",
  "merlin",
@@ -3913,7 +3878,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -3927,7 +3892,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -3940,7 +3905,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "array-bytes",
  "base58",
@@ -3961,7 +3926,7 @@ dependencies = [
  "parity-scale-codec",
  "parity-util-mem",
  "parking_lot",
- "primitive-types 0.11.1",
+ "primitive-types",
  "rand 0.7.3",
  "regex",
  "scale-info",
@@ -3986,7 +3951,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "blake2",
  "byteorder",
@@ -4000,7 +3965,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4011,7 +3976,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4021,7 +3986,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.12.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -4032,7 +3997,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -4050,7 +4015,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -4064,7 +4029,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "bytes 1.2.1",
  "futures",
@@ -4090,7 +4055,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -4101,7 +4066,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.12.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "async-trait",
  "futures",
@@ -4118,7 +4083,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "4.1.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "thiserror",
  "zstd",
@@ -4127,10 +4092,11 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "log",
  "parity-scale-codec",
+ "scale-info",
  "serde",
  "sp-api",
  "sp-core",
@@ -4142,7 +4108,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -4156,7 +4122,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -4166,7 +4132,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -4176,7 +4142,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -4186,7 +4152,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -4209,12 +4175,12 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "bytes 1.2.1",
  "impl-trait-for-tuples",
  "parity-scale-codec",
- "primitive-types 0.11.1",
+ "primitive-types",
  "sp-externalities",
  "sp-runtime-interface-proc-macro",
  "sp-std",
@@ -4227,7 +4193,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -4239,7 +4205,7 @@ dependencies = [
 [[package]]
 name = "sp-sandbox"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -4253,7 +4219,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -4267,7 +4233,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -4278,7 +4244,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.12.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "hash-db",
  "log",
@@ -4300,12 +4266,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 
 [[package]]
 name = "sp-storage"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -4318,7 +4284,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "async-trait",
  "futures-timer",
@@ -4334,7 +4300,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "parity-scale-codec",
  "sp-std",
@@ -4346,7 +4312,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -4355,7 +4321,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "async-trait",
  "log",
@@ -4371,7 +4337,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "ahash",
  "hash-db",
@@ -4394,7 +4360,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -4411,7 +4377,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -4422,7 +4388,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "impl-trait-for-tuples",
  "log",
@@ -4434,7 +4400,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -4539,7 +4505,7 @@ dependencies = [
  "pallet-staking",
  "pallet-transaction-payment",
  "parity-scale-codec",
- "primitive-types 0.12.1",
+ "primitive-types",
  "serde",
  "serde_json",
  "sp-core",
@@ -4586,7 +4552,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "5.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1b1a5e12c0e391c7ed4e3ffa332eb2fe928d257f"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#696bdc67af5fd83aca318263dbd405593b043ba3"
 dependencies = [
  "ansi_term",
  "build-helper",


### PR DESCRIPTION
update to substrate commit [696bdc67af5fd83aca318263dbd405593b043ba3](https://github.com/paritytech/substrate/commit/696bdc67af5fd83aca318263dbd405593b043ba3), which matches the polkadot-v0.9.31 branch

closes #301 
