### PR TITLE
Bump version of all crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,7 @@ dependencies = [
 
 [[package]]
 name = "ac-compose-macros"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ac-primitives",
  "log",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "ac-node-api"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ac-primitives",
  "bitvec",
@@ -51,7 +51,7 @@ dependencies = [
 
 [[package]]
 name = "ac-primitives"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "hex",
  "parity-scale-codec",
@@ -4487,7 +4487,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-api-client"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "ac-compose-macros",
  "ac-node-api",
@@ -4535,7 +4535,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-client-keystore"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "hex",
@@ -4626,7 +4626,7 @@ dependencies = [
 
 [[package]]
 name = "test-no-std"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "ac-compose-macros",
  "ac-node-api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-api-client"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Supercomputing Systems AG <info@scs.ch>"]
 license = "Apache-2.0"
 edition = "2021"

--- a/client-keystore/Cargo.toml
+++ b/client-keystore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-client-keystore"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Supercomputing Systems AG <info@scs.ch>"]
 license = "Apache-2.0"
 edition = "2021"

--- a/compose-macros/Cargo.toml
+++ b/compose-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ac-compose-macros"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Supercomputing Systems AG <info@scs.ch>"]
 license = "Apache-2.0"
 edition = "2021"

--- a/node-api/Cargo.toml
+++ b/node-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ac-node-api"
-version = "0.1.0"
+version = "0.2.0"
 license = "Apache-2.0"
 edition = "2021"
 

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ac-primitives"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Supercomputing Systems AG <info@scs.ch>"]
 license = "Apache-2.0"
 edition = "2021"

--- a/test-no-std/Cargo.toml
+++ b/test-no-std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test-no-std"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Supercomputing Systems AG <info@scs.ch>"]
 license = "Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
Reasoning: The licence header has been changed since v0.1.0. I think that's reason enough for bumping everything