### PR TITLE
Update frame-metdata and remove ed25519-zebra patch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
  "bitvec",
  "derive_more",
  "either",
- "frame-metadata 15.0.0 (git+https://github.com/integritee-network/frame-metadata)",
+ "frame-metadata 15.0.0 (git+https://github.com/paritytech/frame-metadata)",
  "frame-support",
  "frame-system",
  "hex",
@@ -996,7 +996,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata"
 version = "15.0.0"
-source = "git+https://github.com/integritee-network/frame-metadata#3b43da9821238681f9431276d55b92a079142083"
+source = "git+https://github.com/paritytech/frame-metadata#1ea329920838b3f4170f421cde53ce7e6a15ccee"
 dependencies = [
  "cfg-if 1.0.0",
  "parity-scale-codec",
@@ -4630,7 +4630,7 @@ dependencies = [
  "ac-node-api",
  "ac-primitives",
  "env_logger",
- "frame-metadata 15.0.0 (git+https://github.com/integritee-network/frame-metadata)",
+ "frame-metadata 15.0.0 (git+https://github.com/paritytech/frame-metadata)",
  "frame-support",
  "frame-system",
  "hex",
@@ -5589,8 +5589,3 @@ dependencies = [
  "cc",
  "libc",
 ]
-
-[[patch.unused]]
-name = "ed25519-zebra"
-version = "3.0.0"
-source = "git+https://github.com/ZcashFoundation/ed25519-zebra?branch=main#15e028616c6b370dee4e3399153eb8a4348fbe39"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,11 +23,9 @@ serde = { version = "1.0.136", optional = true, features = ["derive"] }
 serde_json = { version = "1.0.79", optional = true }
 thiserror = { version = "1.0.30", optional = true }
 ws = { version = "0.9.2", optional = true, features = ["ssl"] }
-#TODO get from parity when our changes are accepted
-frame-metadata = { version = "15.0.0", default-features = false, git = "https://github.com/integritee-network/frame-metadata", features = ["v14", "full_derive"] }
-#frame-metadata = { version = "15.0.0", default-features = false, features = ["v14"] }
 
 # Substrate dependencies
+frame-metadata = { default-features = false, git = "https://github.com/paritytech/frame-metadata", features = ["v14", "serde_full", "decode"] }
 frame-support = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master" }
 frame-system = { optional = true, git = "https://github.com/paritytech/substrate.git", branch = "master" }
 pallet-balances = { optional = true, git = "https://github.com/paritytech/substrate.git", branch = "master" }
@@ -67,8 +65,8 @@ std = [
     "serde/std",
     "serde_json",
     "thiserror",
-    "frame-metadata/std",
     # substrate
+    "frame-metadata/std",
     "frame-support/std",
     "frame-system",
     "pallet-balances",
@@ -86,7 +84,3 @@ std = [
 ]
 ws-client = ["ws"]
 staking-xt = ["std", "pallet-staking"]
-
-# Remove when fixed: https://github.com/scs/substrate-api-client/issues/286
-[patch.crates-io]
-ed25519-zebra = { git = "https://github.com/ZcashFoundation/ed25519-zebra", branch = "main" }

--- a/node-api/Cargo.toml
+++ b/node-api/Cargo.toml
@@ -15,14 +15,11 @@ scale-info = { version = "2.0.1", features = ["derive", "decode", "bitvec"], def
 serde = { version = "1.0.136", features = ["derive"], default-features = false }
 serde_json = { version = "1.0.79", default-features = false, features = ["alloc"] }
 
-#TODO get from parity when our changes are accepted https://github.com/scs/substrate-api-client/issues/304
-frame-metadata = { version = "15.0.0", default-features = false, git = "https://github.com/integritee-network/frame-metadata", features = ["v14", "full_derive"] }
-#frame-metadata = { version = "15.0.0", features = ["v14"], default-features = false }
-
 # local
 ac-primitives = { path = "../primitives", default-features = false }
 
 # substrate
+frame-metadata = { default-features = false, git = "https://github.com/paritytech/frame-metadata", features = ["v14", "serde_full", "decode"] }
 frame-support = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master" }
 frame-system = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master" }
 sp-core = { default-features = false, features = ["full_crypto"], git = "https://github.com/paritytech/substrate.git", branch = "master" }
@@ -48,10 +45,10 @@ std = [
     "scale-info/std",
     "serde/std",
     "serde_json/std",
-    "frame-metadata/std",
     # local
     "ac-primitives/std",
     # substrate
+    "frame-metadata/std",
     "frame-support/std",
     "frame-system/std",
     "sp-core/std",


### PR DESCRIPTION
frame-metadata is now sourced from parity github instead of crates.io (which is very outdated)

closes #286 
closes #304