### PR TITLE
Bump crate versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,7 @@ dependencies = [
 
 [[package]]
 name = "ac-compose-macros"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "ac-primitives",
  "log",
@@ -26,7 +26,7 @@ dependencies = [
 
 [[package]]
 name = "ac-node-api"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "ac-primitives",
  "bitvec",
@@ -48,7 +48,7 @@ dependencies = [
 
 [[package]]
 name = "ac-primitives"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "frame-system",
  "hex",
@@ -4747,7 +4747,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-api-client"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "ac-compose-macros",
  "ac-node-api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-api-client"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Supercomputing Systems AG <info@scs.ch>"]
 license = "Apache-2.0"
 edition = "2021"

--- a/compose-macros/Cargo.toml
+++ b/compose-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ac-compose-macros"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Supercomputing Systems AG <info@scs.ch>"]
 license = "Apache-2.0"
 edition = "2021"

--- a/node-api/Cargo.toml
+++ b/node-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ac-node-api"
-version = "0.2.0"
+version = "0.2.1"
 license = "Apache-2.0"
 edition = "2021"
 

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ac-primitives"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Supercomputing Systems AG <info@scs.ch>"]
 license = "Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
Preparation for tag v0.8.0

Check diff from now to tag v0.7.0: https://github.com/scs/substrate-api-client/compare/v0.7.0...master