### PR TITLE
Add timeout to rpc client and fn wait_for_event

### DIFF
--- a/examples/example_benchmark_bulk_xt.rs
+++ b/examples/example_benchmark_bulk_xt.rs
@@ -19,10 +19,8 @@
 // > substrate-test-node --dev --execution native --ws-port 9979 -ltxpool=debug
 
 use clap::{load_yaml, App};
-
 use kitchensink_runtime::{BalancesCall, RuntimeCall};
 use sp_keyring::AccountKeyring;
-
 use substrate_api_client::{
 	compose_extrinsic_offline, rpc::WsRpcClient, Api, AssetTipExtrinsicParams,
 	UncheckedExtrinsicV4, XtStatus,

--- a/examples/example_contract_instantiate_with_code.rs
+++ b/examples/example_contract_instantiate_with_code.rs
@@ -15,11 +15,10 @@
 
 //! This example is community maintained and not CI tested, therefore it may not work as is.
 
-use std::sync::mpsc::channel;
-
 use clap::{load_yaml, App};
 use codec::Decode;
 use sp_keyring::AccountKeyring;
+use std::{sync::mpsc::channel, time::Duration};
 use substrate_api_client::{
 	rpc::WsRpcClient, AccountId, Api, PlainTipExtrinsicParams, StaticEvent, XtStatus,
 };
@@ -74,7 +73,9 @@ fn main() {
 
 	println!("[+] Waiting for the contracts.Instantiated event");
 
-	let args: ContractInstantiatedEventArgs = api.wait_for_event(&events_out).unwrap();
+	let timeout = Duration::from_secs(60);
+	let args: ContractInstantiatedEventArgs =
+		api.wait_for_event(&events_out, Some(timeout)).unwrap();
 
 	println!("[+] Event was received. Contract deployed at: {:?}\n", args.contract);
 

--- a/examples/example_event_error_details.rs
+++ b/examples/example_event_error_details.rs
@@ -86,7 +86,7 @@ fn main() {
 	// Transfer should fail as Alice wants to transfer all her balance. She does not have enough money to pay the fees.
 	let (events_in, events_out) = channel();
 	api.subscribe_events(events_in).unwrap();
-	let args: ApiResult<TransferEventArgs> = api.wait_for_event(&events_out);
+	let args: ApiResult<TransferEventArgs> = api.wait_for_event(&events_out, None);
 	match args {
 		Ok(_transfer) => {
 			panic!("Exptected the call to fail.");

--- a/examples/example_generic_event_callback.rs
+++ b/examples/example_generic_event_callback.rs
@@ -51,7 +51,7 @@ fn main() {
 	let api2 = api.clone();
 	let thread_output = thread::spawn(move || {
 		let (events_in, events_out) = channel();
-		let timeout = Duration::from_secs(1);
+		let timeout = Duration::from_millis(1);
 		api2.subscribe_events(events_in).unwrap();
 		let args: TransferEventArgs =
 			api2.wait_for_event::<TransferEventArgs>(&events_out, Some(timeout)).unwrap();

--- a/examples/example_generic_event_callback.rs
+++ b/examples/example_generic_event_callback.rs
@@ -19,7 +19,7 @@ use clap::{load_yaml, App};
 use codec::Decode;
 use sp_keyring::AccountKeyring;
 use sp_runtime::{AccountId32 as AccountId, MultiAddress};
-use std::{sync::mpsc::channel, thread};
+use std::{sync::mpsc::channel, thread, time::Duration};
 use substrate_api_client::{rpc::WsRpcClient, Api, AssetTipExtrinsicParams, StaticEvent, XtStatus};
 
 // Look at the how the transfer event looks like in in the metadata
@@ -51,9 +51,10 @@ fn main() {
 	let api2 = api.clone();
 	let thread_output = thread::spawn(move || {
 		let (events_in, events_out) = channel();
+		let timeout = Duration::from_secs(1);
 		api2.subscribe_events(events_in).unwrap();
 		let args: TransferEventArgs =
-			api2.wait_for_event::<TransferEventArgs>(&events_out).unwrap();
+			api2.wait_for_event::<TransferEventArgs>(&events_out, Some(timeout)).unwrap();
 		args
 	});
 

--- a/examples/example_generic_extrinsic.rs
+++ b/examples/example_generic_extrinsic.rs
@@ -18,6 +18,7 @@
 
 use clap::{load_yaml, App};
 use sp_keyring::AccountKeyring;
+use std::time::Duration;
 use substrate_api_client::{
 	compose_extrinsic, rpc::WsRpcClient, Api, AssetTipExtrinsicParams, GenericAddress,
 	UncheckedExtrinsicV4, XtStatus,
@@ -29,7 +30,8 @@ fn main() {
 
 	// initialize api and set the signer (sender) that is used to sign the extrinsics
 	let from = AccountKeyring::Alice.pair();
-	let client = WsRpcClient::new(&url);
+	let timeout = Duration::from_secs(1);
+	let client = WsRpcClient::new(&url).set_timeout(timeout);
 	let api = Api::<_, _, AssetTipExtrinsicParams>::new(client)
 		.map(|api| api.set_signer(from))
 		.unwrap();

--- a/examples/example_generic_extrinsic.rs
+++ b/examples/example_generic_extrinsic.rs
@@ -30,7 +30,7 @@ fn main() {
 
 	// initialize api and set the signer (sender) that is used to sign the extrinsics
 	let from = AccountKeyring::Alice.pair();
-	let timeout = Duration::from_secs(1);
+	let timeout = Duration::from_millis(1);
 	let client = WsRpcClient::new(&url).set_timeout(timeout);
 	let api = Api::<_, _, AssetTipExtrinsicParams>::new(client)
 		.map(|api| api.set_signer(from))

--- a/primitives/src/extrinsics.rs
+++ b/primitives/src/extrinsics.rs
@@ -159,7 +159,7 @@ mod tests {
 	fn encode_decode_roundtrip_works() {
 		let msg = &b"test-message"[..];
 		let (pair, _) = sr25519::Pair::generate();
-		let signature = pair.sign(&msg);
+		let signature = pair.sign(msg);
 		let multi_sig = MultiSignature::from(signature);
 		let account: AccountId = pair.public().into();
 		let tx_params =

--- a/src/std/error.rs
+++ b/src/std/error.rs
@@ -23,6 +23,8 @@ pub enum Error {
 	RpcClient(#[from] RpcClientError),
 	#[error("ChannelReceiveError, sender is disconnected: {0}")]
 	Disconnected(#[from] sp_std::sync::mpsc::RecvError),
+	#[error("Timeout, the node did take too long to respond: {0}")]
+	Timeout(#[from] sp_std::sync::mpsc::RecvTimeoutError),
 	#[error("Metadata Error: {0:?}")]
 	Metadata(MetadataError),
 	#[error("InvalidMetadata: {0:?}")]

--- a/src/std/error.rs
+++ b/src/std/error.rs
@@ -1,3 +1,20 @@
+/*
+   Copyright 2019 Supercomputing Systems AG
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+	   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+*/
+
 use crate::{rpc::RpcClientError, std::rpc::XtStatus};
 use ac_node_api::{
 	metadata::{InvalidMetadataError, MetadataError},

--- a/src/std/mod.rs
+++ b/src/std/mod.rs
@@ -18,8 +18,8 @@ pub use sp_runtime::{
 };
 pub use sp_std::prelude::*;
 pub use sp_version::RuntimeVersion;
+use std::time::Duration;
 pub use transaction_payment::FeeDetails;
-
 pub mod error;
 pub mod rpc;
 
@@ -112,6 +112,7 @@ where
 	pub runtime_version: RuntimeVersion,
 	client: Client,
 	pub extrinsic_params_builder: Option<Params::OtherParams>,
+	timeout: Duration,
 }
 
 impl<P, Client, Params> Api<P, Client, Params>
@@ -160,6 +161,7 @@ where
 			runtime_version,
 			client,
 			extrinsic_params_builder: None,
+			timeout: Duration::from_secs(900),
 		})
 	}
 
@@ -171,6 +173,12 @@ where
 
 	pub fn set_extrinsic_params_builder(mut self, extrinsic_params: Params::OtherParams) -> Self {
 		self.extrinsic_params_builder = Some(extrinsic_params);
+		self
+	}
+
+	/// The the maximum amount of time the api client waits for a specific event from the node.
+	pub fn set_event_timeout(mut self, timeout: Duration) -> Self {
+		self.timeout = timeout;
 		self
 	}
 

--- a/src/std/mod.rs
+++ b/src/std/mod.rs
@@ -1,3 +1,31 @@
+/*
+   Copyright 2019 Supercomputing Systems AG
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+	   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+*/
+
+use crate::rpc::json_req;
+use ac_node_api::metadata::{Metadata, MetadataError};
+use ac_primitives::{AccountData, AccountInfo, Balance, ExtrinsicParams};
+use codec::{Decode, Encode};
+use log::{debug, info};
+use serde::de::DeserializeOwned;
+use sp_core::H256 as Hash;
+use sp_rpc::number::NumberOrHex;
+use std::convert::{TryFrom, TryInto};
+use transaction_payment::{InclusionFee, RuntimeDispatchInfo};
+
 pub use crate::{
 	std::{
 		error::{ApiResult, Error as ApiClientError},
@@ -5,11 +33,8 @@ pub use crate::{
 	},
 	utils::FromHexString,
 };
-use ac_node_api::metadata::{Metadata, MetadataError};
-use ac_primitives::{AccountData, AccountInfo, Balance, ExtrinsicParams};
 pub use metadata::RuntimeMetadataPrefixed;
 pub use serde_json::Value;
-use sp_core::H256 as Hash;
 pub use sp_core::{crypto::Pair, storage::StorageKey};
 pub use sp_runtime::{
 	generic::SignedBlock,
@@ -19,18 +44,9 @@ pub use sp_runtime::{
 pub use sp_std::prelude::*;
 pub use sp_version::RuntimeVersion;
 pub use transaction_payment::FeeDetails;
+
 pub mod error;
 pub mod rpc;
-
-use std::convert::{TryFrom, TryInto};
-
-use codec::{Decode, Encode};
-use log::{debug, info};
-use serde::de::DeserializeOwned;
-use sp_rpc::number::NumberOrHex;
-use transaction_payment::{InclusionFee, RuntimeDispatchInfo};
-
-use crate::rpc::json_req;
 
 pub trait RpcClient {
 	/// Sends a RPC request that returns a String

--- a/src/std/mod.rs
+++ b/src/std/mod.rs
@@ -112,7 +112,6 @@ where
 	pub runtime_version: RuntimeVersion,
 	client: Client,
 	pub extrinsic_params_builder: Option<Params::OtherParams>,
-	timeout: Duration,
 }
 
 impl<P, Client, Params> Api<P, Client, Params>
@@ -161,7 +160,6 @@ where
 			runtime_version,
 			client,
 			extrinsic_params_builder: None,
-			timeout: Duration::from_secs(900),
 		})
 	}
 
@@ -173,12 +171,6 @@ where
 
 	pub fn set_extrinsic_params_builder(mut self, extrinsic_params: Params::OtherParams) -> Self {
 		self.extrinsic_params_builder = Some(extrinsic_params);
-		self
-	}
-
-	/// The the maximum amount of time the api client waits for a specific event from the node.
-	pub fn set_event_timeout(mut self, timeout: Duration) -> Self {
-		self.timeout = timeout;
 		self
 	}
 

--- a/src/std/mod.rs
+++ b/src/std/mod.rs
@@ -18,7 +18,6 @@ pub use sp_runtime::{
 };
 pub use sp_std::prelude::*;
 pub use sp_version::RuntimeVersion;
-use std::time::Duration;
 pub use transaction_payment::FeeDetails;
 pub mod error;
 pub mod rpc;

--- a/src/std/rpc/ws_client/client.rs
+++ b/src/std/rpc/ws_client/client.rs
@@ -35,17 +35,25 @@ use std::{
 	fmt::Debug,
 	sync::mpsc::{channel, Sender as ThreadOut},
 	thread,
+	time::Duration,
 };
 use ws::{connect, Result as WsResult};
 
 #[derive(Debug, Clone)]
 pub struct WsRpcClient {
 	url: String,
+	timeout: Duration,
 }
 
 impl WsRpcClient {
-	pub fn new(url: &str) -> WsRpcClient {
-		WsRpcClient { url: url.to_string() }
+	pub fn new(url: &str) -> Self {
+		Self { url: url.to_string(), timeout: Duration::from_secs(300) }
+	}
+
+	/// Set the maximum amount of time the api client waits for an answer from the node.
+	pub fn set_timeout(mut self, timeout: Duration) -> Self {
+		self.timeout = timeout;
+		self
 	}
 }
 
@@ -203,6 +211,6 @@ impl WsRpcClient {
 			result: result_in.clone(),
 			message_handler: message_handler.clone(),
 		})?;
-		Ok(result_out.recv()?)
+		Ok(result_out.recv_timeout(self.timeout)?)
 	}
 }

--- a/src/std/rpc/ws_client/client.rs
+++ b/src/std/rpc/ws_client/client.rs
@@ -211,6 +211,7 @@ impl WsRpcClient {
 			result: result_in.clone(),
 			message_handler: message_handler.clone(),
 		})?;
+		log::error!("timout: {:?}", self.timeout);
 		Ok(result_out.recv_timeout(self.timeout)?)
 	}
 }

--- a/src/std/rpc/ws_client/mod.rs
+++ b/src/std/rpc/ws_client/mod.rs
@@ -128,7 +128,7 @@ where
 		receiver: &Receiver<String>,
 	) -> ApiResult<EventDetails> {
 		loop {
-			let events_str = receiver.recv()?;
+			let events_str = receiver.recv_timeout(self.timeout)?;
 			let event_bytes = Vec::from_hex(events_str)?;
 			let events = Events::new(self.metadata.clone(), Default::default(), event_bytes);
 

--- a/src/std/rpc/ws_client/mod.rs
+++ b/src/std/rpc/ws_client/mod.rs
@@ -15,8 +15,6 @@ use ac_node_api::Events;
    limitations under the License.
 
 */
-pub use ac_node_api::{events::EventDetails, StaticEvent};
-
 use crate::{
 	std::{
 		error::Error, json_req, rpc::RpcClientError, Api, ApiResult, FromHexString,
@@ -37,6 +35,7 @@ use std::{
 };
 use ws::{CloseCode, Error as WsError, Handler, Handshake, Message, Result as WsResult, Sender};
 
+pub use ac_node_api::{events::EventDetails, StaticEvent};
 pub use client::WsRpcClient;
 
 pub mod client;


### PR DESCRIPTION
- adds a timeout to the `WsRpcClient`. By default it is 300 secs ( = 5 minutes). Finalization may take quite some time, so I think that's a reasonable amount of time.
- the `wait_for_event` functions now take an additional optional timeout parameter. Because the event may be expected to happen somewhen far in the future, I did not want to introduce a default timeout just like that. 

closes #134 