### PR TITLE
Support `tungstenite-rs` rpc client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -465,6 +465,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
+name = "core-foundation"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -890,6 +900,12 @@ dependencies = [
  "rustc-hex",
  "static_assertions",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foreign-types"
@@ -1397,6 +1413,17 @@ dependencies = [
  "digest 0.9.0",
  "generic-array 0.14.6",
  "hmac 0.8.1",
+]
+
+[[package]]
+name = "http"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
+dependencies = [
+ "bytes 1.2.1",
+ "fnv",
+ "itoa",
 ]
 
 [[package]]
@@ -1952,6 +1979,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "net2"
 version = "0.2.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2108,6 +2153,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
@@ -3636,6 +3687,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.36.1",
+]
+
+[[package]]
 name = "schnorrkel"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3704,6 +3765,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
 dependencies = [
  "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bc1bb97804af6631813c55739f771071e0f2ed33ee20b68c86ec505d906356c"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -3780,6 +3864,17 @@ dependencies = [
  "digest 0.8.1",
  "fake-simd",
  "opaque-debug 0.2.3",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest 0.10.5",
 ]
 
 [[package]]
@@ -4652,6 +4747,8 @@ dependencies = [
  "sp-std",
  "sp-version",
  "thiserror",
+ "tungstenite",
+ "url",
  "wabt",
  "ws",
 ]
@@ -4954,6 +5051,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e66dcbec4290c69dd03c57e76c2469ea5c7ce109c6dd4351c13055cf71ea055"
 
 [[package]]
+name = "tungstenite"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30ee6ab729cd4cf0fd55218530c4522ed30b7b6081752839b68fcec8d0960788"
+dependencies = [
+ "base64",
+ "byteorder",
+ "bytes 1.2.1",
+ "http",
+ "httparse",
+ "log",
+ "native-tls",
+ "rand 0.8.5",
+ "sha1",
+ "thiserror",
+ "url",
+ "utf-8",
+]
+
+[[package]]
 name = "twox-hash"
 version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5026,6 +5143,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "valuable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ primitive-types = { version = "0.12.1", optional = true, features = ["codec"] }
 serde = { version = "1.0.136", optional = true, features = ["derive"] }
 serde_json = { version = "1.0.79", optional = true }
 thiserror = { version = "1.0.30", optional = true }
+tungstenite = { version = "0.18.0", optional = true, features = ["native-tls"] }
+url = { verson = "2.0.0", optional = true }
 ws = { version = "0.9.2", optional = true, features = ["ssl"] }
 
 # Substrate dependencies
@@ -65,6 +67,7 @@ std = [
     "serde/std",
     "serde_json",
     "thiserror",
+    "url",
     # substrate
     "frame-metadata/std",
     "frame-support/std",
@@ -82,5 +85,6 @@ std = [
     "ac-node-api/std",
     "ac-primitives/std",
 ]
+tungstenite-client = ["tungstenite"]
 ws-client = ["ws"]
 staking-xt = ["std", "pallet-staking"]

--- a/examples/benchmark_bulk_xt.rs
+++ b/examples/benchmark_bulk_xt.rs
@@ -40,7 +40,7 @@ fn main() {
 	let client = WsRpcClient::new("ws://127.0.0.1:9944");
 
 	#[cfg(feature = "tungstenite-client")]
-	let client = TungsteniteRpcClient::new("ws://127.0.0.1:9944", 100);
+	let client = TungsteniteRpcClient::new(url::Url::parse("ws://127.0.0.1:9944").unwrap(), 100);
 
 	let mut api = Api::<_, _, AssetTipExtrinsicParams<Runtime>, Runtime>::new(client).unwrap();
 	api.set_signer(from);

--- a/examples/benchmark_bulk_xt.rs
+++ b/examples/benchmark_bulk_xt.rs
@@ -19,10 +19,16 @@
 // > substrate-test-node --dev --execution native --ws-port 9979 -ltxpool=debug
 
 use kitchensink_runtime::{BalancesCall, RuntimeCall};
+
+#[cfg(feature = "ws-client")]
+use substrate_api_client::rpc::WsRpcClient;
+
+#[cfg(feature = "tungstenite-client")]
+use substrate_api_client::rpc::TungsteniteRpcClient;
+
 use sp_keyring::AccountKeyring;
 use substrate_api_client::{
-	compose_extrinsic_offline, rpc::WsRpcClient, Api, AssetTipExtrinsicParams,
-	UncheckedExtrinsicV4, XtStatus,
+	compose_extrinsic_offline, Api, AssetTipExtrinsicParams, UncheckedExtrinsicV4, XtStatus,
 };
 
 fn main() {
@@ -30,7 +36,13 @@ fn main() {
 
 	// initialize api and set the signer (sender) that is used to sign the extrinsics
 	let from = AccountKeyring::Alice.pair();
+
+	#[cfg(feature = "ws-client")]
 	let client = WsRpcClient::new("ws://127.0.0.1:9944");
+
+	#[cfg(feature = "tungstenite-client")]
+	let client = TungsteniteRpcClient::new("ws://127.0.0.1:9944", 100);
+
 	let mut api = Api::<_, _, AssetTipExtrinsicParams>::new(client).unwrap();
 	api.set_signer(from);
 

--- a/examples/benchmark_bulk_xt.rs
+++ b/examples/benchmark_bulk_xt.rs
@@ -18,11 +18,16 @@
 // run this against test node with
 // > substrate-test-node --dev --execution native --ws-port 9979 -ltxpool=debug
 
+#[cfg(feature = "ws-client")]
+use substrate_api_client::rpc::WsRpcClient;
+
+#[cfg(feature = "tungstenite-client")]
+use substrate_api_client::rpc::TungsteniteRpcClient;
+
 use kitchensink_runtime::{BalancesCall, Runtime, RuntimeCall};
 use sp_keyring::AccountKeyring;
 use substrate_api_client::{
-	compose_extrinsic_offline, rpc::WsRpcClient, Api, AssetTipExtrinsicParams,
-	UncheckedExtrinsicV4, XtStatus,
+	compose_extrinsic_offline, Api, AssetTipExtrinsicParams, UncheckedExtrinsicV4, XtStatus,
 };
 
 fn main() {
@@ -30,7 +35,13 @@ fn main() {
 
 	// initialize api and set the signer (sender) that is used to sign the extrinsics
 	let from = AccountKeyring::Alice.pair();
+
+	#[cfg(feature = "ws-client")]
 	let client = WsRpcClient::new("ws://127.0.0.1:9944");
+
+	#[cfg(feature = "tungstenite-client")]
+	let client = TungsteniteRpcClient::new("ws://127.0.0.1:9944", 100);
+
 	let mut api = Api::<_, _, AssetTipExtrinsicParams<Runtime>, Runtime>::new(client).unwrap();
 	api.set_signer(from);
 

--- a/examples/compose_extrinsic_offline.rs
+++ b/examples/compose_extrinsic_offline.rs
@@ -20,9 +20,15 @@ use ac_primitives::AssetTipExtrinsicParamsBuilder;
 use kitchensink_runtime::{BalancesCall, Header, Runtime, RuntimeCall};
 use sp_keyring::AccountKeyring;
 use sp_runtime::{generic::Era, MultiAddress};
+
+#[cfg(feature = "ws-client")]
+use substrate_api_client::rpc::WsRpcClient;
+
+#[cfg(feature = "tungstenite-client")]
+use substrate_api_client::rpc::TungsteniteRpcClient;
+
 use substrate_api_client::{
-	compose_extrinsic_offline, rpc::WsRpcClient, Api, AssetTipExtrinsicParams,
-	UncheckedExtrinsicV4, XtStatus,
+	compose_extrinsic_offline, Api, AssetTipExtrinsicParams, UncheckedExtrinsicV4, XtStatus,
 };
 
 fn main() {
@@ -30,7 +36,11 @@ fn main() {
 
 	// Initialize api and set the signer (sender) that is used to sign the extrinsics.
 	let from = AccountKeyring::Alice.pair();
+	#[cfg(feature = "ws-client")]
 	let client = WsRpcClient::new("ws://127.0.0.1:9944");
+
+	#[cfg(feature = "tungstenite-client")]
+	let client = TungsteniteRpcClient::new("ws://127.0.0.1:9944", 100);
 
 	let mut api = Api::<_, _, AssetTipExtrinsicParams<Runtime>, Runtime>::new(client).unwrap();
 	api.set_signer(from);

--- a/examples/compose_extrinsic_offline.rs
+++ b/examples/compose_extrinsic_offline.rs
@@ -20,9 +20,15 @@ use ac_primitives::AssetTipExtrinsicParamsBuilder;
 use kitchensink_runtime::{BalancesCall, Header, RuntimeCall};
 use sp_keyring::AccountKeyring;
 use sp_runtime::{generic::Era, MultiAddress};
+
+#[cfg(feature = "ws-client")]
+use substrate_api_client::rpc::WsRpcClient;
+
+#[cfg(feature = "tungstenite-client")]
+use substrate_api_client::rpc::TungsteniteRpcClient;
+
 use substrate_api_client::{
-	compose_extrinsic_offline, rpc::WsRpcClient, Api, AssetTipExtrinsicParams,
-	UncheckedExtrinsicV4, XtStatus,
+	compose_extrinsic_offline, Api, AssetTipExtrinsicParams, UncheckedExtrinsicV4, XtStatus,
 };
 
 fn main() {
@@ -30,7 +36,12 @@ fn main() {
 
 	// Initialize api and set the signer (sender) that is used to sign the extrinsics.
 	let from = AccountKeyring::Alice.pair();
+
+	#[cfg(feature = "ws-client")]
 	let client = WsRpcClient::new("ws://127.0.0.1:9944");
+
+	#[cfg(feature = "tungstenite-client")]
+	let client = TungsteniteRpcClient::new("ws://127.0.0.1:9944", 100);
 
 	let mut api = Api::<_, _, AssetTipExtrinsicParams>::new(client).unwrap();
 	api.set_signer(from);

--- a/examples/compose_extrinsic_offline.rs
+++ b/examples/compose_extrinsic_offline.rs
@@ -40,7 +40,7 @@ fn main() {
 	let client = WsRpcClient::new("ws://127.0.0.1:9944");
 
 	#[cfg(feature = "tungstenite-client")]
-	let client = TungsteniteRpcClient::new("ws://127.0.0.1:9944", 100);
+	let client = TungsteniteRpcClient::new(url::Url::parse("ws://127.0.0.1:9944").unwrap(), 100);
 
 	let mut api = Api::<_, _, AssetTipExtrinsicParams<Runtime>, Runtime>::new(client).unwrap();
 	api.set_signer(from);

--- a/examples/custom_nonce.rs
+++ b/examples/custom_nonce.rs
@@ -20,9 +20,15 @@ use ac_primitives::AssetTipExtrinsicParamsBuilder;
 use kitchensink_runtime::{BalancesCall, Header, RuntimeCall};
 use sp_keyring::AccountKeyring;
 use sp_runtime::{generic::Era, MultiAddress};
+
+#[cfg(feature = "ws-client")]
+use substrate_api_client::rpc::WsRpcClient;
+
+#[cfg(feature = "tungstenite-client")]
+use substrate_api_client::rpc::TungsteniteRpcClient;
+
 use substrate_api_client::{
-	compose_extrinsic_offline, rpc::WsRpcClient, Api, AssetTipExtrinsicParams,
-	UncheckedExtrinsicV4, XtStatus,
+	compose_extrinsic_offline, Api, AssetTipExtrinsicParams, UncheckedExtrinsicV4, XtStatus,
 };
 
 fn main() {
@@ -30,7 +36,12 @@ fn main() {
 
 	// Initialize api and set the signer (sender) that is used to sign the extrinsics.
 	let from = AccountKeyring::Alice.pair();
+
+	#[cfg(feature = "ws-client")]
 	let client = WsRpcClient::new("ws://127.0.0.1:9944");
+
+	#[cfg(feature = "tungstenite-client")]
+	let client = TungsteniteRpcClient::new("ws://127.0.0.1:9944", 100);
 
 	let mut api = Api::<_, _, AssetTipExtrinsicParams>::new(client).unwrap();
 	api.set_signer(from);

--- a/examples/custom_nonce.rs
+++ b/examples/custom_nonce.rs
@@ -20,9 +20,15 @@ use ac_primitives::AssetTipExtrinsicParamsBuilder;
 use kitchensink_runtime::{BalancesCall, Header, Runtime, RuntimeCall};
 use sp_keyring::AccountKeyring;
 use sp_runtime::{generic::Era, MultiAddress};
+
+#[cfg(feature = "ws-client")]
+use substrate_api_client::rpc::WsRpcClient;
+
+#[cfg(feature = "tungstenite-client")]
+use substrate_api_client::rpc::TungsteniteRpcClient;
+
 use substrate_api_client::{
-	compose_extrinsic_offline, rpc::WsRpcClient, Api, AssetTipExtrinsicParams,
-	UncheckedExtrinsicV4, XtStatus,
+	compose_extrinsic_offline, Api, AssetTipExtrinsicParams, UncheckedExtrinsicV4, XtStatus,
 };
 
 fn main() {
@@ -30,7 +36,12 @@ fn main() {
 
 	// Initialize api and set the signer (sender) that is used to sign the extrinsics.
 	let from = AccountKeyring::Alice.pair();
+
+	#[cfg(feature = "ws-client")]
 	let client = WsRpcClient::new("ws://127.0.0.1:9944");
+
+	#[cfg(feature = "tungstenite-client")]
+	let client = TungsteniteRpcClient::new("ws://127.0.0.1:9944", 100);
 
 	let mut api = Api::<_, _, AssetTipExtrinsicParams<Runtime>, Runtime>::new(client).unwrap();
 	api.set_signer(from);

--- a/examples/custom_nonce.rs
+++ b/examples/custom_nonce.rs
@@ -41,7 +41,7 @@ fn main() {
 	let client = WsRpcClient::new("ws://127.0.0.1:9944");
 
 	#[cfg(feature = "tungstenite-client")]
-	let client = TungsteniteRpcClient::new("ws://127.0.0.1:9944", 100);
+	let client = TungsteniteRpcClient::new(url::Url::parse("ws://127.0.0.1:9944").unwrap(), 100);
 
 	let mut api = Api::<_, _, AssetTipExtrinsicParams<Runtime>, Runtime>::new(client).unwrap();
 	api.set_signer(from);

--- a/examples/event_callback.rs
+++ b/examples/event_callback.rs
@@ -26,12 +26,23 @@ use std::sync::mpsc::channel;
 // Replace this crate by your own if you run a custom substrate node to get your custom events.
 use kitchensink_runtime::RuntimeEvent;
 
-use substrate_api_client::{rpc::WsRpcClient, utils::FromHexString, Api, AssetTipExtrinsicParams};
+#[cfg(feature = "ws-client")]
+use substrate_api_client::rpc::WsRpcClient;
+
+#[cfg(feature = "tungstenite-client")]
+use substrate_api_client::rpc::TungsteniteRpcClient;
+
+use substrate_api_client::{utils::FromHexString, Api, AssetTipExtrinsicParams};
 
 fn main() {
 	env_logger::init();
 
+	#[cfg(feature = "ws-client")]
 	let client = WsRpcClient::new("ws://127.0.0.1:9944");
+
+	#[cfg(feature = "tungstenite-client")]
+	let client = TungsteniteRpcClient::new("ws://127.0.0.1:9944", 100);
+
 	let api =
 		Api::<sr25519::Pair, _, AssetTipExtrinsicParams<Runtime>, Runtime>::new(client).unwrap();
 

--- a/examples/event_callback.rs
+++ b/examples/event_callback.rs
@@ -41,7 +41,7 @@ fn main() {
 	let client = WsRpcClient::new("ws://127.0.0.1:9944");
 
 	#[cfg(feature = "tungstenite-client")]
-	let client = TungsteniteRpcClient::new("ws://127.0.0.1:9944", 100);
+	let client = TungsteniteRpcClient::new(url::Url::parse("ws://127.0.0.1:9944").unwrap(), 100);
 
 	let api =
 		Api::<sr25519::Pair, _, AssetTipExtrinsicParams<Runtime>, Runtime>::new(client).unwrap();

--- a/examples/event_callback.rs
+++ b/examples/event_callback.rs
@@ -25,12 +25,23 @@ use sp_core::{sr25519, H256 as Hash};
 // Replace this crate by your own if you run a custom substrate node to get your custom events.
 use kitchensink_runtime::RuntimeEvent;
 
-use substrate_api_client::{rpc::WsRpcClient, utils::FromHexString, Api, AssetTipExtrinsicParams};
+#[cfg(feature = "ws-client")]
+use substrate_api_client::rpc::WsRpcClient;
+
+#[cfg(feature = "tungstenite-client")]
+use substrate_api_client::rpc::TungsteniteRpcClient;
+
+use substrate_api_client::{subscription, utils::FromHexString, Api, AssetTipExtrinsicParams};
 
 fn main() {
 	env_logger::init();
 
+	#[cfg(feature = "ws-client")]
 	let client = WsRpcClient::new("ws://127.0.0.1:9944");
+
+	#[cfg(feature = "tungstenite-client")]
+	let client = TungsteniteRpcClient::new("ws://127.0.0.1:9944", 100);
+
 	let api = Api::<sr25519::Pair, _, AssetTipExtrinsicParams>::new(client).unwrap();
 
 	println!("Subscribe to events");

--- a/examples/event_callback.rs
+++ b/examples/event_callback.rs
@@ -31,7 +31,7 @@ use substrate_api_client::rpc::WsRpcClient;
 #[cfg(feature = "tungstenite-client")]
 use substrate_api_client::rpc::TungsteniteRpcClient;
 
-use substrate_api_client::{subscription, utils::FromHexString, Api, AssetTipExtrinsicParams};
+use substrate_api_client::{utils::FromHexString, Api, AssetTipExtrinsicParams};
 
 fn main() {
 	env_logger::init();

--- a/examples/event_error_details.rs
+++ b/examples/event_error_details.rs
@@ -18,9 +18,14 @@ use sp_core::crypto::Pair;
 use sp_keyring::AccountKeyring;
 use sp_runtime::{AccountId32 as AccountId, MultiAddress};
 use std::sync::mpsc::channel;
-use substrate_api_client::{
-	rpc::WsRpcClient, Api, ApiResult, AssetTipExtrinsicParams, StaticEvent, XtStatus,
-};
+
+#[cfg(feature = "ws-client")]
+use substrate_api_client::rpc::WsRpcClient;
+
+#[cfg(feature = "tungstenite-client")]
+use substrate_api_client::rpc::TungsteniteRpcClient;
+
+use substrate_api_client::{Api, ApiResult, AssetTipExtrinsicParams, StaticEvent, XtStatus};
 
 // Look at the how the transfer event looks like in in the metadata
 #[derive(Decode)]
@@ -41,7 +46,12 @@ fn main() {
 	// initialize api and set the signer (sender) that is used to sign the extrinsics
 	let from = AccountKeyring::Alice.pair();
 
+	#[cfg(feature = "ws-client")]
 	let client = WsRpcClient::new("ws://127.0.0.1:9944");
+
+	#[cfg(feature = "tungstenite-client")]
+	let client = TungsteniteRpcClient::new("ws://127.0.0.1:9944", 100);
+
 	let mut api = Api::<_, _, AssetTipExtrinsicParams>::new(client).unwrap();
 	api.set_signer(from.clone());
 

--- a/examples/event_error_details.rs
+++ b/examples/event_error_details.rs
@@ -51,7 +51,7 @@ fn main() {
 	let client = WsRpcClient::new("ws://127.0.0.1:9944");
 
 	#[cfg(feature = "tungstenite-client")]
-	let client = TungsteniteRpcClient::new("ws://127.0.0.1:9944", 100);
+	let client = TungsteniteRpcClient::new(url::Url::parse("ws://127.0.0.1:9944").unwrap(), 100);
 
 	let mut api = Api::<_, _, AssetTipExtrinsicParams<Runtime>, Runtime>::new(client).unwrap();
 	api.set_signer(from.clone());

--- a/examples/event_error_details.rs
+++ b/examples/event_error_details.rs
@@ -19,9 +19,14 @@ use sp_core::crypto::Pair;
 use sp_keyring::AccountKeyring;
 use sp_runtime::{AccountId32 as AccountId, MultiAddress};
 use std::sync::mpsc::channel;
-use substrate_api_client::{
-	rpc::WsRpcClient, Api, ApiResult, AssetTipExtrinsicParams, StaticEvent, XtStatus,
-};
+
+#[cfg(feature = "ws-client")]
+use substrate_api_client::rpc::WsRpcClient;
+
+#[cfg(feature = "tungstenite-client")]
+use substrate_api_client::rpc::TungsteniteRpcClient;
+
+use substrate_api_client::{Api, ApiResult, AssetTipExtrinsicParams, StaticEvent, XtStatus};
 
 // Look at the how the transfer event looks like in in the metadata
 #[derive(Decode)]
@@ -42,7 +47,12 @@ fn main() {
 	// initialize api and set the signer (sender) that is used to sign the extrinsics
 	let from = AccountKeyring::Alice.pair();
 
+	#[cfg(feature = "ws-client")]
 	let client = WsRpcClient::new("ws://127.0.0.1:9944");
+
+	#[cfg(feature = "tungstenite-client")]
+	let client = TungsteniteRpcClient::new("ws://127.0.0.1:9944", 100);
+
 	let mut api = Api::<_, _, AssetTipExtrinsicParams<Runtime>, Runtime>::new(client).unwrap();
 	api.set_signer(from.clone());
 

--- a/examples/generic_event_callback.rs
+++ b/examples/generic_event_callback.rs
@@ -20,7 +20,14 @@ use codec::Decode;
 use sp_keyring::AccountKeyring;
 use sp_runtime::{AccountId32 as AccountId, MultiAddress};
 use std::{sync::mpsc::channel, thread};
-use substrate_api_client::{rpc::WsRpcClient, Api, AssetTipExtrinsicParams, StaticEvent, XtStatus};
+
+#[cfg(feature = "ws-client")]
+use substrate_api_client::rpc::WsRpcClient;
+
+#[cfg(feature = "tungstenite-client")]
+use substrate_api_client::rpc::TungsteniteRpcClient;
+
+use substrate_api_client::{Api, AssetTipExtrinsicParams, StaticEvent, XtStatus};
 
 // Look at the how the transfer event looks like in in the metadata
 #[derive(Decode)]
@@ -40,7 +47,13 @@ fn main() {
 
 	// Initialize api and set the signer (sender) that is used to sign the extrinsics.
 	let alice = AccountKeyring::Alice.pair();
+
+	#[cfg(feature = "ws-client")]
 	let client = WsRpcClient::new("ws://127.0.0.1:9944");
+
+	#[cfg(feature = "tungstenite-client")]
+	let client = TungsteniteRpcClient::new("ws://127.0.0.1:9944", 100);
+
 	let mut api = Api::<_, _, AssetTipExtrinsicParams>::new(client).unwrap();
 	api.set_signer(alice);
 

--- a/examples/generic_event_callback.rs
+++ b/examples/generic_event_callback.rs
@@ -53,7 +53,7 @@ fn main() {
 	let client = WsRpcClient::new("ws://127.0.0.1:9944");
 
 	#[cfg(feature = "tungstenite-client")]
-	let client = TungsteniteRpcClient::new("ws://127.0.0.1:9944", 100);
+	let client = TungsteniteRpcClient::new(url::Url::parse("ws://127.0.0.1:9944").unwrap(), 100);
 
 	let mut api = Api::<_, _, AssetTipExtrinsicParams<Runtime>, Runtime>::new(client).unwrap();
 	api.set_signer(alice);

--- a/examples/generic_event_callback.rs
+++ b/examples/generic_event_callback.rs
@@ -21,7 +21,14 @@ use kitchensink_runtime::Runtime;
 use sp_keyring::AccountKeyring;
 use sp_runtime::{AccountId32 as AccountId, MultiAddress};
 use std::{sync::mpsc::channel, thread};
-use substrate_api_client::{rpc::WsRpcClient, Api, AssetTipExtrinsicParams, StaticEvent, XtStatus};
+
+#[cfg(feature = "ws-client")]
+use substrate_api_client::rpc::WsRpcClient;
+
+#[cfg(feature = "tungstenite-client")]
+use substrate_api_client::rpc::TungsteniteRpcClient;
+
+use substrate_api_client::{Api, AssetTipExtrinsicParams, StaticEvent, XtStatus};
 
 // Look at the how the transfer event looks like in in the metadata
 #[derive(Decode)]
@@ -41,7 +48,13 @@ fn main() {
 
 	// Initialize api and set the signer (sender) that is used to sign the extrinsics.
 	let alice = AccountKeyring::Alice.pair();
+
+	#[cfg(feature = "ws-client")]
 	let client = WsRpcClient::new("ws://127.0.0.1:9944");
+
+	#[cfg(feature = "tungstenite-client")]
+	let client = TungsteniteRpcClient::new("ws://127.0.0.1:9944", 100);
+
 	let mut api = Api::<_, _, AssetTipExtrinsicParams<Runtime>, Runtime>::new(client).unwrap();
 	api.set_signer(alice);
 

--- a/examples/generic_extrinsic.rs
+++ b/examples/generic_extrinsic.rs
@@ -17,9 +17,15 @@
 //! module, whereas the desired module and call are supplied as a string.
 
 use sp_keyring::AccountKeyring;
+
+#[cfg(feature = "ws-client")]
+use substrate_api_client::rpc::WsRpcClient;
+
+#[cfg(feature = "tungstenite-client")]
+use substrate_api_client::rpc::TungsteniteRpcClient;
+
 use substrate_api_client::{
-	compose_extrinsic, rpc::WsRpcClient, Api, AssetTipExtrinsicParams, GenericAddress,
-	UncheckedExtrinsicV4, XtStatus,
+	compose_extrinsic, Api, AssetTipExtrinsicParams, GenericAddress, UncheckedExtrinsicV4, XtStatus,
 };
 
 fn main() {
@@ -27,7 +33,13 @@ fn main() {
 
 	// initialize api and set the signer (sender) that is used to sign the extrinsics
 	let from = AccountKeyring::Alice.pair();
+
+	#[cfg(feature = "ws-client")]
 	let client = WsRpcClient::new("ws://127.0.0.1:9944");
+
+	#[cfg(feature = "tungstenite-client")]
+	let client = TungsteniteRpcClient::new("ws://127.0.0.1:9944", 100);
+
 	let mut api = Api::<_, _, AssetTipExtrinsicParams>::new(client).unwrap();
 	api.set_signer(from);
 	// set the recipient

--- a/examples/generic_extrinsic.rs
+++ b/examples/generic_extrinsic.rs
@@ -18,9 +18,15 @@
 
 use kitchensink_runtime::Runtime;
 use sp_keyring::AccountKeyring;
+
+#[cfg(feature = "ws-client")]
+use substrate_api_client::rpc::WsRpcClient;
+
+#[cfg(feature = "tungstenite-client")]
+use substrate_api_client::rpc::TungsteniteRpcClient;
+
 use substrate_api_client::{
-	compose_extrinsic, rpc::WsRpcClient, Api, AssetTipExtrinsicParams, GenericAddress,
-	UncheckedExtrinsicV4, XtStatus,
+	compose_extrinsic, Api, AssetTipExtrinsicParams, GenericAddress, UncheckedExtrinsicV4, XtStatus,
 };
 
 fn main() {
@@ -28,7 +34,13 @@ fn main() {
 
 	// initialize api and set the signer (sender) that is used to sign the extrinsics
 	let from = AccountKeyring::Alice.pair();
+
+	#[cfg(feature = "ws-client")]
 	let client = WsRpcClient::new("ws://127.0.0.1:9944");
+
+	#[cfg(feature = "tungstenite-client")]
+	let client = TungsteniteRpcClient::new("ws://127.0.0.1:9944", 100);
+
 	let mut api = Api::<_, _, AssetTipExtrinsicParams<Runtime>, Runtime>::new(client).unwrap();
 	api.set_signer(from);
 	// set the recipient

--- a/examples/generic_extrinsic.rs
+++ b/examples/generic_extrinsic.rs
@@ -39,7 +39,7 @@ fn main() {
 	let client = WsRpcClient::new("ws://127.0.0.1:9944");
 
 	#[cfg(feature = "tungstenite-client")]
-	let client = TungsteniteRpcClient::new("ws://127.0.0.1:9944", 100);
+	let client = TungsteniteRpcClient::new(url::Url::parse("ws://127.0.0.1:9944").unwrap(), 100);
 
 	let mut api = Api::<_, _, AssetTipExtrinsicParams<Runtime>, Runtime>::new(client).unwrap();
 	api.set_signer(from);
@@ -60,6 +60,6 @@ fn main() {
 	println!("[+] Composed Extrinsic:\n {:?}\n", xt);
 
 	// send and watch extrinsic until InBlock
-	let tx_hash = api.send_extrinsic(xt.hex_encode(), XtStatus::InBlock).unwrap();
+	let tx_hash = api.send_extrinsic(xt.hex_encode(), XtStatus::Finalized).unwrap();
 	println!("[+] Transaction got included. Hash: {:?}", tx_hash);
 }

--- a/examples/get_account_identity.rs
+++ b/examples/get_account_identity.rs
@@ -45,7 +45,7 @@ fn main() {
 	let client = WsRpcClient::new("ws://127.0.0.1:9944");
 
 	#[cfg(feature = "tungstenite-client")]
-	let client = TungsteniteRpcClient::new("ws://127.0.0.1:9944", 100);
+	let client = TungsteniteRpcClient::new(url::Url::parse("ws://127.0.0.1:9944").unwrap(), 100);
 
 	let alice = AccountKeyring::Alice.pair();
 	let mut api =

--- a/examples/get_account_identity.rs
+++ b/examples/get_account_identity.rs
@@ -20,9 +20,15 @@ use kitchensink_runtime::Runtime as KitchensinkRuntime;
 use pallet_identity::{Data, IdentityInfo, Registration};
 use sp_core::{crypto::Pair, H256};
 use sp_keyring::AccountKeyring;
+
+#[cfg(feature = "ws-client")]
+use substrate_api_client::rpc::WsRpcClient;
+
+#[cfg(feature = "tungstenite-client")]
+use substrate_api_client::rpc::TungsteniteRpcClient;
+
 use substrate_api_client::{
-	compose_extrinsic, rpc::WsRpcClient, Api, AssetTipExtrinsicParams, UncheckedExtrinsicV4,
-	XtStatus,
+	compose_extrinsic, Api, AssetTipExtrinsicParams, UncheckedExtrinsicV4, XtStatus,
 };
 
 type BalanceOf<T> = <<T as pallet_identity::Config>::Currency as Currency<
@@ -35,7 +41,12 @@ fn main() {
 	env_logger::init();
 
 	// Create the node-api client and set the signer.
+	#[cfg(feature = "ws-client")]
 	let client = WsRpcClient::new("ws://127.0.0.1:9944");
+
+	#[cfg(feature = "tungstenite-client")]
+	let client = TungsteniteRpcClient::new("ws://127.0.0.1:9944", 100);
+
 	let alice = AccountKeyring::Alice.pair();
 	let mut api = Api::<_, _, AssetTipExtrinsicParams>::new(client).unwrap();
 	api.set_signer(alice.clone());

--- a/examples/get_blocks.rs
+++ b/examples/get_blocks.rs
@@ -20,14 +20,26 @@ use kitchensink_runtime::{Block, Header, Runtime};
 use sp_core::sr25519;
 use sp_runtime::generic::SignedBlock as SignedBlockG;
 use std::sync::mpsc::channel;
-use substrate_api_client::{rpc::WsRpcClient, Api, AssetTipExtrinsicParams};
+
+#[cfg(feature = "ws-client")]
+use substrate_api_client::rpc::WsRpcClient;
+
+#[cfg(feature = "tungstenite-client")]
+use substrate_api_client::rpc::TungsteniteRpcClient;
+
+use substrate_api_client::{Api, AssetTipExtrinsicParams};
 
 type SignedBlock = SignedBlockG<Block>;
 
 fn main() {
 	env_logger::init();
 
+	#[cfg(feature = "ws-client")]
 	let client = WsRpcClient::new("ws://127.0.0.1:9944");
+
+	#[cfg(feature = "tungstenite-client")]
+	let client = TungsteniteRpcClient::new("ws://127.0.0.1:9944", 100);
+
 	let api =
 		Api::<sr25519::Pair, _, AssetTipExtrinsicParams<Runtime>, Runtime>::new(client).unwrap();
 

--- a/examples/get_blocks.rs
+++ b/examples/get_blocks.rs
@@ -38,7 +38,7 @@ fn main() {
 	let client = WsRpcClient::new("ws://127.0.0.1:9944");
 
 	#[cfg(feature = "tungstenite-client")]
-	let client = TungsteniteRpcClient::new("ws://127.0.0.1:9944", 100);
+	let client = TungsteniteRpcClient::new(url::Url::parse("ws://127.0.0.1:9944").unwrap(), 100);
 
 	let api =
 		Api::<sr25519::Pair, _, AssetTipExtrinsicParams<Runtime>, Runtime>::new(client).unwrap();
@@ -63,7 +63,7 @@ fn main() {
 	let (sender, receiver) = channel();
 	api.subscribe_finalized_heads(sender).unwrap();
 
-	for _ in 0..5 {
+	for _ in 0..10 {
 		let head: Header =
 			receiver.recv().map(|header| serde_json::from_str(&header).unwrap()).unwrap();
 		println!("Got new Block {:?}", head);

--- a/examples/get_blocks.rs
+++ b/examples/get_blocks.rs
@@ -20,14 +20,26 @@ use kitchensink_runtime::{Block, Header};
 use sp_core::sr25519;
 use sp_runtime::generic::SignedBlock as SignedBlockG;
 use std::sync::mpsc::channel;
-use substrate_api_client::{rpc::WsRpcClient, Api, AssetTipExtrinsicParams};
+
+#[cfg(feature = "ws-client")]
+use substrate_api_client::rpc::WsRpcClient;
+
+#[cfg(feature = "tungstenite-client")]
+use substrate_api_client::rpc::TungsteniteRpcClient;
+
+use substrate_api_client::{Api, AssetTipExtrinsicParams};
 
 type SignedBlock = SignedBlockG<Block>;
 
 fn main() {
 	env_logger::init();
 
+	#[cfg(feature = "ws-client")]
 	let client = WsRpcClient::new("ws://127.0.0.1:9944");
+
+	#[cfg(feature = "tungstenite-client")]
+	let client = TungsteniteRpcClient::new("ws://127.0.0.1:9944", 100);
+
 	let api = Api::<sr25519::Pair, _, AssetTipExtrinsicParams>::new(client).unwrap();
 
 	let head = api.get_finalized_head().unwrap().unwrap();

--- a/examples/get_existential_deposit.rs
+++ b/examples/get_existential_deposit.rs
@@ -15,12 +15,23 @@ limitations under the License.
 
 ///! Very simple example that shows how to get some simple storage values.
 use sp_runtime::app_crypto::sp_core::sr25519;
-use substrate_api_client::{rpc::WsRpcClient, Api, AssetTipExtrinsicParams};
+
+#[cfg(feature = "ws-client")]
+use substrate_api_client::rpc::WsRpcClient;
+
+#[cfg(feature = "tungstenite-client")]
+use substrate_api_client::rpc::TungsteniteRpcClient;
+use substrate_api_client::{Api, AssetTipExtrinsicParams};
 
 fn main() {
 	env_logger::init();
 
+	#[cfg(feature = "ws-client")]
 	let client = WsRpcClient::new("ws://127.0.0.1:9944");
+
+	#[cfg(feature = "tungstenite-client")]
+	let client = TungsteniteRpcClient::new("ws://127.0.0.1:9944", 100);
+
 	let api = Api::<sr25519::Pair, _, AssetTipExtrinsicParams>::new(client).unwrap();
 
 	// get existential deposit

--- a/examples/get_existential_deposit.rs
+++ b/examples/get_existential_deposit.rs
@@ -33,7 +33,7 @@ fn main() {
 	let client = WsRpcClient::new("ws://127.0.0.1:9944");
 
 	#[cfg(feature = "tungstenite-client")]
-	let client = TungsteniteRpcClient::new("ws://127.0.0.1:9944", 100);
+	let client = TungsteniteRpcClient::new(url::Url::parse("ws://127.0.0.1:9944").unwrap(), 100);
 
 	let api =
 		Api::<sr25519::Pair, _, AssetTipExtrinsicParams<Runtime>, Runtime>::new(client).unwrap();

--- a/examples/get_existential_deposit.rs
+++ b/examples/get_existential_deposit.rs
@@ -17,12 +17,24 @@ limitations under the License.
 
 use kitchensink_runtime::Runtime;
 use sp_runtime::app_crypto::sp_core::sr25519;
-use substrate_api_client::{rpc::WsRpcClient, Api, AssetTipExtrinsicParams};
+
+#[cfg(feature = "ws-client")]
+use substrate_api_client::rpc::WsRpcClient;
+
+#[cfg(feature = "tungstenite-client")]
+use substrate_api_client::rpc::TungsteniteRpcClient;
+
+use substrate_api_client::{Api, AssetTipExtrinsicParams};
 
 fn main() {
 	env_logger::init();
 
+	#[cfg(feature = "ws-client")]
 	let client = WsRpcClient::new("ws://127.0.0.1:9944");
+
+	#[cfg(feature = "tungstenite-client")]
+	let client = TungsteniteRpcClient::new("ws://127.0.0.1:9944", 100);
+
 	let api =
 		Api::<sr25519::Pair, _, AssetTipExtrinsicParams<Runtime>, Runtime>::new(client).unwrap();
 

--- a/examples/get_storage.rs
+++ b/examples/get_storage.rs
@@ -39,7 +39,7 @@ fn main() {
 	let client = WsRpcClient::new("ws://127.0.0.1:9944");
 
 	#[cfg(feature = "tungstenite-client")]
-	let client = TungsteniteRpcClient::new("ws://127.0.0.1:9944", 100);
+	let client = TungsteniteRpcClient::new(url::Url::parse("ws://127.0.0.1:9944").unwrap(), 100);
 
 	let mut api = Api::<_, _, AssetTipExtrinsicParams<Runtime>, Runtime>::new(client).unwrap();
 

--- a/examples/get_storage.rs
+++ b/examples/get_storage.rs
@@ -18,7 +18,14 @@
 use frame_system::AccountInfo as GenericAccountInfo;
 use kitchensink_runtime::Runtime;
 use sp_keyring::AccountKeyring;
-use substrate_api_client::{rpc::WsRpcClient, Api, AssetTipExtrinsicParams};
+
+#[cfg(feature = "ws-client")]
+use substrate_api_client::rpc::WsRpcClient;
+
+#[cfg(feature = "tungstenite-client")]
+use substrate_api_client::rpc::TungsteniteRpcClient;
+
+use substrate_api_client::{Api, AssetTipExtrinsicParams};
 
 type IndexFor<T> = <T as frame_system::Config>::Index;
 type AccountDataFor<T> = <T as frame_system::Config>::AccountData;
@@ -28,7 +35,12 @@ type AccountInfo = GenericAccountInfo<IndexFor<Runtime>, AccountDataFor<Runtime>
 fn main() {
 	env_logger::init();
 
+	#[cfg(feature = "ws-client")]
 	let client = WsRpcClient::new("ws://127.0.0.1:9944");
+
+	#[cfg(feature = "tungstenite-client")]
+	let client = TungsteniteRpcClient::new("ws://127.0.0.1:9944", 100);
+
 	let mut api = Api::<_, _, AssetTipExtrinsicParams<Runtime>, Runtime>::new(client).unwrap();
 
 	// get some plain storage value

--- a/examples/get_storage.rs
+++ b/examples/get_storage.rs
@@ -15,12 +15,24 @@
 
 ///! Very simple example that shows how to get some simple storage values.
 use sp_keyring::AccountKeyring;
-use substrate_api_client::{rpc::WsRpcClient, AccountInfo, Api, AssetTipExtrinsicParams};
+
+#[cfg(feature = "ws-client")]
+use substrate_api_client::rpc::WsRpcClient;
+
+#[cfg(feature = "tungstenite-client")]
+use substrate_api_client::rpc::TungsteniteRpcClient;
+
+use substrate_api_client::{AccountInfo, Api, AssetTipExtrinsicParams};
 
 fn main() {
 	env_logger::init();
 
+	#[cfg(feature = "ws-client")]
 	let client = WsRpcClient::new("ws://127.0.0.1:9944");
+
+	#[cfg(feature = "tungstenite-client")]
+	let client = TungsteniteRpcClient::new("ws://127.0.0.1:9944", 100);
+
 	let mut api = Api::<_, _, AssetTipExtrinsicParams>::new(client).unwrap();
 
 	// get some plain storage value

--- a/examples/print_metadata.rs
+++ b/examples/print_metadata.rs
@@ -18,12 +18,24 @@
 
 use kitchensink_runtime::Runtime;
 use sp_core::sr25519;
-use substrate_api_client::{rpc::WsRpcClient, Api, AssetTipExtrinsicParams, Metadata};
+
+#[cfg(feature = "ws-client")]
+use substrate_api_client::rpc::WsRpcClient;
+
+#[cfg(feature = "tungstenite-client")]
+use substrate_api_client::rpc::TungsteniteRpcClient;
+
+use substrate_api_client::{Api, AssetTipExtrinsicParams, Metadata};
 
 fn main() {
 	env_logger::init();
 
+	#[cfg(feature = "ws-client")]
 	let client = WsRpcClient::new("ws://127.0.0.1:9944");
+
+	#[cfg(feature = "tungstenite-client")]
+	let client = TungsteniteRpcClient::new("ws://127.0.0.1:9944", 100);
+
 	let mut api =
 		Api::<sr25519::Pair, _, AssetTipExtrinsicParams<Runtime>, Runtime>::new(client).unwrap();
 

--- a/examples/print_metadata.rs
+++ b/examples/print_metadata.rs
@@ -17,12 +17,23 @@
 ///! debugging tool.
 use sp_core::sr25519;
 
-use substrate_api_client::{rpc::WsRpcClient, Api, AssetTipExtrinsicParams, Metadata};
+#[cfg(feature = "ws-client")]
+use substrate_api_client::rpc::WsRpcClient;
+
+#[cfg(feature = "tungstenite-client")]
+use substrate_api_client::rpc::TungsteniteRpcClient;
+
+use substrate_api_client::{Api, AssetTipExtrinsicParams, Metadata};
 
 fn main() {
 	env_logger::init();
 
+	#[cfg(feature = "ws-client")]
 	let client = WsRpcClient::new("ws://127.0.0.1:9944");
+
+	#[cfg(feature = "tungstenite-client")]
+	let client = TungsteniteRpcClient::new("ws://127.0.0.1:9944", 100);
+
 	let mut api = Api::<sr25519::Pair, _, AssetTipExtrinsicParams>::new(client).unwrap();
 
 	let meta = api.metadata().clone();

--- a/examples/print_metadata.rs
+++ b/examples/print_metadata.rs
@@ -34,7 +34,7 @@ fn main() {
 	let client = WsRpcClient::new("ws://127.0.0.1:9944");
 
 	#[cfg(feature = "tungstenite-client")]
-	let client = TungsteniteRpcClient::new("ws://127.0.0.1:9944", 100);
+	let client = TungsteniteRpcClient::new(url::Url::parse("ws://127.0.0.1:9944").unwrap(), 100);
 
 	let mut api =
 		Api::<sr25519::Pair, _, AssetTipExtrinsicParams<Runtime>, Runtime>::new(client).unwrap();

--- a/examples/sudo.rs
+++ b/examples/sudo.rs
@@ -18,9 +18,16 @@
 
 use codec::Compact;
 use sp_keyring::AccountKeyring;
+
+#[cfg(feature = "ws-client")]
+use substrate_api_client::rpc::WsRpcClient;
+
+#[cfg(feature = "tungstenite-client")]
+use substrate_api_client::rpc::TungsteniteRpcClient;
+
 use substrate_api_client::{
-	compose_call, compose_extrinsic, rpc::WsRpcClient, Api, AssetTipExtrinsicParams,
-	GenericAddress, UncheckedExtrinsicV4, XtStatus,
+	compose_call, compose_extrinsic, Api, AssetTipExtrinsicParams, GenericAddress,
+	UncheckedExtrinsicV4, XtStatus,
 };
 
 fn main() {
@@ -28,7 +35,13 @@ fn main() {
 
 	// initialize api and set the signer (sender) that is used to sign the extrinsics
 	let sudoer = AccountKeyring::Alice.pair();
+
+	#[cfg(feature = "ws-client")]
 	let client = WsRpcClient::new("ws://127.0.0.1:9944");
+
+	#[cfg(feature = "tungstenite-client")]
+	let client = TungsteniteRpcClient::new("ws://127.0.0.1:9944", 100);
+
 	let mut api = Api::<_, _, AssetTipExtrinsicParams>::new(client).unwrap();
 	api.set_signer(sudoer);
 

--- a/examples/sudo.rs
+++ b/examples/sudo.rs
@@ -19,9 +19,16 @@
 use codec::Compact;
 use kitchensink_runtime::Runtime;
 use sp_keyring::AccountKeyring;
+
+#[cfg(feature = "ws-client")]
+use substrate_api_client::rpc::WsRpcClient;
+
+#[cfg(feature = "tungstenite-client")]
+use substrate_api_client::rpc::TungsteniteRpcClient;
+
 use substrate_api_client::{
-	compose_call, compose_extrinsic, rpc::WsRpcClient, Api, AssetTipExtrinsicParams,
-	GenericAddress, UncheckedExtrinsicV4, XtStatus,
+	compose_call, compose_extrinsic, Api, AssetTipExtrinsicParams, GenericAddress,
+	UncheckedExtrinsicV4, XtStatus,
 };
 
 fn main() {
@@ -29,7 +36,12 @@ fn main() {
 
 	// initialize api and set the signer (sender) that is used to sign the extrinsics
 	let sudoer = AccountKeyring::Alice.pair();
+	#[cfg(feature = "ws-client")]
 	let client = WsRpcClient::new("ws://127.0.0.1:9944");
+
+	#[cfg(feature = "tungstenite-client")]
+	let client = TungsteniteRpcClient::new("ws://127.0.0.1:9944", 100);
+
 	let mut api = Api::<_, _, AssetTipExtrinsicParams<Runtime>, Runtime>::new(client).unwrap();
 	api.set_signer(sudoer);
 

--- a/examples/sudo.rs
+++ b/examples/sudo.rs
@@ -40,7 +40,7 @@ fn main() {
 	let client = WsRpcClient::new("ws://127.0.0.1:9944");
 
 	#[cfg(feature = "tungstenite-client")]
-	let client = TungsteniteRpcClient::new("ws://127.0.0.1:9944", 100);
+	let client = TungsteniteRpcClient::new(url::Url::parse("ws://127.0.0.1:9944").unwrap(), 100);
 
 	let mut api = Api::<_, _, AssetTipExtrinsicParams<Runtime>, Runtime>::new(client).unwrap();
 	api.set_signer(sudoer);

--- a/examples/transfer_using_seed.rs
+++ b/examples/transfer_using_seed.rs
@@ -20,7 +20,14 @@ use sp_core::{
 	sr25519,
 };
 use sp_runtime::MultiAddress;
-use substrate_api_client::{rpc::WsRpcClient, Api, AssetTipExtrinsicParams, XtStatus};
+
+#[cfg(feature = "ws-client")]
+use substrate_api_client::rpc::WsRpcClient;
+
+#[cfg(feature = "tungstenite-client")]
+use substrate_api_client::rpc::TungsteniteRpcClient;
+
+use substrate_api_client::{Api, AssetTipExtrinsicParams, XtStatus};
 
 fn main() {
 	env_logger::init();
@@ -33,7 +40,12 @@ fn main() {
 	println!("signer account: {}", alice.public().to_ss58check());
 
 	// Initialize api and set the signer (sender) that is used to sign the extrinsics.
+	#[cfg(feature = "ws-client")]
 	let client = WsRpcClient::new("ws://127.0.0.1:9944");
+
+	#[cfg(feature = "tungstenite-client")]
+	let client = TungsteniteRpcClient::new("ws://127.0.0.1:9944", 100);
+
 	let mut api = Api::<_, _, AssetTipExtrinsicParams>::new(client).unwrap();
 	api.set_signer(alice.clone());
 

--- a/examples/transfer_using_seed.rs
+++ b/examples/transfer_using_seed.rs
@@ -45,7 +45,7 @@ fn main() {
 	let client = WsRpcClient::new("ws://127.0.0.1:9944");
 
 	#[cfg(feature = "tungstenite-client")]
-	let client = TungsteniteRpcClient::new("ws://127.0.0.1:9944", 100);
+	let client = TungsteniteRpcClient::new(url::Url::parse("ws://127.0.0.1:9944").unwrap(), 100);
 
 	let mut api = Api::<_, _, AssetTipExtrinsicParams<Runtime>, Runtime>::new(client).unwrap();
 	api.set_signer(alice.clone());

--- a/examples/transfer_using_seed.rs
+++ b/examples/transfer_using_seed.rs
@@ -21,7 +21,14 @@ use sp_core::{
 	sr25519,
 };
 use sp_runtime::MultiAddress;
-use substrate_api_client::{rpc::WsRpcClient, Api, AssetTipExtrinsicParams, XtStatus};
+
+#[cfg(feature = "ws-client")]
+use substrate_api_client::rpc::WsRpcClient;
+
+#[cfg(feature = "tungstenite-client")]
+use substrate_api_client::rpc::TungsteniteRpcClient;
+
+use substrate_api_client::{Api, AssetTipExtrinsicParams, XtStatus};
 
 fn main() {
 	env_logger::init();
@@ -34,7 +41,12 @@ fn main() {
 	println!("signer account: {}", alice.public().to_ss58check());
 
 	// Initialize api and set the signer (sender) that is used to sign the extrinsics.
+	#[cfg(feature = "ws-client")]
 	let client = WsRpcClient::new("ws://127.0.0.1:9944");
+
+	#[cfg(feature = "tungstenite-client")]
+	let client = TungsteniteRpcClient::new("ws://127.0.0.1:9944", 100);
+
 	let mut api = Api::<_, _, AssetTipExtrinsicParams<Runtime>, Runtime>::new(client).unwrap();
 	api.set_signer(alice.clone());
 

--- a/src/api/api_client.rs
+++ b/src/api/api_client.rs
@@ -601,7 +601,7 @@ where
 		self.get_constant("Balances", "ExistentialDeposit")
 	}
 
-	#[cfg(feature = "ws-client")]
+	#[cfg(any(feature = "ws-client", feature = "tungstenite-client"))]
 	pub fn send_extrinsic(
 		&self,
 		xthex_prefixed: String,
@@ -613,7 +613,7 @@ where
 			.map_err(ApiClientError::RpcClient)
 	}
 
-	#[cfg(not(feature = "ws-client"))]
+	#[cfg(all(not(feature = "ws-client"), not(feature = "tungstenite-client")))]
 	pub fn send_extrinsic(&self, xthex_prefixed: String) -> ApiResult<Option<Runtime::Hash>> {
 		debug!("sending extrinsic: {:?}", xthex_prefixed);
 		// XtStatus should never be used used but we need to put something

--- a/src/api/api_client.rs
+++ b/src/api/api_client.rs
@@ -568,7 +568,7 @@ where
 		self.get_constant("Balances", "ExistentialDeposit")
 	}
 
-	#[cfg(feature = "ws-client")]
+	#[cfg(any(feature = "ws-client", feature = "tungstenite-client"))]
 	pub fn send_extrinsic(
 		&self,
 		xthex_prefixed: String,
@@ -580,7 +580,7 @@ where
 			.map_err(ApiClientError::RpcClient)
 	}
 
-	#[cfg(not(feature = "ws-client"))]
+	#[cfg(all(not(feature = "ws-client"), not(feature = "tungstenite-client")))]
 	pub fn send_extrinsic(&self, xthex_prefixed: String) -> ApiResult<Option<Hash>> {
 		debug!("sending extrinsic: {:?}", xthex_prefixed);
 		// XtStatus should never be used used but we need to put something

--- a/src/api/error.rs
+++ b/src/api/error.rs
@@ -41,7 +41,7 @@ pub enum Error {
 	Metadata(MetadataError),
 	#[error("InvalidMetadata: {0:?}")]
 	InvalidMetadata(InvalidMetadataError),
-	#[cfg(feature = "ws-client")]
+	#[cfg(any(feature = "ws-client", feature = "tungstenite-client"))]
 	#[error("Events Error: {0:?}")]
 	NodeApi(ac_node_api::error::Error),
 	#[error("Error decoding storage value: {0}")]
@@ -72,7 +72,7 @@ impl From<MetadataError> for Error {
 	}
 }
 
-#[cfg(feature = "ws-client")]
+#[cfg(any(feature = "ws-client", feature = "tungstenite-client"))]
 impl From<ac_node_api::error::Error> for Error {
 	fn from(error: ac_node_api::error::Error) -> Self {
 		Error::NodeApi(error)

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -37,9 +37,10 @@ use serde::{Deserialize, Serialize};
 pub mod api_client;
 pub mod error;
 
-#[cfg(feature = "ws-client")]
+#[cfg(any(feature = "ws-client", feature = "tungstenite-client"))]
 pub mod subscription;
-#[cfg(feature = "ws-client")]
+
+#[cfg(any(feature = "ws-client", feature = "tungstenite-client"))]
 pub use subscription::*;
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]

--- a/src/api/subscription.rs
+++ b/src/api/subscription.rs
@@ -15,9 +15,15 @@
 
 */
 
+#[cfg(feature = "ws-client")]
+use crate::ws_client::client::WsRpcClient;
+
+#[cfg(feature = "tungstenite-client")]
+use crate::tungstenite_client::client::TungsteniteRpcClient;
+
 use crate::{
 	api::{error::Error, Api, ApiResult, FromHexString},
-	rpc::{json_req, ws_client::client::WsRpcClient, RpcClient as RpcClientTrait, Subscriber},
+	rpc::{json_req, RpcClient as RpcClientTrait, Subscriber},
 	utils, Hash, Index,
 };
 pub use ac_node_api::{events::EventDetails, StaticEvent};
@@ -28,12 +34,24 @@ use sp_core::Pair;
 use sp_runtime::MultiSigner;
 use std::sync::mpsc::{Receiver, Sender as ThreadOut};
 
+#[cfg(feature = "ws-client")]
 impl<P, Params> Api<P, WsRpcClient, Params>
 where
 	Params: ExtrinsicParams<Index, Hash>,
 {
 	pub fn default_with_url(url: &str) -> ApiResult<Self> {
 		let client = WsRpcClient::new(url);
+		Self::new(client)
+	}
+}
+
+#[cfg(feature = "tungstenite-client")]
+impl<P, Params> Api<P, TungsteniteRpcClient, Params>
+where
+	Params: ExtrinsicParams<Index, Hash>,
+{
+	pub fn default_with_url(url: &str) -> ApiResult<Self> {
+		let client = TungsteniteRpcClient::new(url, 10);
 		Self::new(client)
 	}
 }

--- a/src/api/subscription.rs
+++ b/src/api/subscription.rs
@@ -15,9 +15,15 @@
 
 */
 
+#[cfg(feature = "ws-client")]
+use crate::ws_client::client::WsRpcClient;
+
+#[cfg(feature = "tungstenite-client")]
+use crate::tungstenite_client::client::TungsteniteRpcClient;
+
 use crate::{
 	api::{error::Error, Api, ApiResult, FromHexString},
-	rpc::{json_req, ws_client::client::WsRpcClient, RpcClient as RpcClientTrait, Subscriber},
+	rpc::{json_req, RpcClient as RpcClientTrait, Subscriber},
 	utils,
 };
 pub use ac_node_api::{events::EventDetails, StaticEvent};
@@ -31,6 +37,7 @@ use sp_rpc::number::NumberOrHex;
 use sp_runtime::MultiSigner;
 use std::sync::mpsc::{Receiver, Sender as ThreadOut};
 
+#[cfg(feature = "ws-client")]
 impl<Signer, Params, Runtime> Api<Signer, WsRpcClient, Params, Runtime>
 where
 	Params: ExtrinsicParams<Runtime::Index, Runtime::Hash>,
@@ -41,6 +48,21 @@ where
 {
 	pub fn default_with_url(url: &str) -> ApiResult<Self> {
 		let client = WsRpcClient::new(url);
+		Self::new(client)
+	}
+}
+
+#[cfg(feature = "tungstenite-client")]
+impl<Signer, Params, Runtime> Api<Signer, TungsteniteRpcClient, Params, Runtime>
+where
+	Params: ExtrinsicParams<Runtime::Index, Runtime::Hash>,
+	Runtime: BalancesConfig,
+	Runtime::Hash: FromHexString,
+	Runtime::Balance: TryFrom<NumberOrHex> + FromStr,
+	Runtime::Index: Decode,
+{
+	pub fn default_with_url(url: &str) -> ApiResult<Self> {
+		let client = TungsteniteRpcClient::new(url, 10);
 		Self::new(client)
 	}
 }

--- a/src/api/subscription.rs
+++ b/src/api/subscription.rs
@@ -61,7 +61,7 @@ where
 	Runtime::Balance: TryFrom<NumberOrHex> + FromStr,
 	Runtime::Index: Decode,
 {
-	pub fn default_with_url(url: &str) -> ApiResult<Self> {
+	pub fn default_with_url(url: url::Url) -> ApiResult<Self> {
 		let client = TungsteniteRpcClient::new(url, 10);
 		Self::new(client)
 	}

--- a/src/rpc/error.rs
+++ b/src/rpc/error.rs
@@ -31,6 +31,9 @@ pub enum Error {
 	#[cfg(feature = "ws-client")]
 	#[error("Websocket ws error: {0}")]
 	Ws(Box<ws::Error>),
+	#[cfg(feature = "tungstenite-client")]
+	#[error("WebSocket tungstenite Error: {0}")]
+	TungsteniteWebSocket(#[from] tungstenite::Error),
 	#[error("Expected some error information, but nothing was found: {0}")]
 	NoErrorInformationFound(String),
 	#[error("ChannelReceiveError, sender is disconnected: {0}")]
@@ -39,8 +42,11 @@ pub enum Error {
 	Io(#[from] std::io::Error),
 	#[error(transparent)]
 	Other(#[from] Box<dyn std::error::Error + Send + Sync + 'static>),
+	#[error("Exceeded the maximum number of attempts to connect to the server")]
+	ConnectionAttemptsExceeded,
 }
 
+#[cfg(feature = "ws-client")]
 impl From<ws::Error> for Error {
 	fn from(error: ws::Error) -> Self {
 		Self::Ws(Box::new(error))

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -20,12 +20,20 @@ pub use ws_client::WsRpcClient;
 #[cfg(feature = "ws-client")]
 pub mod ws_client;
 
+#[cfg(feature = "tungstenite-client")]
+pub use tungstenite_client::client::TungsteniteRpcClient;
+
+#[cfg(feature = "tungstenite-client")]
+pub mod tungstenite_client;
+
 pub mod error;
 pub mod json_req;
 
 pub use error::*;
 
 use crate::{api::XtStatus, Hash};
+use log::info;
+use serde_json::Value;
 use std::sync::mpsc::Sender as ThreadOut;
 
 /// Trait to be implemented by the ws-client for sending rpc requests and extrinsic.
@@ -41,4 +49,68 @@ pub trait RpcClient {
 /// Trait to be implemented by the ws-client for subscribing to the substrate node.
 pub trait Subscriber {
 	fn start_subscriber(&self, json_req: String, result_in: ThreadOut<String>) -> Result<()>;
+}
+
+#[allow(clippy::result_large_err)]
+pub trait HandleMessage {
+	type ThreadMessage;
+	type Error;
+	type Context;
+	type Result;
+
+	fn handle_message(
+		&self,
+		context: &mut Self::Context,
+	) -> core::result::Result<Self::Result, Self::Error>;
+}
+
+pub(crate) fn parse_status(msg: &str) -> Result<(XtStatus, Option<String>)> {
+	let value: Value = serde_json::from_str(msg)?;
+
+	if value["error"].as_object().is_some() {
+		return Err(into_extrinsic_err(&value))
+	}
+
+	if let Some(obj) = value["params"]["result"].as_object() {
+		if let Some(hash) = obj.get("finalized") {
+			info!("finalized: {:?}", hash);
+			return Ok((XtStatus::Finalized, Some(hash.to_string())))
+		} else if let Some(hash) = obj.get("inBlock") {
+			info!("inBlock: {:?}", hash);
+			return Ok((XtStatus::InBlock, Some(hash.to_string())))
+		} else if let Some(array) = obj.get("broadcast") {
+			info!("broadcast: {:?}", array);
+			return Ok((XtStatus::Broadcast, Some(array.to_string())))
+		}
+	};
+
+	match value["params"]["result"].as_str() {
+		Some("ready") => Ok((XtStatus::Ready, None)),
+		Some("future") => Ok((XtStatus::Future, None)),
+		Some(&_) => Ok((XtStatus::Unknown, None)),
+		None => Ok((XtStatus::Unknown, None)),
+	}
+}
+
+/// Todo: this is the code that was used in `parse_status` Don't we want to just print the
+/// error as is instead of introducing our custom format here?
+fn into_extrinsic_err(resp_with_err: &Value) -> Error {
+	let err_obj = match resp_with_err["error"].as_object() {
+		Some(obj) => obj,
+		None => return Error::NoErrorInformationFound(format!("{:?}", resp_with_err)),
+	};
+
+	let error = err_obj.get("message").map_or_else(|| "", |e| e.as_str().unwrap_or_default());
+	let code = err_obj.get("code").map_or_else(|| -1, |c| c.as_i64().unwrap_or_default());
+	let details = err_obj.get("data").map_or_else(|| "", |d| d.as_str().unwrap_or_default());
+
+	Error::Extrinsic(format!("extrinsic error code {}: {}: {}", code, error, details))
+}
+
+fn result_from_json_response(resp: &str) -> Result<String> {
+	let value: Value = serde_json::from_str(resp)?;
+
+	let resp = value["result"].as_str().ok_or_else(|| into_extrinsic_err(&value))?;
+
+	Ok(resp.to_string())
 }

--- a/src/rpc/tungstenite_client/client.rs
+++ b/src/rpc/tungstenite_client/client.rs
@@ -1,0 +1,330 @@
+/*
+   Copyright 2019 Supercomputing Systems AG
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+	   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+*/
+use crate::{
+	json_req,
+	rpc::{Error as RpcClientError, Result, RpcClient as RpcClientTrait},
+	tungstenite_client::{
+		read_until_text_message, GetRequestHandler, SubmitAndWatchHandler, SubmitOnlyHandler,
+		SubscriptionHandler,
+	},
+	FromHexString, HandleMessage, Subscriber, XtStatus,
+};
+use log::{debug, error, info, warn};
+use serde_json::Value;
+use sp_core::H256 as Hash;
+use std::{
+	fmt::Debug, net::TcpStream, sync::mpsc::Sender as ThreadOut, thread, thread::sleep,
+	time::Duration,
+};
+use tungstenite::{
+	client::connect_with_config,
+	protocol::{frame::coding::CloseCode, CloseFrame},
+	stream::MaybeTlsStream,
+	Message, WebSocket,
+};
+use url::Url;
+
+pub(crate) type MySocket = WebSocket<MaybeTlsStream<TcpStream>>;
+
+#[derive(Debug, Clone)]
+pub struct TungsteniteRpcClient {
+	url: String,
+	max_attempts: u8,
+}
+
+impl TungsteniteRpcClient {
+	pub fn new(url: &str, max_attempts: u8) -> TungsteniteRpcClient {
+		TungsteniteRpcClient { url: url.to_string(), max_attempts }
+	}
+
+	fn direct_rpc_request<MessageHandler>(
+		&self,
+		json_req: String,
+		message_handler: MessageHandler,
+	) -> Result<String>
+	where
+		MessageHandler: HandleMessage<Error = (RpcClientError, bool), Context = MySocket, Result = String>
+			+ Clone
+			+ Send
+			+ 'static,
+		MessageHandler::ThreadMessage: Send + Sync + Debug,
+	{
+		let url = Url::parse(self.url.as_str()).map_err(|e| RpcClientError::Other(e.into()))?;
+		let mut current_attempt: u8 = 1;
+		let mut socket: MySocket;
+
+		while current_attempt <= self.max_attempts {
+			match connect_with_config(url.clone(), None, 2) {
+				Ok(res) => {
+					socket = res.0;
+					let response = res.1;
+					debug!("Connected to the server. Response HTTP code: {}", response.status());
+					if socket.can_read() {
+						current_attempt = 1;
+						let ping = socket.read_message();
+						if ping.is_err() {
+							error!("failed to read ping message. error: {:?}", ping.unwrap_err());
+						} else {
+							debug!(
+								"read ping message:{:?}. Connected successfully.",
+								ping.unwrap()
+							);
+							let r = match socket.write_message(Message::Text(json_req.clone())) {
+								Ok(_) => {
+									let r = message_handler.handle_message(&mut socket);
+									let _ = socket.close(None);
+									r
+								},
+								Err(e) => {
+									let _ = socket.close(None);
+									Err((RpcClientError::TungsteniteWebSocket(e), true))
+								},
+							};
+							match r {
+								Ok(e) => return Ok(e),
+								Err((e, retry)) => {
+									error!(
+										"failed to send request. error:{:?}, retry:{:?}",
+										e, retry
+									);
+									if retry {
+										if current_attempt == self.max_attempts {
+											return Err(e)
+										}
+									} else {
+										return Err(e)
+									}
+								},
+							};
+						}
+					}
+					let _ = socket.close(Some(CloseFrame {
+						code: CloseCode::Normal,
+						reason: Default::default(),
+					}));
+				},
+				Err(e) => {
+					error!("failed to connect the server({:?}). error: {:?}", self.url, e);
+				},
+			};
+			warn!(
+				"attempt to request after {} sec. current attempt {}",
+				5 * current_attempt,
+				current_attempt
+			);
+			sleep(Duration::from_secs((5 * current_attempt) as u64));
+			current_attempt += 1;
+		}
+		Err(RpcClientError::ConnectionAttemptsExceeded)
+	}
+}
+
+impl RpcClientTrait for TungsteniteRpcClient {
+	fn get_request(&self, jsonreq: Value) -> Result<Option<String>> {
+		self.direct_rpc_request(jsonreq.to_string(), GetRequestHandler::default())
+			.map(|v| Some(v))
+		// self.direct_rpc_request(jsonreq.to_string(), on_get_request_msg)
+	}
+
+	fn send_extrinsic(
+		&self,
+		xthex_prefixed: String,
+		exit_on: XtStatus,
+	) -> Result<Option<sp_core::H256>> {
+		// Todo: Make all variants return a H256: #175.
+
+		let jsonreq = match exit_on {
+			XtStatus::SubmitOnly => json_req::author_submit_extrinsic(&xthex_prefixed).to_string(),
+			_ => json_req::author_submit_and_watch_extrinsic(&xthex_prefixed).to_string(),
+		};
+		let response = self.direct_rpc_request(jsonreq, SubmitAndWatchHandler::new(exit_on))?;
+		info!("Got response {:?} while waiting for {:?}", response, exit_on);
+		if response.is_empty() {
+			Ok(None)
+		} else {
+			Ok(Some(Hash::from_hex(response)?))
+		}
+	}
+}
+
+impl Subscriber for TungsteniteRpcClient {
+	fn start_subscriber(&self, json_req: String, result_in: ThreadOut<String>) -> Result<()> {
+		self.start_rpc_client_thread(json_req, result_in, SubscriptionHandler::default())
+	}
+}
+
+impl TungsteniteRpcClient {
+	pub fn get(
+		&self,
+		json_req: String,
+		result_in: ThreadOut<<GetRequestHandler as HandleMessage>::ThreadMessage>,
+	) -> Result<()> {
+		self.start_rpc_client_thread(json_req, result_in, GetRequestHandler::default())
+	}
+
+	pub fn send_extrinsic(
+		&self,
+		json_req: String,
+		result_in: ThreadOut<<SubmitOnlyHandler as HandleMessage>::ThreadMessage>,
+	) -> Result<()> {
+		self.start_rpc_client_thread(json_req, result_in, SubmitOnlyHandler::default())
+	}
+
+	pub fn send_extrinsic_until_ready(
+		&self,
+		json_req: String,
+		result_in: ThreadOut<<SubmitAndWatchHandler as HandleMessage>::ThreadMessage>,
+	) -> Result<()> {
+		self.start_rpc_client_thread(
+			json_req,
+			result_in,
+			SubmitAndWatchHandler::new(XtStatus::Ready),
+		)
+	}
+
+	pub fn send_extrinsic_and_wait_until_broadcast(
+		&self,
+		json_req: String,
+		result_in: ThreadOut<<SubmitAndWatchHandler as HandleMessage>::ThreadMessage>,
+	) -> Result<()> {
+		self.start_rpc_client_thread(
+			json_req,
+			result_in,
+			SubmitAndWatchHandler::new(XtStatus::Broadcast),
+		)
+	}
+
+	pub fn send_extrinsic_and_wait_until_in_block(
+		&self,
+		json_req: String,
+		result_in: ThreadOut<<SubmitAndWatchHandler as HandleMessage>::ThreadMessage>,
+	) -> Result<()> {
+		self.start_rpc_client_thread(
+			json_req,
+			result_in,
+			SubmitAndWatchHandler::new(XtStatus::InBlock),
+		)
+	}
+
+	pub fn send_extrinsic_and_wait_until_finalized(
+		&self,
+		json_req: String,
+		result_in: ThreadOut<<SubmitAndWatchHandler as HandleMessage>::ThreadMessage>,
+	) -> Result<()> {
+		self.start_rpc_client_thread(
+			json_req,
+			result_in,
+			SubmitAndWatchHandler::new(XtStatus::Finalized),
+		)
+	}
+
+	pub fn start_rpc_client_thread<MessageHandler>(
+		&self,
+		json_req: String,
+		result_in: ThreadOut<MessageHandler::ThreadMessage>,
+		message_handler: MessageHandler,
+	) -> Result<()>
+	where
+		MessageHandler: HandleMessage<Error = (RpcClientError, bool), Context = MySocket>
+			+ Clone
+			+ Send
+			+ 'static,
+		MessageHandler::ThreadMessage: Send + Sync + Debug,
+		MessageHandler::ThreadMessage: From<MessageHandler::Result>,
+	{
+		let url = Url::parse(self.url.as_str()).map_err(|e| RpcClientError::Other(e.into()))?;
+		let max_attempts = self.max_attempts;
+
+		thread::spawn(move || {
+			let mut current_attempt: u8 = 1;
+			let mut socket: MySocket;
+
+			while current_attempt <= max_attempts {
+				match connect_with_config(url.clone(), None, max_attempts) {
+					Ok(res) => {
+						socket = res.0;
+						let response = res.1;
+						debug!(
+							"Connected to the server. Response HTTP code: {}",
+							response.status()
+						);
+						match socket.write_message(Message::Text(json_req.clone())) {
+							Ok(_) => {},
+							Err(e) => {
+								error!("write msg error:{:?}", e);
+							},
+						}
+						if socket.can_read() {
+							current_attempt = 1;
+							// After sending the subscription request, there will be a response(result)
+							let msg_from_req = read_until_text_message(&mut socket);
+							match msg_from_req {
+								Ok(msg_from_req) => {
+									debug!("response message: {:?}", msg_from_req);
+									loop {
+										let msg = read_until_text_message(&mut socket);
+										if msg.is_err() {
+											error!("err:{:?}", msg.unwrap_err());
+											break
+										}
+										match message_handler.handle_message(&mut socket) {
+											Ok(msg) =>
+												if let Err(e) = result_in.send(msg.into()) {
+													//thread_message.send(result)
+													error!("failed to send channel: {:?} ", e);
+													return
+												},
+											Err((e, retry)) => {
+												error!("on_subscription_msg: {:?}", e);
+												if retry {
+													if current_attempt == max_attempts {
+														return
+													}
+												} else {
+													return
+												}
+											},
+										}
+									}
+								},
+								Err(e) => {
+									error!("response message error:{:?}", e);
+								},
+							};
+						}
+						let _ = socket.close(Some(CloseFrame {
+							code: CloseCode::Normal,
+							reason: Default::default(),
+						}));
+					},
+					Err(e) => {
+						error!("failed to connect the server({:?}). error: {:?}", url, e);
+					},
+				};
+				warn!(
+					"attempt to request after {} sec. current attempt {}",
+					5 * current_attempt,
+					current_attempt
+				);
+				sleep(Duration::from_secs((5 * current_attempt) as u64));
+				current_attempt += 1;
+			}
+			error!("max request attempts exceeded");
+		});
+		Ok(())
+	}
+}

--- a/src/rpc/tungstenite_client/client.rs
+++ b/src/rpc/tungstenite_client/client.rs
@@ -68,7 +68,7 @@ impl TungsteniteRpcClient {
 		let mut socket: MySocket;
 
 		while current_attempt <= self.max_attempts {
-			match connect_with_config(url.clone(), None, 2) {
+			match connect_with_config(url.clone(), None, u8::MAX) {
 				Ok(res) => {
 					socket = res.0;
 					let response = res.1;
@@ -254,7 +254,7 @@ impl TungsteniteRpcClient {
 			let mut socket: MySocket;
 
 			while current_attempt <= max_attempts {
-				match connect_with_config(url.clone(), None, max_attempts) {
+				match connect_with_config(url.clone(), None, u8::MAX) {
 					Ok(res) => {
 						socket = res.0;
 						let response = res.1;

--- a/src/rpc/tungstenite_client/client.rs
+++ b/src/rpc/tungstenite_client/client.rs
@@ -25,7 +25,6 @@ use crate::{
 };
 use log::{debug, error, info, warn};
 use serde_json::Value;
-use sp_core::H256 as Hash;
 use std::{
 	fmt::Debug, net::TcpStream, sync::mpsc::Sender as ThreadOut, thread, thread::sleep,
 	time::Duration,
@@ -68,7 +67,7 @@ impl TungsteniteRpcClient {
 		let mut socket: MySocket;
 
 		while current_attempt <= self.max_attempts {
-			match connect_with_config(url.clone(), None, u8::MAX) {
+			match connect_with_config(url.clone(), None, u8::MAX - 1) {
 				Ok(res) => {
 					socket = res.0;
 					let response = res.1;
@@ -140,11 +139,11 @@ impl RpcClientTrait for TungsteniteRpcClient {
 		// self.direct_rpc_request(jsonreq.to_string(), on_get_request_msg)
 	}
 
-	fn send_extrinsic(
+	fn send_extrinsic<Hash: FromHexString>(
 		&self,
 		xthex_prefixed: String,
 		exit_on: XtStatus,
-	) -> Result<Option<sp_core::H256>> {
+	) -> Result<Option<Hash>> {
 		// Todo: Make all variants return a H256: #175.
 
 		let jsonreq = match exit_on {
@@ -254,7 +253,7 @@ impl TungsteniteRpcClient {
 			let mut socket: MySocket;
 
 			while current_attempt <= max_attempts {
-				match connect_with_config(url.clone(), None, u8::MAX) {
+				match connect_with_config(url.clone(), None, u8::MAX - 1) {
 					Ok(res) => {
 						socket = res.0;
 						let response = res.1;

--- a/src/rpc/tungstenite_client/mod.rs
+++ b/src/rpc/tungstenite_client/mod.rs
@@ -1,0 +1,175 @@
+/*
+   Copyright 2019 Supercomputing Systems AG
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+	   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+*/
+
+use crate::{
+	rpc::{error::Error as RpcClientError, parse_status, result_from_json_response},
+	HandleMessage, XtStatus,
+};
+
+use log::{debug, error};
+use serde_json::Value;
+use tungstenite::Message;
+
+pub mod client;
+
+use client::MySocket;
+
+#[derive(Default, Debug, PartialEq, Eq, Clone)]
+pub struct GetRequestHandler;
+
+impl HandleMessage for GetRequestHandler {
+	type ThreadMessage = String;
+	type Error = (RpcClientError, bool); // (error,retry)
+	type Context = MySocket;
+	type Result = String;
+
+	fn handle_message(&self, context: &mut Self::Context) -> Result<Self::Result, Self::Error> {
+		let msg = read_until_text_message(context).map_err(|e| (e.into(), true))?;
+		debug!("Got get_request_msg {}", msg);
+		let result_str = serde_json::from_str(msg.as_str())
+			.map(|v: Value| v["result"].to_string())
+			.map_err(|e| (RpcClientError::Serde(e), false))?;
+		Ok(result_str)
+	}
+}
+
+#[derive(Default, Debug, PartialEq, Eq, Clone)]
+pub struct SubscriptionHandler {}
+
+impl HandleMessage for SubscriptionHandler {
+	type ThreadMessage = String;
+	type Error = (RpcClientError, bool); // (error,retry)
+	type Context = MySocket;
+	type Result = String;
+
+	fn handle_message(&self, context: &mut Self::Context) -> Result<Self::Result, Self::Error> {
+		loop {
+			let msg = read_until_text_message(context).map_err(|e| (e.into(), true))?;
+			debug!("got on_subscription_msg {}", msg);
+			let value: Value = serde_json::from_str(msg.as_str())
+				.map_err(|e| (RpcClientError::Serde(e), false))?;
+
+			match value["id"].as_str() {
+				Some(_idstr) => {},
+				_ => {
+					// subscriptions
+					debug!("no id field found in response. must be subscription");
+					debug!("method: {:?}", value["method"].as_str());
+					match value["method"].as_str() {
+						Some("state_storage") => {
+							let changes = &value["params"]["result"]["changes"];
+							match changes[0][1].as_str() {
+								Some(change_set) => return Ok(change_set.to_string()),
+								None => println!("No events happened"),
+							};
+						},
+						Some("chain_finalizedHead") => {
+							let head = serde_json::to_string(&value["params"]["result"])
+								.map_err(|e| (RpcClientError::Serde(e), false))?;
+							return Ok(head)
+						},
+						_ => error!("unsupported method"),
+					}
+				},
+			};
+		}
+	}
+}
+
+#[derive(Default, Debug, PartialEq, Eq, Clone)]
+pub struct SubmitOnlyHandler;
+
+impl HandleMessage for SubmitOnlyHandler {
+	type ThreadMessage = String;
+	type Error = (RpcClientError, bool); // (error,retry)
+	type Context = MySocket;
+	type Result = String;
+
+	fn handle_message(&self, context: &mut Self::Context) -> Result<Self::Result, Self::Error> {
+		let msg = read_until_text_message(context).map_err(|e| (e.into(), true))?;
+		debug!("got msg {}", msg);
+		return match result_from_json_response(msg.as_str()) {
+			Ok(val) => Ok(val),
+			Err(e) => Err((e.into(), false)),
+		}
+	}
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct SubmitAndWatchHandler {
+	exit_on: XtStatus,
+}
+
+impl SubmitAndWatchHandler {
+	pub fn new(exit_on: XtStatus) -> Self {
+		Self { exit_on }
+	}
+}
+
+impl HandleMessage for SubmitAndWatchHandler {
+	type ThreadMessage = String;
+	type Error = (RpcClientError, bool); // (error,retry)
+	type Context = MySocket;
+	type Result = String;
+
+	fn handle_message(&self, context: &mut Self::Context) -> Result<Self::Result, Self::Error> {
+		loop {
+			let msg = read_until_text_message(context).map_err(|e| (e.into(), true))?;
+			debug!("receive msg:{:?}", msg);
+			match parse_status(msg.as_str()) {
+				Ok((xt_status, val)) =>
+					if xt_status as u32 >= 10 {
+						let error = RpcClientError::Extrinsic(format!(
+							"Unexpected extrinsic status: {:?}, stopped watch process prematurely.",
+							xt_status
+						));
+						return Err((error, false))
+					} else if xt_status as u32 >= self.exit_on as u32 {
+						return Ok(val.unwrap_or("".to_string()))
+					},
+				Err(e) => return Err((e, false)),
+			}
+		}
+	}
+}
+
+pub(crate) fn read_until_text_message(socket: &mut MySocket) -> Result<String, tungstenite::Error> {
+	loop {
+		match socket.read_message() {
+			Ok(Message::Text(s)) => {
+				debug!("receive text: {:?}", s);
+				break Ok(s)
+			},
+			Ok(Message::Binary(_)) => {
+				debug!("skip binary msg");
+			},
+			Ok(Message::Ping(_)) => {
+				debug!("skip ping msg");
+			},
+			Ok(Message::Pong(_)) => {
+				debug!("skip ping msg");
+			},
+			Ok(Message::Close(_)) => {
+				debug!("skip close msg");
+			},
+			Ok(Message::Frame(_)) => {
+				debug!("skip frame msg");
+			},
+			Err(e) => break Err(e),
+		}
+	}
+}

--- a/src/rpc/ws_client/client.rs
+++ b/src/rpc/ws_client/client.rs
@@ -15,7 +15,6 @@
 
 */
 
-use super::HandleMessage;
 use crate::{
 	api::{FromHexString, XtStatus},
 	rpc::{
@@ -26,6 +25,8 @@ use crate::{
 		},
 		Result, RpcClient as RpcClientTrait, Subscriber,
 	},
+	ws_client::MessageContext,
+	HandleMessage,
 };
 use log::info;
 use serde_json::Value;
@@ -167,6 +168,8 @@ impl WsRpcClient {
 	where
 		MessageHandler: HandleMessage + Clone + Send + 'static,
 		MessageHandler::ThreadMessage: Send + Sync + Debug,
+		MessageHandler::Error: Into<ws::Error>,
+		MessageHandler::Context: From<MessageContext<MessageHandler::ThreadMessage>>,
 	{
 		let url = self.url.clone();
 		let _client =
@@ -191,6 +194,8 @@ impl WsRpcClient {
 	where
 		MessageHandler: HandleMessage + Clone + Send + 'static,
 		MessageHandler::ThreadMessage: Send + Sync + Debug,
+		MessageHandler::Error: Into<ws::Error>,
+		MessageHandler::Context: From<MessageContext<MessageHandler::ThreadMessage>>,
 	{
 		let (result_in, result_out) = channel();
 		connect(self.url.as_str(), |out| RpcClient {


### PR DESCRIPTION
This PR

-  implement new rpc client with [tungstenite-rs ](https://github.com/snapview/tungstenite-rs)
-  `tungstenite-client` attempt to reconnect to rpc node once disconnected

Run example with tungstenite
```bash
cargo run --no-default-features --features tungstenite-client,std --example get_storage
```