### PR TITLE
[Api] add `update_runtime` function and return metadata from cache

### DIFF
--- a/compose-macros/src/lib.rs
+++ b/compose-macros/src/lib.rs
@@ -109,8 +109,8 @@ macro_rules! compose_extrinsic {
             use $crate::sp_runtime::generic::Era;
 
             debug!("Composing generic extrinsic for module {:?} and call {:?}", $module, $call);
-            let call = $crate::compose_call!($api.metadata.clone(), $module, $call $(, ($args)) *);
-            if let Some(signer) = $api.signer.clone() {
+            let call = $crate::compose_call!($api.metadata().clone(), $module, $call $(, ($args)) *);
+            if let Some(signer) = $api.signer() {
                 $crate::compose_extrinsic_offline!(
                     signer,
                     call.clone(),

--- a/examples/batch_payout.rs
+++ b/examples/batch_payout.rs
@@ -17,9 +17,8 @@ fn main() {
 
 	let from = AccountKeyring::Alice.pair();
 	let client = WsRpcClient::new("ws://127.0.0.1:9944");
-	let api = Api::<_, _, PlainTipExtrinsicParams>::new(client)
-		.map(|api| api.set_signer(from))
-		.unwrap();
+	let mut api = Api::<_, _, PlainTipExtrinsicParams>::new(client).unwrap();
+	api.set_signer(from);
 	let grace_period: GracePeriod = GracePeriod { enabled: false, eras: 0 };
 	let mut results: Vec<Value> = Vec::new();
 
@@ -95,7 +94,7 @@ pub fn get_last_reward(
 	};
 	let active_era: ActiveEraInfo =
 		api.get_storage_value("Staking", "ActiveEra", None).unwrap().unwrap();
-	let storagekey = api.metadata.storage_map_key("Staking", "Ledger", &account).unwrap();
+	let storagekey = api.metadata().storage_map_key("Staking", "Ledger", &account).unwrap();
 	let mut res = StakingLedger {
 		stash: account,
 		total: 0,

--- a/examples/benchmark_bulk_xt.rs
+++ b/examples/benchmark_bulk_xt.rs
@@ -46,7 +46,7 @@ fn main() {
 		// compose the extrinsic with all the element
 		#[allow(clippy::redundant_clone)]
 		let xt: UncheckedExtrinsicV4<_, _> = compose_extrinsic_offline!(
-			api.clone().signer.unwrap(),
+			api.signer().unwrap().clone(),
 			RuntimeCall::Balances(BalancesCall::transfer {
 				dest: GenericAddress::Id(to.clone()),
 				value: 1_000_000

--- a/examples/benchmark_bulk_xt.rs
+++ b/examples/benchmark_bulk_xt.rs
@@ -30,7 +30,7 @@ fn main() {
 
 	// initialize api and set the signer (sender) that is used to sign the extrinsics
 	let from = AccountKeyring::Alice.pair();
-let client = WsRpcClient::new("ws://127.0.0.1:9944");
+	let client = WsRpcClient::new("ws://127.0.0.1:9944");
 	let mut api = Api::<_, _, AssetTipExtrinsicParams>::new(client).unwrap();
 	api.set_signer(from);
 

--- a/examples/benchmark_bulk_xt.rs
+++ b/examples/benchmark_bulk_xt.rs
@@ -30,10 +30,9 @@ fn main() {
 
 	// initialize api and set the signer (sender) that is used to sign the extrinsics
 	let from = AccountKeyring::Alice.pair();
-	let client = WsRpcClient::new("ws://127.0.0.1:9944");
-	let api = Api::<_, _, AssetTipExtrinsicParams>::new(client)
-		.map(|api| api.set_signer(from))
-		.unwrap();
+let client = WsRpcClient::new("ws://127.0.0.1:9944");
+	let mut api = Api::<_, _, AssetTipExtrinsicParams>::new(client).unwrap();
+	api.set_signer(from);
 
 	println!("[+] Alice's Account Nonce is {}\n", api.get_nonce().unwrap());
 

--- a/examples/compose_extrinsic_offline.rs
+++ b/examples/compose_extrinsic_offline.rs
@@ -56,7 +56,7 @@ fn main() {
 	// Compose the extrinsic.
 	#[allow(clippy::redundant_clone)]
 	let xt: UncheckedExtrinsicV4<_, _> = compose_extrinsic_offline!(
-		updated_api.clone().signer.unwrap(),
+		updated_api.signer().unwrap().clone(),
 		RuntimeCall::Balances(BalancesCall::transfer { dest: to.clone(), value: 42 }),
 		updated_api.extrinsic_params(alice_nonce)
 	);

--- a/examples/compose_extrinsic_offline.rs
+++ b/examples/compose_extrinsic_offline.rs
@@ -32,9 +32,8 @@ fn main() {
 	let from = AccountKeyring::Alice.pair();
 	let client = WsRpcClient::new("ws://127.0.0.1:9944");
 
-	let api = Api::<_, _, AssetTipExtrinsicParams>::new(client)
-		.map(|api| api.set_signer(from))
-		.unwrap();
+	let mut api = Api::<_, _, AssetTipExtrinsicParams>::new(client).unwrap();
+	api.set_signer(from);
 
 	// Information for Era for mortal transactions.
 	let head = api.get_finalized_head().unwrap().unwrap();
@@ -44,10 +43,11 @@ fn main() {
 		.era(Era::mortal(period, h.number.into()), head)
 		.tip(0);
 
-	let updated_api = api.set_extrinsic_params_builder(tx_params);
+	// Set the custom params builder:
+	api.set_extrinsic_params_builder(tx_params);
 
 	// Get the nonce of Alice.
-	let alice_nonce = updated_api.get_nonce().unwrap();
+	let alice_nonce = api.get_nonce().unwrap();
 	println!("[+] Alice's Account Nonce is {}\n", alice_nonce);
 
 	// Define the recipient.
@@ -56,14 +56,14 @@ fn main() {
 	// Compose the extrinsic.
 	#[allow(clippy::redundant_clone)]
 	let xt: UncheckedExtrinsicV4<_, _> = compose_extrinsic_offline!(
-		updated_api.signer().unwrap().clone(),
+		api.signer().unwrap().clone(),
 		RuntimeCall::Balances(BalancesCall::transfer { dest: to.clone(), value: 42 }),
-		updated_api.extrinsic_params(alice_nonce)
+		api.extrinsic_params(alice_nonce)
 	);
 
 	println!("[+] Composed Extrinsic:\n {:?}\n", xt);
 
 	// Send and watch extrinsic until in block.
-	let block_hash = updated_api.send_extrinsic(xt.hex_encode(), XtStatus::InBlock).unwrap();
+	let block_hash = api.send_extrinsic(xt.hex_encode(), XtStatus::InBlock).unwrap();
 	println!("[+] Transaction got included in block {:?}", block_hash);
 }

--- a/examples/contract_instantiate_with_code.rs
+++ b/examples/contract_instantiate_with_code.rs
@@ -15,10 +15,9 @@
 
 //! This example is community maintained and not CI tested, therefore it may not work as is.
 
-use std::sync::mpsc::channel;
-
 use codec::Decode;
 use sp_keyring::AccountKeyring;
+use std::sync::mpsc::channel;
 use substrate_api_client::{
 	rpc::WsRpcClient, AccountId, Api, PlainTipExtrinsicParams, StaticEvent, XtStatus,
 };
@@ -41,9 +40,9 @@ fn main() {
 	// initialize api and set the signer (sender) that is used to sign the extrinsics
 	let from = AccountKeyring::Alice.pair();
 	let client = WsRpcClient::new("ws://127.0.0.1:9944");
-	let api = Api::<_, _, PlainTipExtrinsicParams>::new(client)
-		.map(|api| api.set_signer(from))
-		.unwrap();
+	let mut api = Api::<_, _, PlainTipExtrinsicParams>::new(client).unwrap();
+	api.set_signer(from);
+
 	println!("[+] Alice's Account Nonce is {}", api.get_nonce().unwrap());
 
 	// contract to be deployed on the chain

--- a/examples/custom_nonce.rs
+++ b/examples/custom_nonce.rs
@@ -32,9 +32,8 @@ fn main() {
 	let from = AccountKeyring::Alice.pair();
 	let client = WsRpcClient::new("ws://127.0.0.1:9944");
 
-	let api = Api::<_, _, AssetTipExtrinsicParams>::new(client)
-		.map(|api| api.set_signer(from))
-		.unwrap();
+	let mut api = Api::<_, _, AssetTipExtrinsicParams>::new(client).unwrap();
+	api.set_signer(from);
 
 	// Information for Era for mortal transactions.
 	let head = api.get_finalized_head().unwrap().unwrap();
@@ -44,10 +43,11 @@ fn main() {
 		.era(Era::mortal(period, h.number.into()), head)
 		.tip(0);
 
-	let updated_api = api.set_extrinsic_params_builder(tx_params);
+	// Set the custom parmas builder:
+	api.set_extrinsic_params_builder(tx_params);
 
 	// Get the nonce of Alice.
-	let alice_nonce = updated_api.get_nonce().unwrap();
+	let alice_nonce = api.get_nonce().unwrap();
 	println!("[+] Alice's Account Nonce is {}\n", alice_nonce);
 
 	// Define the recipient.
@@ -56,15 +56,15 @@ fn main() {
 	// Create an extrinsic that should get included in the future pool due to a nonce that is too high.
 	#[allow(clippy::redundant_clone)]
 	let xt: UncheckedExtrinsicV4<_, _> = compose_extrinsic_offline!(
-		updated_api.signer().unwrap().clone(),
+		api.signer().unwrap().clone(),
 		RuntimeCall::Balances(BalancesCall::transfer { dest: to.clone(), value: 42 }),
-		updated_api.extrinsic_params(alice_nonce + 1)
+		api.extrinsic_params(alice_nonce + 1)
 	);
 
 	println!("[+] Composed Extrinsic:\n {:?}\n", xt);
 
 	// Send and watch extrinsic until InBlock.
-	match updated_api.send_extrinsic(xt.hex_encode(), XtStatus::InBlock) {
+	match api.send_extrinsic(xt.hex_encode(), XtStatus::InBlock) {
 		Err(error) => {
 			println!("Retrieved error {:?}", error);
 			assert!(format!("{:?}", error).contains("Future"));

--- a/examples/custom_nonce.rs
+++ b/examples/custom_nonce.rs
@@ -56,7 +56,7 @@ fn main() {
 	// Create an extrinsic that should get included in the future pool due to a nonce that is too high.
 	#[allow(clippy::redundant_clone)]
 	let xt: UncheckedExtrinsicV4<_, _> = compose_extrinsic_offline!(
-		updated_api.clone().signer.unwrap(),
+		updated_api.signer().unwrap().clone(),
 		RuntimeCall::Balances(BalancesCall::transfer { dest: to.clone(), value: 42 }),
 		updated_api.extrinsic_params(alice_nonce + 1)
 	);

--- a/examples/event_error_details.rs
+++ b/examples/event_error_details.rs
@@ -16,7 +16,7 @@ limitations under the License.
 use codec::Decode;
 use sp_core::crypto::Pair;
 use sp_keyring::AccountKeyring;
-use sp_runtime::{app_crypto::sp_core::sr25519, AccountId32 as AccountId, MultiAddress};
+use sp_runtime::{AccountId32 as AccountId, MultiAddress};
 use std::sync::mpsc::channel;
 use substrate_api_client::{
 	rpc::WsRpcClient, Api, ApiResult, AssetTipExtrinsicParams, StaticEvent, XtStatus,

--- a/examples/event_error_details.rs
+++ b/examples/event_error_details.rs
@@ -42,9 +42,8 @@ fn main() {
 	let from = AccountKeyring::Alice.pair();
 
 	let client = WsRpcClient::new("ws://127.0.0.1:9944");
-	let api = Api::<sr25519::Pair, _, AssetTipExtrinsicParams>::new(client)
-		.map(|api| api.set_signer(from.clone()))
-		.unwrap();
+	let mut api = Api::<_, _, AssetTipExtrinsicParams>::new(client).unwrap();
+	api.set_signer(from.clone());
 
 	let from_account_id = AccountKeyring::Alice.to_account_id();
 

--- a/examples/generic_event_callback.rs
+++ b/examples/generic_event_callback.rs
@@ -41,9 +41,8 @@ fn main() {
 	// Initialize api and set the signer (sender) that is used to sign the extrinsics.
 	let alice = AccountKeyring::Alice.pair();
 	let client = WsRpcClient::new("ws://127.0.0.1:9944");
-	let api = Api::<_, _, AssetTipExtrinsicParams>::new(client)
-		.map(|api| api.set_signer(alice.clone()))
-		.unwrap();
+	let mut api = Api::<_, _, AssetTipExtrinsicParams>::new(client).unwrap();
+	api.set_signer(alice);
 
 	println!("Subscribe to events");
 

--- a/examples/generic_extrinsic.rs
+++ b/examples/generic_extrinsic.rs
@@ -28,10 +28,8 @@ fn main() {
 	// initialize api and set the signer (sender) that is used to sign the extrinsics
 	let from = AccountKeyring::Alice.pair();
 	let client = WsRpcClient::new("ws://127.0.0.1:9944");
-	let api = Api::<_, _, AssetTipExtrinsicParams>::new(client)
-		.map(|api| api.set_signer(from))
-		.unwrap();
-
+	let mut api = Api::<_, _, AssetTipExtrinsicParams>::new(client).unwrap();
+	api.set_signer(from);
 	// set the recipient
 	let to = AccountKeyring::Bob.to_account_id();
 

--- a/examples/get_account_identity.rs
+++ b/examples/get_account_identity.rs
@@ -37,9 +37,8 @@ fn main() {
 	// Create the node-api client and set the signer.
 	let client = WsRpcClient::new("ws://127.0.0.1:9944");
 	let alice = AccountKeyring::Alice.pair();
-	let api = Api::<_, _, AssetTipExtrinsicParams>::new(client)
-		.map(|api| api.set_signer(alice.clone()))
-		.unwrap();
+	let mut api = Api::<_, _, AssetTipExtrinsicParams>::new(client).unwrap();
+	api.set_signer(alice.clone());
 
 	// Fill Identity storage
 	let info = IdentityInfo::<MaxAdditionalFieldsOf<KitchensinkRuntime>> {

--- a/examples/get_storage.rs
+++ b/examples/get_storage.rs
@@ -45,6 +45,6 @@ fn main() {
 
 	// get Alice's AccountNonce with api.get_nonce()
 	let signer = AccountKeyring::Alice.pair();
-	api.signer = Some(signer);
+	api.set_signer(signer);
 	println!("[+] Alice's Account Nonce is {}", api.get_nonce().unwrap());
 }

--- a/examples/print_metadata.rs
+++ b/examples/print_metadata.rs
@@ -23,7 +23,7 @@ fn main() {
 	env_logger::init();
 
 	let client = WsRpcClient::new("ws://127.0.0.1:9944");
-	let api = Api::<sr25519::Pair, _, AssetTipExtrinsicParams>::new(client).unwrap();
+	let mut api = Api::<sr25519::Pair, _, AssetTipExtrinsicParams>::new(client).unwrap();
 
 	let meta = api.metadata().clone();
 
@@ -34,7 +34,8 @@ fn main() {
 	meta.print_pallets_with_errors();
 	meta.print_pallets_with_constants();
 
-	let api = api.update_runtime().unwrap();
+	// Update the runtime and metadata.
+	api.update_runtime().unwrap();
 
 	// Print full substrate metadata json formatted.
 	println!("{}", Metadata::pretty_format(&api.metadata().metadata).unwrap())

--- a/examples/print_metadata.rs
+++ b/examples/print_metadata.rs
@@ -34,6 +34,8 @@ fn main() {
 	meta.print_pallets_with_errors();
 	meta.print_pallets_with_constants();
 
+	let api = api.update_runtime().unwrap();
+
 	// Print full substrate metadata json formatted.
 	println!("{}", Metadata::pretty_format(&api.get_metadata().metadata).unwrap())
 }

--- a/examples/print_metadata.rs
+++ b/examples/print_metadata.rs
@@ -35,5 +35,5 @@ fn main() {
 	meta.print_pallets_with_constants();
 
 	// Print full substrate metadata json formatted.
-	println!("{}", Metadata::pretty_format(&api.get_metadata()).unwrap())
+	println!("{}", Metadata::pretty_format(&api.get_metadata().metadata).unwrap())
 }

--- a/examples/print_metadata.rs
+++ b/examples/print_metadata.rs
@@ -25,7 +25,7 @@ fn main() {
 	let client = WsRpcClient::new("ws://127.0.0.1:9944");
 	let api = Api::<sr25519::Pair, _, AssetTipExtrinsicParams>::new(client).unwrap();
 
-	let meta = api.get_metadata().clone();
+	let meta = api.metadata().clone();
 
 	meta.print_overview();
 	meta.print_pallets();
@@ -37,5 +37,5 @@ fn main() {
 	let api = api.update_runtime().unwrap();
 
 	// Print full substrate metadata json formatted.
-	println!("{}", Metadata::pretty_format(&api.get_metadata().metadata).unwrap())
+	println!("{}", Metadata::pretty_format(&api.metadata().metadata).unwrap())
 }

--- a/examples/print_metadata.rs
+++ b/examples/print_metadata.rs
@@ -17,7 +17,6 @@
 ///! debugging tool.
 use sp_core::sr25519;
 
-use std::convert::TryFrom;
 use substrate_api_client::{rpc::WsRpcClient, Api, AssetTipExtrinsicParams, Metadata};
 
 fn main() {
@@ -26,7 +25,7 @@ fn main() {
 	let client = WsRpcClient::new("ws://127.0.0.1:9944");
 	let api = Api::<sr25519::Pair, _, AssetTipExtrinsicParams>::new(client).unwrap();
 
-	let meta = Metadata::try_from(api.get_metadata().unwrap()).unwrap();
+	let meta = api.get_metadata().clone();
 
 	meta.print_overview();
 	meta.print_pallets();
@@ -36,5 +35,5 @@ fn main() {
 	meta.print_pallets_with_constants();
 
 	// Print full substrate metadata json formatted.
-	println!("{}", Metadata::pretty_format(&api.get_metadata().unwrap()).unwrap())
+	println!("{}", Metadata::pretty_format(&api.get_metadata()).unwrap())
 }

--- a/examples/staking_payout.rs
+++ b/examples/staking_payout.rs
@@ -12,9 +12,8 @@ fn main() {
 	env_logger::init();
 	let from = AccountKeyring::Alice.pair();
 	let client = WsRpcClient::new("ws://127.0.0.1:9944");
-	let api = Api::<_, _, PlainTipExtrinsicParams>::new(client)
-		.map(|api| api.set_signer(from))
-		.unwrap();
+	let mut api = Api::<_, _, PlainTipExtrinsicParams>::new(client).unwrap();
+	api.set_signer(from);
 	let mut exposure: Exposure<AccountId32, u128> = Exposure { total: 0, own: 0, others: vec![] };
 	let account =
 		match AccountId32::from_ss58check("5DJcEbkNxsnNwHGrseg7cgbfUG8eiKzpuZqgSph5HqHrjgf6") {

--- a/examples/sudo.rs
+++ b/examples/sudo.rs
@@ -29,9 +29,8 @@ fn main() {
 	// initialize api and set the signer (sender) that is used to sign the extrinsics
 	let sudoer = AccountKeyring::Alice.pair();
 	let client = WsRpcClient::new("ws://127.0.0.1:9944");
-	let api = Api::<_, _, AssetTipExtrinsicParams>::new(client)
-		.map(|api| api.set_signer(sudoer))
-		.unwrap();
+	let mut api = Api::<_, _, AssetTipExtrinsicParams>::new(client).unwrap();
+	api.set_signer(sudoer);
 
 	// set the recipient of newly issued funds
 	let to = AccountKeyring::Bob.to_account_id();

--- a/examples/sudo.rs
+++ b/examples/sudo.rs
@@ -39,7 +39,7 @@ fn main() {
 	// this call can only be called by sudo
 	#[allow(clippy::redundant_clone)]
 	let call = compose_call!(
-		api.metadata.clone(),
+		api.metadata().clone(),
 		"Balances",
 		"set_balance",
 		GenericAddress::Id(to),

--- a/examples/transfer_using_seed.rs
+++ b/examples/transfer_using_seed.rs
@@ -34,9 +34,8 @@ fn main() {
 
 	// Initialize api and set the signer (sender) that is used to sign the extrinsics.
 	let client = WsRpcClient::new("ws://127.0.0.1:9944");
-	let api = Api::<_, _, AssetTipExtrinsicParams>::new(client)
-		.map(|api| api.set_signer(alice.clone()))
-		.unwrap();
+	let mut api = Api::<_, _, AssetTipExtrinsicParams>::new(client).unwrap();
+	api.set_signer(alice.clone());
 
 	// Bob
 	let bob = sr25519::Public::from_ss58check("5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty")

--- a/node-api/src/metadata.rs
+++ b/node-api/src/metadata.rs
@@ -17,10 +17,8 @@ use frame_metadata::{
 	StorageEntryMetadata, META_RESERVED,
 };
 use scale_info::{form::PortableForm, PortableRegistry, Type};
-use sp_core::storage::StorageKey;
-
-#[cfg(feature = "std")]
 use serde::Serialize;
+use sp_core::storage::StorageKey;
 
 // We use `BTreeMap` because we can't use `HashMap` in `no_std`.
 use sp_std::collections::btree_map::BTreeMap;

--- a/node-api/src/metadata.rs
+++ b/node-api/src/metadata.rs
@@ -67,7 +67,7 @@ pub enum MetadataError {
 	IncompatibleMetadata,
 }
 
-#[derive(Clone, Debug, Encode, Decode)]
+#[derive(Clone, Debug, Encode, Decode, Serialize)]
 pub struct Metadata {
 	pub metadata: RuntimeMetadataLastVersion,
 	pub pallets: BTreeMap<String, PalletMetadata>,
@@ -161,7 +161,7 @@ impl Metadata {
 	}
 
 	#[cfg(feature = "std")]
-	pub fn pretty_format(metadata: &RuntimeMetadataPrefixed) -> Option<String> {
+	pub fn pretty_format<Metadata: Serialize>(metadata: &Metadata) -> Option<String> {
 		let buf = Vec::new();
 		let formatter = serde_json::ser::PrettyFormatter::with_indent(b" ");
 		let mut ser = serde_json::Serializer::with_formatter(buf, formatter);
@@ -171,7 +171,7 @@ impl Metadata {
 }
 
 /// Metadata for a specific pallet.
-#[derive(Clone, Debug, Encode, Decode)]
+#[derive(Clone, Debug, Encode, Decode, Serialize)]
 pub struct PalletMetadata {
 	pub index: u8,
 	pub name: String,
@@ -233,7 +233,7 @@ impl PalletMetadata {
 }
 
 /// Metadata for specific field.
-#[derive(Clone, Debug, Encode, Decode)]
+#[derive(Clone, Debug, Encode, Decode, Serialize)]
 pub struct EventFieldMetadata {
 	name: Option<String>,
 	type_name: Option<String>,
@@ -263,7 +263,7 @@ impl EventFieldMetadata {
 }
 
 /// Metadata for specific events.
-#[derive(Clone, Debug, Encode, Decode)]
+#[derive(Clone, Debug, Encode, Decode, Serialize)]
 pub struct EventMetadata {
 	pallet: String,
 	event: String,
@@ -293,7 +293,7 @@ impl EventMetadata {
 	}
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Encode, Decode)]
+#[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Encode, Decode, Serialize)]
 pub struct ErrorMetadata {
 	pallet: String,
 	error: String,

--- a/node-api/src/metadata.rs
+++ b/node-api/src/metadata.rs
@@ -17,8 +17,10 @@ use frame_metadata::{
 	StorageEntryMetadata, META_RESERVED,
 };
 use scale_info::{form::PortableForm, PortableRegistry, Type};
-use serde::Serialize;
 use sp_core::storage::StorageKey;
+
+#[cfg(feature = "std")]
+use serde::Serialize;
 
 // We use `BTreeMap` because we can't use `HashMap` in `no_std`.
 use sp_std::collections::btree_map::BTreeMap;
@@ -65,7 +67,7 @@ pub enum MetadataError {
 	IncompatibleMetadata,
 }
 
-#[derive(Clone, Debug, Encode, Decode, Serialize)]
+#[derive(Clone, Debug, Encode, Decode)]
 pub struct Metadata {
 	pub metadata: RuntimeMetadataLastVersion,
 	pub pallets: BTreeMap<String, PalletMetadata>,
@@ -169,7 +171,7 @@ impl Metadata {
 }
 
 /// Metadata for a specific pallet.
-#[derive(Clone, Debug, Encode, Decode, Serialize)]
+#[derive(Clone, Debug, Encode, Decode)]
 pub struct PalletMetadata {
 	pub index: u8,
 	pub name: String,
@@ -231,7 +233,7 @@ impl PalletMetadata {
 }
 
 /// Metadata for specific field.
-#[derive(Clone, Debug, Encode, Decode, Serialize)]
+#[derive(Clone, Debug, Encode, Decode)]
 pub struct EventFieldMetadata {
 	name: Option<String>,
 	type_name: Option<String>,
@@ -261,7 +263,7 @@ impl EventFieldMetadata {
 }
 
 /// Metadata for specific events.
-#[derive(Clone, Debug, Encode, Decode, Serialize)]
+#[derive(Clone, Debug, Encode, Decode)]
 pub struct EventMetadata {
 	pallet: String,
 	event: String,
@@ -291,7 +293,7 @@ impl EventMetadata {
 	}
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Encode, Decode, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Encode, Decode)]
 pub struct ErrorMetadata {
 	pallet: String,
 	error: String,

--- a/src/api/api_client.rs
+++ b/src/api/api_client.rs
@@ -193,7 +193,7 @@ where
 
 	/// Gets genesis hash directly from the node. Not a public method, because once the Api is created,
 	/// the genesis hash can be retrieved directly from the Api.
-	fn get_genesis_hash_from_node(client: &Client) -> ApiResult<Hash> {
+	pub fn get_genesis_hash_from_node(client: &Client) -> ApiResult<Hash> {
 		let jsonreq = json_req::chain_get_genesis_hash();
 		let genesis = client.get_request(jsonreq)?;
 
@@ -203,7 +203,7 @@ where
 		}
 	}
 
-	fn get_runtime_version_from_node(client: &Client) -> ApiResult<RuntimeVersion> {
+	pub fn get_runtime_version_from_node(client: &Client) -> ApiResult<RuntimeVersion> {
 		let jsonreq = json_req::state_get_runtime_version();
 		let version = client.get_request(jsonreq)?;
 
@@ -213,7 +213,7 @@ where
 		}
 	}
 
-	fn get_metadata_from_node(client: &Client) -> ApiResult<RuntimeMetadataPrefixed> {
+	pub fn get_metadata_from_node(client: &Client) -> ApiResult<RuntimeMetadataPrefixed> {
 		let jsonreq = json_req::state_get_metadata();
 		let meta = client.get_request(jsonreq)?;
 

--- a/src/api/api_client.rs
+++ b/src/api/api_client.rs
@@ -239,6 +239,10 @@ where
 		&self.metadata
 	}
 
+	pub fn get_genesis_hash(&self) -> Hash {
+		self.genesis_hash
+	}
+
 	pub fn get_spec_version(&self) -> u32 {
 		self.runtime_version.spec_version
 	}

--- a/src/api/api_client.rs
+++ b/src/api/api_client.rs
@@ -141,10 +141,7 @@ where
 
 	/// Get the private key pair of the api signer.
 	pub fn signer(&self) -> Option<&P> {
-		match &self.signer {
-			Some(signer) => Some(signer),
-			None => None,
-		}
+		self.signer.as_ref()
 	}
 
 	/// Get the cached genesis hash of the substrate node.

--- a/src/api/api_client.rs
+++ b/src/api/api_client.rs
@@ -84,9 +84,9 @@ use std::convert::{TryFrom, TryInto};
 /// }
 ///
 /// impl RpcClient for MyClient {
-///     fn get_request(&self, jsonreq: Value) -> RpcResult<String> {
+///     fn get_request(&self, jsonreq: Value) -> RpcResult<Option<String>> {
 ///         self.send_json::<Value>("".into(), jsonreq)
-///             .map(|v| v.to_string())
+///             .map(|v| Some(v.to_string()))
 ///     }
 ///
 ///     fn send_extrinsic(

--- a/src/api/api_client.rs
+++ b/src/api/api_client.rs
@@ -127,18 +127,19 @@ where
 	Client: RpcClient,
 	Params: ExtrinsicParams<Index, Hash>,
 {
-	#[must_use]
-	pub fn set_signer(mut self, signer: P) -> Self {
+	/// Set the api signer account.
+	pub fn set_signer(&mut self, signer: P) {
 		self.signer = Some(signer);
-		self
 	}
 
+	/// Get the public part of the api signer account.
 	pub fn signer_account(&self) -> Option<AccountId> {
 		let pair = self.signer.as_ref()?;
 		let multi_signer = MultiSigner::from(pair.public());
 		Some(multi_signer.into_account())
 	}
 
+	/// Get the private key pair of the api signer.
 	pub fn signer(&self) -> Option<&P> {
 		match &self.signer {
 			Some(signer) => Some(signer),
@@ -146,31 +147,37 @@ where
 		}
 	}
 
+	/// Get the cached genesis hash of the substrate node.
 	pub fn genesis_hash(&self) -> Hash {
 		self.genesis_hash
 	}
 
+	/// Get the cached metadata of the substrate node.
 	pub fn metadata(&self) -> &Metadata {
 		&self.metadata
 	}
 
+	/// Get the cached runtime version of the substrate node.
 	pub fn runtime_version(&self) -> &RuntimeVersion {
 		&self.runtime_version
 	}
 
+	/// Get the cached spec version of the substrate node.
 	pub fn spec_version(&self) -> u32 {
 		self.runtime_version.spec_version
 	}
 
+	/// Get the rpc client.
 	pub fn client(&self) -> &Client {
 		&self.client
 	}
 
-	pub fn set_extrinsic_params_builder(mut self, extrinsic_params: Params::OtherParams) -> Self {
+	/// Set the extrinscs param builder.
+	pub fn set_extrinsic_params_builder(&mut self, extrinsic_params: Params::OtherParams) {
 		self.extrinsic_params_builder = Some(extrinsic_params);
-		self
 	}
 
+	/// Get the extrinsic params, built with the set or if none, the default Params Builder.
 	pub fn extrinsic_params(&self, nonce: Index) -> Params {
 		let extrinsic_params_builder = self.extrinsic_params_builder.clone().unwrap_or_default();
 		<Params as ExtrinsicParams<Index, Hash>>::new(
@@ -271,7 +278,7 @@ where
 
 	/// Updates the runtime and metadata of the api via node query.
 	// Ideally, this function is called if a substrate update runtime event is encountered.
-	pub fn update_runtime(mut self) -> ApiResult<Self> {
+	pub fn update_runtime(&mut self) -> ApiResult<()> {
 		let metadata = Self::get_metadata(&self.client).map(Metadata::try_from)??;
 		debug!("Metadata: {:?}", metadata);
 
@@ -280,7 +287,7 @@ where
 
 		self.metadata = metadata;
 		self.runtime_version = runtime_version;
-		Ok(self)
+		Ok(())
 	}
 
 	pub fn get_account_info(&self, address: &AccountId) -> ApiResult<Option<AccountInfo>> {

--- a/src/api/subscription.rs
+++ b/src/api/subscription.rs
@@ -25,7 +25,7 @@ use ac_node_api::{DispatchError, Events};
 use ac_primitives::ExtrinsicParams;
 use log::*;
 use sp_core::Pair;
-use sp_runtime::MultiSignature;
+use sp_runtime::MultiSigner;
 use std::sync::mpsc::{Receiver, Sender as ThreadOut};
 
 impl<P, Params> Api<P, WsRpcClient, Params>
@@ -41,7 +41,7 @@ where
 impl<P, Client, Params> Api<P, Client, Params>
 where
 	P: Pair,
-	MultiSignature: From<P::Signature>,
+	MultiSigner: From<P::Public>,
 	Client: RpcClientTrait + Subscriber,
 	Params: ExtrinsicParams<Index, Hash>,
 {
@@ -49,13 +49,13 @@ where
 		debug!("subscribing to events");
 		let key = utils::storage_key("System", "Events");
 		let jsonreq = json_req::state_subscribe_storage(vec![key]).to_string();
-		self.client.start_subscriber(jsonreq, sender).map_err(|e| e.into())
+		self.client().start_subscriber(jsonreq, sender).map_err(|e| e.into())
 	}
 
 	pub fn subscribe_finalized_heads(&self, sender: ThreadOut<String>) -> ApiResult<()> {
 		debug!("subscribing to finalized heads");
 		let jsonreq = json_req::chain_subscribe_finalized_heads().to_string();
-		self.client.start_subscriber(jsonreq, sender).map_err(|e| e.into())
+		self.client().start_subscriber(jsonreq, sender).map_err(|e| e.into())
 	}
 
 	pub fn wait_for_event<Ev: StaticEvent>(&self, receiver: &Receiver<String>) -> ApiResult<Ev> {
@@ -72,7 +72,7 @@ where
 		loop {
 			let events_str = receiver.recv()?;
 			let event_bytes = Vec::from_hex(events_str)?;
-			let events = Events::new(self.metadata.clone(), Default::default(), event_bytes);
+			let events = Events::new(self.metadata().clone(), Default::default(), event_bytes);
 
 			for maybe_event_details in events.iter() {
 				let event_details = maybe_event_details?;
@@ -82,7 +82,7 @@ where
 				// than the one that is being waited for.
 				if extrinsic_has_failed(&event_details) {
 					let dispatch_error =
-						DispatchError::decode_from(event_details.field_bytes(), &self.metadata);
+						DispatchError::decode_from(event_details.field_bytes(), &self.metadata());
 					return Err(Error::Dispatch(dispatch_error))
 				}
 

--- a/src/api/subscription.rs
+++ b/src/api/subscription.rs
@@ -82,7 +82,7 @@ where
 				// than the one that is being waited for.
 				if extrinsic_has_failed(&event_details) {
 					let dispatch_error =
-						DispatchError::decode_from(event_details.field_bytes(), &self.metadata());
+						DispatchError::decode_from(event_details.field_bytes(), self.metadata());
 					return Err(Error::Dispatch(dispatch_error))
 				}
 

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -30,8 +30,8 @@ use std::sync::mpsc::Sender as ThreadOut;
 
 /// Trait to be implemented by the ws-client for sending rpc requests and extrinsic.
 pub trait RpcClient {
-	/// Sends a RPC request to the substrate node and returns the answer as string.
-	fn get_request(&self, jsonreq: serde_json::Value) -> Result<String>;
+	/// Sends a RPC request to the substrate node and returns the optional answer as string.
+	fn get_request(&self, jsonreq: serde_json::Value) -> Result<Option<String>>;
 
 	/// Submits ans watches an extrinsic until requested XtStatus and returns the block hash
 	/// the extrinsic was included, if XtStatus is InBlock or Finalized.

--- a/src/rpc/ws_client/client.rs
+++ b/src/rpc/ws_client/client.rs
@@ -49,10 +49,8 @@ impl WsRpcClient {
 }
 
 impl RpcClientTrait for WsRpcClient {
-	fn get_request(&self, jsonreq: Value) -> Result<String> {
-		Ok(self
-			.direct_rpc_request(jsonreq.to_string(), GetRequestHandler::default())??
-			.unwrap_or_default())
+	fn get_request(&self, jsonreq: Value) -> Result<Option<String>> {
+		self.direct_rpc_request(jsonreq.to_string(), GetRequestHandler::default())?
 	}
 
 	fn send_extrinsic(


### PR DESCRIPTION
💥  **Breaking Changes**:  
- `Api` variables are no longer public. They should be accessed via the getter methods
- `get_metadata`, `get_spec_version`, `get_genesis_hash` are now private. The user should access these values via the cached values in the `Api` struct.
    ❗  Careful: In case one relied on `get_metadata` returning the most recent metadata from the node, that's not the case any more. If that's necessary, run `update_runtime()` before calling the cache via `metadata()`.
- Setter methods (such as `set_signer`) now take a mutable reference and do not return a `Self` anymore.
 


💚  **Feature Changes**: 
- Added `update_runtime` function to update the Api in case of a runtime upgrade
- removes extra `_get_request` function: RpcClient now directly returns an `Option` without mapping it to an empty string and back to an Option.
- Added some descriptive comments and split up the `impl Api` for a more sensible layout.
