### PR TITLE
[CI] Add automatic draft release generation

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,9 +1,11 @@
 name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
+exclude-labels:
+  - 'E0-silent'
 categories:
   - title: '⚡ Breaking API changes'
     labels:
-      - 'E1-breaksapi'
+      - 'E2-breaksapi'
   - title: ' 🌈 Features'
     labels:
       - 'F8-newfeature'
@@ -14,8 +16,8 @@ categories:
   - title: ' Miscellaneous '
     collapse-after: 5
     label:
-      - 'E0-breaksnothing'
-      - 'E1-breaksapi'
+      - 'E1-breaksnothing'
+      - 'E2-breaksapi'
 change-template: '- $TITLE (#$NUMBER) @$AUTHOR '
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
 template: |

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,22 @@
+name-template: 'v$RESOLVED_VERSION 🌈'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: '⚡ Breaking changes'
+    labels:
+      - 'E1-breaksapi'
+  - title: '🚀 Features'
+    labels:
+      - 'F8-newfeature'
+      - 'F7-enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'F2-bug'
+  - title: '💨 Optimizations '
+    label:
+      - 'F6-optimization'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,22 +1,24 @@
-name-template: 'v$RESOLVED_VERSION 🌈'
+name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
 categories:
-  - title: '⚡ Breaking changes'
+  - title: '⚡ Breaking API changes'
     labels:
       - 'E1-breaksapi'
-  - title: '🚀 Features'
+  - title: ' 🌈 Features'
     labels:
       - 'F8-newfeature'
       - 'F7-enhancement'
   - title: '🐛 Bug Fixes'
     labels:
       - 'F2-bug'
-  - title: '💨 Optimizations '
+  - title: ' Miscellaneous '
+    collapse-after: 5
     label:
-      - 'F6-optimization'
-change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+      - 'E0-breaksnothing'
+      - 'E1-breaksapi'
+change-template: '- $TITLE (#$NUMBER) @$AUTHOR '
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
 template: |
-  ## Changes
+  ## What's Changed since $PREVIOUS_TAG
 
   $CHANGES

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -15,8 +15,8 @@ jobs:
       # Drafts your next Release notes as Pull Requests are merged into "master"
       - uses: release-drafter/release-drafter@v5
         # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
-        # with:
-        #   config-name: my-config.yml
-        #   disable-autolabeler: true
+        with:
+          tag:  ${{ github.ref_name }}
+          name:  ${{ github.ref_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -1,0 +1,22 @@
+name: Release - Publish Draft
+
+on:
+  push:
+    tags:
+      # Catches v1.2.3 and v1.2.3-rc1
+      - v[0-9]+.[0-9]+.[0-9]+*
+jobs:
+  update_release_draft:
+    permissions:
+      # write permission is required to create a github release
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: release-drafter/release-drafter@v5
+        # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
+        # with:
+        #   config-name: my-config.yml
+        #   disable-autolabeler: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
CI generate a draft release upon a new tag that looks like the following: https://github.com/haerdib/substrate-api-client/releases/tag/v0.9.2

- only PR's that include an `E1` or `E2` label are included, `E0` are ignored. To ensure atleast one E label is set, I'm suggesting to introduce a label checker https://github.com/scs/substrate-api-client/issues/324
![grafik](https://user-images.githubusercontent.com/73821294/202661061-cdcf3581-1cd0-4fc9-8862-c7794ad385b1.png)

More Info: https://github.com/release-drafter/release-drafter
