### PR TITLE
Add jsonrpsee as default rpc client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
                  cargo clippy --all --exclude test-no-std -- -D warnings,
                  cargo clippy --all-features --examples -- -D warnings,
 
-                 cargo test --all --exclude test-no-std,
+                 cargo test --all --all-features --exclude test-no-std,
 
                  cargo fmt --all -- --check
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Upload examples
         uses: actions/upload-artifact@v3
-        if: matrix.check == 'cargo build --release --examples --features staking-xt'
+        if: matrix.check == 'cargo build --release --examples --all-features'
         with:
           name: examples
           path:  |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,9 +121,8 @@ jobs:
           print_metadata,
           sudo,
           transfer_using_seed,
-          transfer_using_seed_tungstenite_client,
-          transfer_using_seed_ws_client,
-
+          transfer_with_tungstenite_client,
+          transfer_with_ws_client,
         ]
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,10 +37,10 @@ jobs:
                  cargo build --release -p test-no-std --features compose-macros,
                  cargo build --release -p test-no-std --features node-api,
 
-                 cargo build --release --examples --features staking-xt,
+                 cargo build --release --examples --all-features,
 
                  cargo clippy --all --exclude test-no-std -- -D warnings,
-                 cargo clippy --features staking-xt --examples -- -D warnings,
+                 cargo clippy --all-features --examples -- -D warnings,
 
                  cargo test --all --exclude test-no-std,
 
@@ -121,6 +121,9 @@ jobs:
           print_metadata,
           sudo,
           transfer_using_seed,
+          transfer_using_seed_tungstenite_client,
+          transfer_using_seed_ws_client,
+
         ]
     steps:
       - uses: actions/checkout@v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,6 +167,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
+name = "async-lock"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8101efe8695a6c17e02911402145357e718ac92d3ff88ae8419e84b1707b685"
+dependencies = [
+ "event-listener",
+ "futures-lite",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -232,6 +242,15 @@ name = "base64ct"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b645a089122eccb6111b4f81cbc1a49f5900ac4666bb93ac027feaecf15607bf"
+
+[[package]]
+name = "beef"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bincode"
@@ -858,6 +877,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
 name = "fake-simd"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1241,6 +1266,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
 
 [[package]]
+name = "futures-lite"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694489acd39452c77daa48516b894c153f192c3578d5a839b62c58099fcbf48"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1612,6 +1652,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonrpsee"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d291e3a5818a2384645fd9756362e6d89cf0541b0b916fa7702ea4a9833608e"
+dependencies = [
+ "jsonrpsee-client-transport",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+]
+
+[[package]]
+name = "jsonrpsee-client-transport"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965de52763f2004bc91ac5bcec504192440f0b568a5d621c59d9dbd6f886c3fb"
+dependencies = [
+ "futures-util",
+ "http",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+ "pin-project",
+ "rustls-native-certs",
+ "soketto",
+ "thiserror",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tracing",
+ "webpki-roots",
+]
+
+[[package]]
+name = "jsonrpsee-core"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e70b4439a751a5de7dd5ed55eacff78ebf4ffe0fc009cb1ebb11417f5b536b"
+dependencies = [
+ "anyhow",
+ "async-lock",
+ "async-trait",
+ "beef",
+ "futures-channel",
+ "futures-timer",
+ "futures-util",
+ "jsonrpsee-types",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-types"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bd522fe1ce3702fd94812965d7bb7a3364b1c9aba743944c5a00529aae80f8c"
+dependencies = [
+ "anyhow",
+ "beef",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
 name = "k256"
 version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1959,6 +2067,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
+dependencies = [
+ "libc",
+ "log",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "mio-extras"
 version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1966,7 +2086,7 @@ checksum = "52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19"
 dependencies = [
  "lazycell",
  "log",
- "mio",
+ "mio 0.6.23",
  "slab",
 ]
 
@@ -3348,6 +3468,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1ad0aff30c1da14b1254fcb2af73e1fa9a28670e584a626f53a369d0e157304"
 
 [[package]]
+name = "parking"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3399,6 +3525,26 @@ name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+
+[[package]]
+name = "pin-project"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -3664,6 +3810,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin 0.5.2",
+ "untrusted",
+ "web-sys",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3711,6 +3872,39 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.20.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "539a2bfe908f471bfa933876bd1eb6a19cf2176d375f82ef7f99530a40e48c2c"
+dependencies = [
+ "log",
+ "ring",
+ "sct",
+ "webpki",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0167bac7a9f490495f3c33013e7722b53cb087ecbe082fb0c6387c96f634ea50"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55"
+dependencies = [
+ "base64",
 ]
 
 [[package]]
@@ -3823,6 +4017,16 @@ name = "scratch"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
+
+[[package]]
+name = "sct"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "sec1"
@@ -3965,6 +4169,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha-1"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4066,6 +4283,31 @@ name = "smallvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+
+[[package]]
+name = "socket2"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "soketto"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d1c5305e39e09653383c2c7244f2f78b3bcae37cf50c64cb4789c9f5096ec2"
+dependencies = [
+ "base64",
+ "bytes 1.2.1",
+ "futures",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha-1 0.9.8",
+]
 
 [[package]]
 name = "sp-api"
@@ -4765,6 +5007,12 @@ dependencies = [
 
 [[package]]
 name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "spin"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f6002a767bff9e83f8eeecf883ecb8011875a21ae8da43bffb817a57e78cc09"
@@ -4852,7 +5100,9 @@ dependencies = [
  "frame-metadata 15.0.0 (git+https://github.com/paritytech/frame-metadata)",
  "frame-support",
  "frame-system",
+ "futures",
  "hex",
+ "jsonrpsee",
  "kitchensink-runtime",
  "log",
  "pallet-balances",
@@ -4870,6 +5120,7 @@ dependencies = [
  "sp-std",
  "sp-version",
  "thiserror",
+ "tokio",
  "tungstenite",
  "url",
  "wabt",
@@ -5061,6 +5312,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
+name = "tokio"
+version = "1.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eab6d665857cc6ca78d6e80303a02cea7a7851e85dfbd77cbdc09bd129f1ef46"
+dependencies = [
+ "autocfg",
+ "libc",
+ "mio 0.8.5",
+ "num_cpus",
+ "pin-project-lite",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
+dependencies = [
+ "rustls",
+ "tokio",
+ "webpki",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb2e075f03b3d66d8d8785356224ba688d2906a371015e225beeb65ca92c740"
+dependencies = [
+ "bytes 1.2.1",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "toml"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5199,7 +5502,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "digest 0.10.5",
  "rand 0.8.5",
  "static_assertions",
@@ -5255,6 +5558,12 @@ name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
@@ -5313,6 +5622,12 @@ dependencies = [
  "cmake",
  "glob",
 ]
+
+[[package]]
+name = "waker-fn"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
 
 [[package]]
 name = "walkdir"
@@ -5458,7 +5773,7 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01bf50edb2ea9d922aa75a7bf3c15e26a6c9e2d18c56e862b49737a582901729"
 dependencies = [
- "spin",
+ "spin 0.9.4",
  "wasmi_arena",
  "wasmi_core 0.5.0",
  "wasmparser-nostd",
@@ -5644,6 +5959,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.22.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368bfe657969fb01238bb756d351dcade285e0f6fcbd36dcb23359a5169975be"
+dependencies = [
+ "webpki",
+]
+
+[[package]]
 name = "winapi"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5796,11 +6140,11 @@ dependencies = [
  "bytes 0.4.12",
  "httparse",
  "log",
- "mio",
+ "mio 0.6.23",
  "mio-extras",
  "openssl",
  "rand 0.7.3",
- "sha-1",
+ "sha-1 0.8.2",
  "slab",
  "url",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,9 @@ members = [
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ['derive'] }
+futures = { version = "0.3", optional = true }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
+jsonrpsee = { version = "0.16", optional = true, features = ["async-client", "client-ws-transport", "jsonrpsee-types"] }
 log = { version = "0.4.14", default-features = false }
 primitive-types = { version = "0.12.1", optional = true, features = ["codec"] }
 serde = { version = "1.0.136", default-features = false, features = ["derive"] }
@@ -50,10 +52,11 @@ pallet-balances = { git = "https://github.com/paritytech/substrate.git", branch 
 pallet-identity = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
 pallet-staking = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
 sp-keyring = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
+tokio = { version = "1.16", features = ["rt-multi-thread", "macros", "time"] }
 wabt = "0.10.0"
 
 [features]
-default = ["std", "ws-client"]
+default = ["std", "jsonrpsee-client"]
 # To support `no_std` builds in non-32 bit environments.
 disable_target_static_assertions = [
     "sp-runtime-interface/disable_target_static_assertions",
@@ -82,6 +85,7 @@ std = [
     "ac-node-api/std",
     "ac-primitives/std",
 ]
+jsonrpsee-client = ["std", "jsonrpsee", "futures"]
 tungstenite-client = ["std", "tungstenite"]
-ws-client = ["ws"]
+ws-client = ["std", "ws"]
 staking-xt = ["std"]

--- a/about.toml
+++ b/about.toml
@@ -9,6 +9,7 @@ accepted = [
     "ISC",
     "OpenSSL",
     "Unicode-DFS-2016",
+    "NOASSERTION",
 ]
 ignore-dev-dependencies = true
 ignore-build-dependencies = true

--- a/examples/batch_payout.rs
+++ b/examples/batch_payout.rs
@@ -14,7 +14,8 @@ use sp_runtime::{app_crypto::Ss58Codec, AccountId32};
 use substrate_api_client::{rpc::JsonrpseeClient, Api, PlainTipExtrinsicParams, XtStatus};
 
 #[cfg(feature = "staking-xt")]
-fn main() {
+#[tokio::main]
+async fn main() {
 	env_logger::init();
 
 	let from = AccountKeyring::Alice.pair();

--- a/examples/batch_payout.rs
+++ b/examples/batch_payout.rs
@@ -11,14 +11,14 @@ use sp_keyring::AccountKeyring;
 #[cfg(feature = "staking-xt")]
 use sp_runtime::{app_crypto::Ss58Codec, AccountId32};
 #[cfg(feature = "staking-xt")]
-use substrate_api_client::{rpc::WsRpcClient, Api, PlainTipExtrinsicParams, XtStatus};
+use substrate_api_client::{rpc::JsonrpseeClient, Api, PlainTipExtrinsicParams, XtStatus};
 
 #[cfg(feature = "staking-xt")]
 fn main() {
 	env_logger::init();
 
 	let from = AccountKeyring::Alice.pair();
-	let client = WsRpcClient::with_default_url();
+	let client = JsonrpseeClient::with_default_url().unwrap();
 	let mut api = Api::<_, _, PlainTipExtrinsicParams<Runtime>, Runtime>::new(client).unwrap();
 	api.set_signer(from);
 	let grace_period: GracePeriod = GracePeriod { enabled: false, eras: 0 };
@@ -91,7 +91,7 @@ pub fn get_last_reward(
 	validator_address: &str,
 	api: &substrate_api_client::Api<
 		sp_core::sr25519::Pair,
-		WsRpcClient,
+		JsonrpseeClient,
 		PlainTipExtrinsicParams<Runtime>,
 		Runtime,
 	>,

--- a/examples/benchmark_bulk_xt.rs
+++ b/examples/benchmark_bulk_xt.rs
@@ -18,29 +18,20 @@
 // run this against test node with
 // > substrate-test-node --dev --execution native --ws-port 9979 -ltxpool=debug
 
-#[cfg(feature = "ws-client")]
-use substrate_api_client::rpc::WsRpcClient;
-
-#[cfg(feature = "tungstenite-client")]
-use substrate_api_client::rpc::TungsteniteRpcClient;
-
 use kitchensink_runtime::{BalancesCall, Runtime, RuntimeCall};
 use sp_keyring::AccountKeyring;
 use substrate_api_client::{
-	compose_extrinsic_offline, Api, AssetTipExtrinsicParams, UncheckedExtrinsicV4,
+	compose_extrinsic_offline, Api, AssetTipExtrinsicParams, JsonrpseeClient, UncheckedExtrinsicV4,
 };
 
-fn main() {
+#[tokio::main]
+async fn main() {
 	env_logger::init();
 
 	// initialize api and set the signer (sender) that is used to sign the extrinsics
 	let from = AccountKeyring::Alice.pair();
 
-	#[cfg(feature = "ws-client")]
-	let client = WsRpcClient::with_default_url();
-
-	#[cfg(feature = "tungstenite-client")]
-	let client = TungsteniteRpcClient::with_default_url(100);
+	let client = JsonrpseeClient::with_default_url().unwrap();
 
 	let mut api = Api::<_, _, AssetTipExtrinsicParams<Runtime>, Runtime>::new(client).unwrap();
 	api.set_signer(from);

--- a/examples/compose_extrinsic_offline.rs
+++ b/examples/compose_extrinsic_offline.rs
@@ -20,15 +20,9 @@ use ac_primitives::AssetTipExtrinsicParamsBuilder;
 use kitchensink_runtime::{BalancesCall, Header, Runtime, RuntimeCall};
 use sp_keyring::AccountKeyring;
 use sp_runtime::{generic::Era, MultiAddress};
-
-#[cfg(feature = "ws-client")]
-use substrate_api_client::rpc::WsRpcClient;
-
-#[cfg(feature = "tungstenite-client")]
-use substrate_api_client::rpc::TungsteniteRpcClient;
-
 use substrate_api_client::{
-	compose_extrinsic_offline, Api, AssetTipExtrinsicParams, UncheckedExtrinsicV4, XtStatus,
+	compose_extrinsic_offline, rpc::JsonrpseeClient, Api, AssetTipExtrinsicParams,
+	UncheckedExtrinsicV4, XtStatus,
 };
 
 fn main() {
@@ -37,11 +31,7 @@ fn main() {
 	// Initialize api and set the signer (sender) that is used to sign the extrinsics.
 	let from = AccountKeyring::Alice.pair();
 
-	#[cfg(feature = "ws-client")]
-	let client = WsRpcClient::with_default_url();
-
-	#[cfg(feature = "tungstenite-client")]
-	let client = TungsteniteRpcClient::with_default_url(100);
+	let client = JsonrpseeClient::with_default_url().unwrap();
 
 	let mut api = Api::<_, _, AssetTipExtrinsicParams<Runtime>, Runtime>::new(client).unwrap();
 	api.set_signer(from);

--- a/examples/compose_extrinsic_offline.rs
+++ b/examples/compose_extrinsic_offline.rs
@@ -25,7 +25,8 @@ use substrate_api_client::{
 	UncheckedExtrinsicV4, XtStatus,
 };
 
-fn main() {
+#[tokio::main]
+async fn main() {
 	env_logger::init();
 
 	// Initialize api and set the signer (sender) that is used to sign the extrinsics.

--- a/examples/contract_instantiate_with_code.rs
+++ b/examples/contract_instantiate_with_code.rs
@@ -34,7 +34,8 @@ impl StaticEvent for ContractInstantiatedEventArgs {
 	const EVENT: &'static str = "Instantiated";
 }
 
-fn main() {
+#[tokio::main]
+async fn main() {
 	env_logger::init();
 
 	// initialize api and set the signer (sender) that is used to sign the extrinsics

--- a/examples/contract_instantiate_with_code.rs
+++ b/examples/contract_instantiate_with_code.rs
@@ -19,7 +19,7 @@ use codec::Decode;
 use kitchensink_runtime::Runtime;
 use sp_keyring::AccountKeyring;
 use substrate_api_client::{
-	rpc::WsRpcClient, AccountId, Api, PlainTipExtrinsicParams, StaticEvent, XtStatus,
+	rpc::JsonrpseeClient, AccountId, Api, PlainTipExtrinsicParams, StaticEvent, XtStatus,
 };
 
 #[allow(unused)]
@@ -39,7 +39,7 @@ fn main() {
 
 	// initialize api and set the signer (sender) that is used to sign the extrinsics
 	let from = AccountKeyring::Alice.pair();
-	let client = WsRpcClient::with_default_url();
+	let client = JsonrpseeClient::with_default_url().unwrap();
 	let mut api = Api::<_, _, PlainTipExtrinsicParams<Runtime>, Runtime>::new(client).unwrap();
 	api.set_signer(from);
 

--- a/examples/custom_nonce.rs
+++ b/examples/custom_nonce.rs
@@ -20,15 +20,9 @@ use ac_primitives::AssetTipExtrinsicParamsBuilder;
 use kitchensink_runtime::{BalancesCall, Runtime, RuntimeCall};
 use sp_keyring::AccountKeyring;
 use sp_runtime::{generic::Era, MultiAddress};
-
-#[cfg(feature = "ws-client")]
-use substrate_api_client::rpc::WsRpcClient;
-
-#[cfg(feature = "tungstenite-client")]
-use substrate_api_client::rpc::TungsteniteRpcClient;
-
 use substrate_api_client::{
-	compose_extrinsic_offline, Api, AssetTipExtrinsicParams, UncheckedExtrinsicV4, XtStatus,
+	compose_extrinsic_offline, rpc::JsonrpseeClient, Api, AssetTipExtrinsicParams,
+	UncheckedExtrinsicV4, XtStatus,
 };
 
 fn main() {
@@ -37,11 +31,7 @@ fn main() {
 	// Initialize api and set the signer (sender) that is used to sign the extrinsics.
 	let from = AccountKeyring::Alice.pair();
 
-	#[cfg(feature = "ws-client")]
-	let client = WsRpcClient::with_default_url();
-
-	#[cfg(feature = "tungstenite-client")]
-	let client = TungsteniteRpcClient::with_default_url(100);
+	let client = JsonrpseeClient::with_default_url().unwrap();
 
 	let mut api = Api::<_, _, AssetTipExtrinsicParams<Runtime>, Runtime>::new(client).unwrap();
 	api.set_signer(from);

--- a/examples/custom_nonce.rs
+++ b/examples/custom_nonce.rs
@@ -25,7 +25,8 @@ use substrate_api_client::{
 	UncheckedExtrinsicV4, XtStatus,
 };
 
-fn main() {
+#[tokio::main]
+async fn main() {
 	env_logger::init();
 
 	// Initialize api and set the signer (sender) that is used to sign the extrinsics.

--- a/examples/event_callback.rs
+++ b/examples/event_callback.rs
@@ -28,7 +28,8 @@ use substrate_api_client::{rpc::JsonrpseeClient, Api, AssetTipExtrinsicParams};
 // Replace this crate by your own if you run a custom substrate node to get your custom events.
 use kitchensink_runtime::RuntimeEvent;
 
-fn main() {
+#[tokio::main]
+async fn main() {
 	env_logger::init();
 
 	let client = JsonrpseeClient::with_default_url().unwrap();

--- a/examples/event_callback.rs
+++ b/examples/event_callback.rs
@@ -14,33 +14,24 @@
 */
 
 //! Very simple example that shows how to subscribe to events.
+
 use codec::Decode;
 use kitchensink_runtime::Runtime;
 use log::debug;
 use sp_core::{sr25519, H256 as Hash};
 use substrate_api_client::HandleSubscription;
 
+use substrate_api_client::{rpc::JsonrpseeClient, Api, AssetTipExtrinsicParams};
+
 // This module depends on node_runtime.
 // To avoid dependency collisions, node_runtime has been removed from the substrate-api-client library.
 // Replace this crate by your own if you run a custom substrate node to get your custom events.
 use kitchensink_runtime::RuntimeEvent;
 
-#[cfg(feature = "ws-client")]
-use substrate_api_client::rpc::WsRpcClient;
-
-#[cfg(feature = "tungstenite-client")]
-use substrate_api_client::rpc::TungsteniteRpcClient;
-
-use substrate_api_client::{Api, AssetTipExtrinsicParams};
-
 fn main() {
 	env_logger::init();
 
-	#[cfg(feature = "ws-client")]
-	let client = WsRpcClient::with_default_url();
-
-	#[cfg(feature = "tungstenite-client")]
-	let client = TungsteniteRpcClient::with_default_url(100);
+	let client = JsonrpseeClient::with_default_url().unwrap();
 
 	let api =
 		Api::<sr25519::Pair, _, AssetTipExtrinsicParams<Runtime>, Runtime>::new(client).unwrap();

--- a/examples/event_error_details.rs
+++ b/examples/event_error_details.rs
@@ -18,14 +18,9 @@ use kitchensink_runtime::Runtime;
 use sp_core::crypto::Pair;
 use sp_keyring::AccountKeyring;
 use sp_runtime::{AccountId32 as AccountId, MultiAddress};
-
-#[cfg(feature = "ws-client")]
-use substrate_api_client::rpc::WsRpcClient;
-
-#[cfg(feature = "tungstenite-client")]
-use substrate_api_client::rpc::TungsteniteRpcClient;
-
-use substrate_api_client::{Api, ApiResult, AssetTipExtrinsicParams, StaticEvent, XtStatus};
+use substrate_api_client::{
+	rpc::JsonrpseeClient, Api, ApiResult, AssetTipExtrinsicParams, StaticEvent, XtStatus,
+};
 
 #[derive(Decode)]
 struct TransferEventArgs {
@@ -45,12 +40,7 @@ fn main() {
 	// initialize api and set the signer (sender) that is used to sign the extrinsics
 	let from = AccountKeyring::Alice.pair();
 
-	#[cfg(feature = "ws-client")]
-	let client = WsRpcClient::with_default_url();
-
-	#[cfg(feature = "tungstenite-client")]
-	let client = TungsteniteRpcClient::with_default_url(100);
-
+	let client = JsonrpseeClient::with_default_url().unwrap();
 	let mut api = Api::<_, _, AssetTipExtrinsicParams<Runtime>, Runtime>::new(client).unwrap();
 	api.set_signer(from.clone());
 

--- a/examples/event_error_details.rs
+++ b/examples/event_error_details.rs
@@ -34,7 +34,8 @@ impl StaticEvent for TransferEventArgs {
 	const EVENT: &'static str = "Transfer";
 }
 
-fn main() {
+#[tokio::main]
+async fn main() {
 	env_logger::init();
 
 	// initialize api and set the signer (sender) that is used to sign the extrinsics

--- a/examples/generic_event_callback.rs
+++ b/examples/generic_event_callback.rs
@@ -21,14 +21,9 @@ use kitchensink_runtime::Runtime;
 use sp_keyring::AccountKeyring;
 use sp_runtime::{AccountId32 as AccountId, MultiAddress};
 use std::thread;
-
-#[cfg(feature = "ws-client")]
-use substrate_api_client::rpc::WsRpcClient;
-
-#[cfg(feature = "tungstenite-client")]
-use substrate_api_client::rpc::TungsteniteRpcClient;
-
-use substrate_api_client::{Api, AssetTipExtrinsicParams, StaticEvent, XtStatus};
+use substrate_api_client::{
+	rpc::JsonrpseeClient, Api, AssetTipExtrinsicParams, StaticEvent, XtStatus,
+};
 
 // Look at the how the transfer event looks like in in the metadata
 #[derive(Decode)]
@@ -48,13 +43,7 @@ fn main() {
 
 	// Initialize api and set the signer (sender) that is used to sign the extrinsics.
 	let alice = AccountKeyring::Alice.pair();
-
-	#[cfg(feature = "ws-client")]
-	let client = WsRpcClient::with_default_url();
-
-	#[cfg(feature = "tungstenite-client")]
-	let client = TungsteniteRpcClient::with_default_url(100);
-
+	let client = JsonrpseeClient::with_default_url().unwrap();
 	let mut api = Api::<_, _, AssetTipExtrinsicParams<Runtime>, Runtime>::new(client).unwrap();
 	api.set_signer(alice);
 

--- a/examples/generic_event_callback.rs
+++ b/examples/generic_event_callback.rs
@@ -38,7 +38,8 @@ impl StaticEvent for TransferEventArgs {
 	const EVENT: &'static str = "Transfer";
 }
 
-fn main() {
+#[tokio::main]
+async fn main() {
 	env_logger::init();
 
 	// Initialize api and set the signer (sender) that is used to sign the extrinsics.

--- a/examples/generic_extrinsic.rs
+++ b/examples/generic_extrinsic.rs
@@ -18,15 +18,9 @@
 
 use kitchensink_runtime::Runtime;
 use sp_keyring::AccountKeyring;
-
-#[cfg(feature = "ws-client")]
-use substrate_api_client::rpc::WsRpcClient;
-
-#[cfg(feature = "tungstenite-client")]
-use substrate_api_client::rpc::TungsteniteRpcClient;
-
 use substrate_api_client::{
-	compose_extrinsic, Api, AssetTipExtrinsicParams, GenericAddress, UncheckedExtrinsicV4, XtStatus,
+	compose_extrinsic, rpc::JsonrpseeClient, Api, AssetTipExtrinsicParams, GenericAddress,
+	UncheckedExtrinsicV4, XtStatus,
 };
 
 fn main() {
@@ -35,11 +29,7 @@ fn main() {
 	// initialize api and set the signer (sender) that is used to sign the extrinsics
 	let from = AccountKeyring::Alice.pair();
 
-	#[cfg(feature = "ws-client")]
-	let client = WsRpcClient::with_default_url();
-
-	#[cfg(feature = "tungstenite-client")]
-	let client = TungsteniteRpcClient::with_default_url(100);
+	let client = JsonrpseeClient::with_default_url().unwrap();
 
 	let mut api = Api::<_, _, AssetTipExtrinsicParams<Runtime>, Runtime>::new(client).unwrap();
 	api.set_signer(from);

--- a/examples/generic_extrinsic.rs
+++ b/examples/generic_extrinsic.rs
@@ -23,7 +23,8 @@ use substrate_api_client::{
 	UncheckedExtrinsicV4, XtStatus,
 };
 
-fn main() {
+#[tokio::main]
+async fn main() {
 	env_logger::init();
 
 	// initialize api and set the signer (sender) that is used to sign the extrinsics

--- a/examples/get_account_identity.rs
+++ b/examples/get_account_identity.rs
@@ -31,7 +31,8 @@ type BalanceOf<T> = <<T as pallet_identity::Config>::Currency as Currency<
 type MaxRegistrarsOf<T> = <T as pallet_identity::Config>::MaxRegistrars;
 type MaxAdditionalFieldsOf<T> = <T as pallet_identity::Config>::MaxAdditionalFields;
 
-fn main() {
+#[tokio::main]
+async fn main() {
 	env_logger::init();
 
 	// Create the node-api client and set the signer.

--- a/examples/get_account_identity.rs
+++ b/examples/get_account_identity.rs
@@ -20,15 +20,9 @@ use kitchensink_runtime::Runtime as KitchensinkRuntime;
 use pallet_identity::{Data, IdentityInfo, Registration};
 use sp_core::{crypto::Pair, H256};
 use sp_keyring::AccountKeyring;
-
-#[cfg(feature = "ws-client")]
-use substrate_api_client::rpc::WsRpcClient;
-
-#[cfg(feature = "tungstenite-client")]
-use substrate_api_client::rpc::TungsteniteRpcClient;
-
 use substrate_api_client::{
-	compose_extrinsic, Api, AssetTipExtrinsicParams, UncheckedExtrinsicV4, XtStatus,
+	compose_extrinsic, rpc::JsonrpseeClient, Api, AssetTipExtrinsicParams, UncheckedExtrinsicV4,
+	XtStatus,
 };
 
 type BalanceOf<T> = <<T as pallet_identity::Config>::Currency as Currency<
@@ -41,11 +35,7 @@ fn main() {
 	env_logger::init();
 
 	// Create the node-api client and set the signer.
-	#[cfg(feature = "ws-client")]
-	let client = WsRpcClient::with_default_url();
-
-	#[cfg(feature = "tungstenite-client")]
-	let client = TungsteniteRpcClient::with_default_url(100);
+	let client = JsonrpseeClient::with_default_url().unwrap();
 
 	let alice = AccountKeyring::Alice.pair();
 	let mut api =

--- a/examples/get_blocks.rs
+++ b/examples/get_blocks.rs
@@ -18,24 +18,14 @@
 
 use kitchensink_runtime::Runtime;
 use sp_core::sr25519;
-use substrate_api_client::HandleSubscription;
-
-#[cfg(feature = "ws-client")]
-use substrate_api_client::rpc::WsRpcClient;
-
-#[cfg(feature = "tungstenite-client")]
-use substrate_api_client::rpc::TungsteniteRpcClient;
-
-use substrate_api_client::{Api, AssetTipExtrinsicParams};
+use substrate_api_client::{
+	rpc::JsonrpseeClient, Api, AssetTipExtrinsicParams, HandleSubscription,
+};
 
 fn main() {
 	env_logger::init();
 
-	#[cfg(feature = "ws-client")]
-	let client = WsRpcClient::with_default_url();
-
-	#[cfg(feature = "tungstenite-client")]
-	let client = TungsteniteRpcClient::with_default_url(100);
+	let client = JsonrpseeClient::with_default_url().unwrap();
 
 	let api =
 		Api::<sr25519::Pair, _, AssetTipExtrinsicParams<Runtime>, Runtime>::new(client).unwrap();

--- a/examples/get_blocks.rs
+++ b/examples/get_blocks.rs
@@ -22,7 +22,8 @@ use substrate_api_client::{
 	rpc::JsonrpseeClient, Api, AssetTipExtrinsicParams, HandleSubscription,
 };
 
-fn main() {
+#[tokio::main]
+async fn main() {
 	env_logger::init();
 
 	let client = JsonrpseeClient::with_default_url().unwrap();

--- a/examples/get_existential_deposit.rs
+++ b/examples/get_existential_deposit.rs
@@ -19,7 +19,8 @@ use kitchensink_runtime::Runtime;
 use sp_runtime::app_crypto::sp_core::sr25519;
 use substrate_api_client::{rpc::JsonrpseeClient, Api, AssetTipExtrinsicParams};
 
-fn main() {
+#[tokio::main]
+async fn main() {
 	env_logger::init();
 
 	let client = JsonrpseeClient::with_default_url().unwrap();

--- a/examples/get_existential_deposit.rs
+++ b/examples/get_existential_deposit.rs
@@ -17,23 +17,12 @@ limitations under the License.
 
 use kitchensink_runtime::Runtime;
 use sp_runtime::app_crypto::sp_core::sr25519;
-
-#[cfg(feature = "ws-client")]
-use substrate_api_client::rpc::WsRpcClient;
-
-#[cfg(feature = "tungstenite-client")]
-use substrate_api_client::rpc::TungsteniteRpcClient;
-
-use substrate_api_client::{Api, AssetTipExtrinsicParams};
+use substrate_api_client::{rpc::JsonrpseeClient, Api, AssetTipExtrinsicParams};
 
 fn main() {
 	env_logger::init();
 
-	#[cfg(feature = "ws-client")]
-	let client = WsRpcClient::with_default_url();
-
-	#[cfg(feature = "tungstenite-client")]
-	let client = TungsteniteRpcClient::with_default_url(100);
+	let client = JsonrpseeClient::with_default_url().unwrap();
 
 	let api =
 		Api::<sr25519::Pair, _, AssetTipExtrinsicParams<Runtime>, Runtime>::new(client).unwrap();

--- a/examples/get_storage.rs
+++ b/examples/get_storage.rs
@@ -25,7 +25,8 @@ type AccountDataFor<T> = <T as frame_system::Config>::AccountData;
 
 type AccountInfo = GenericAccountInfo<IndexFor<Runtime>, AccountDataFor<Runtime>>;
 
-fn main() {
+#[tokio::main]
+async fn main() {
 	env_logger::init();
 
 	let client = JsonrpseeClient::with_default_url().unwrap();

--- a/examples/get_storage.rs
+++ b/examples/get_storage.rs
@@ -18,14 +18,7 @@
 use frame_system::AccountInfo as GenericAccountInfo;
 use kitchensink_runtime::Runtime;
 use sp_keyring::AccountKeyring;
-
-#[cfg(feature = "ws-client")]
-use substrate_api_client::rpc::WsRpcClient;
-
-#[cfg(feature = "tungstenite-client")]
-use substrate_api_client::rpc::TungsteniteRpcClient;
-
-use substrate_api_client::{Api, AssetTipExtrinsicParams};
+use substrate_api_client::{rpc::JsonrpseeClient, Api, AssetTipExtrinsicParams};
 
 type IndexFor<T> = <T as frame_system::Config>::Index;
 type AccountDataFor<T> = <T as frame_system::Config>::AccountData;
@@ -35,11 +28,7 @@ type AccountInfo = GenericAccountInfo<IndexFor<Runtime>, AccountDataFor<Runtime>
 fn main() {
 	env_logger::init();
 
-	#[cfg(feature = "ws-client")]
-	let client = WsRpcClient::with_default_url();
-
-	#[cfg(feature = "tungstenite-client")]
-	let client = TungsteniteRpcClient::with_default_url(100);
+	let client = JsonrpseeClient::with_default_url().unwrap();
 
 	let mut api = Api::<_, _, AssetTipExtrinsicParams<Runtime>, Runtime>::new(client).unwrap();
 

--- a/examples/print_metadata.rs
+++ b/examples/print_metadata.rs
@@ -18,23 +18,12 @@
 
 use kitchensink_runtime::Runtime;
 use sp_core::sr25519;
-
-#[cfg(feature = "ws-client")]
-use substrate_api_client::rpc::WsRpcClient;
-
-#[cfg(feature = "tungstenite-client")]
-use substrate_api_client::rpc::TungsteniteRpcClient;
-
-use substrate_api_client::{Api, AssetTipExtrinsicParams, Metadata};
+use substrate_api_client::{rpc::JsonrpseeClient, Api, AssetTipExtrinsicParams, Metadata};
 
 fn main() {
 	env_logger::init();
 
-	#[cfg(feature = "ws-client")]
-	let client = WsRpcClient::with_default_url();
-
-	#[cfg(feature = "tungstenite-client")]
-	let client = TungsteniteRpcClient::with_default_url(100);
+	let client = JsonrpseeClient::with_default_url().unwrap();
 
 	let mut api =
 		Api::<sr25519::Pair, _, AssetTipExtrinsicParams<Runtime>, Runtime>::new(client).unwrap();

--- a/examples/print_metadata.rs
+++ b/examples/print_metadata.rs
@@ -20,7 +20,8 @@ use kitchensink_runtime::Runtime;
 use sp_core::sr25519;
 use substrate_api_client::{rpc::JsonrpseeClient, Api, AssetTipExtrinsicParams, Metadata};
 
-fn main() {
+#[tokio::main]
+async fn main() {
 	env_logger::init();
 
 	let client = JsonrpseeClient::with_default_url().unwrap();

--- a/examples/staking_payout.rs
+++ b/examples/staking_payout.rs
@@ -7,13 +7,13 @@ use sp_keyring::AccountKeyring;
 #[cfg(feature = "staking-xt")]
 use sp_runtime::{app_crypto::Ss58Codec, AccountId32};
 #[cfg(feature = "staking-xt")]
-use substrate_api_client::{rpc::WsRpcClient, Api, AssetTipExtrinsicParams, XtStatus};
+use substrate_api_client::{rpc::JsonrpseeClient, Api, AssetTipExtrinsicParams, XtStatus};
 
 #[cfg(feature = "staking-xt")]
 fn main() {
 	env_logger::init();
 	let from = AccountKeyring::Alice.pair();
-	let client = WsRpcClient::with_default_url();
+	let client = JsonrpseeClient::with_default_url().unwrap();
 	let mut api = Api::<_, _, AssetTipExtrinsicParams<Runtime>, Runtime>::new(client).unwrap();
 	api.set_signer(from);
 	let mut exposure: Exposure<AccountId32, u128> = Exposure { total: 0, own: 0, others: vec![] };

--- a/examples/staking_payout.rs
+++ b/examples/staking_payout.rs
@@ -10,7 +10,8 @@ use sp_runtime::{app_crypto::Ss58Codec, AccountId32};
 use substrate_api_client::{rpc::JsonrpseeClient, Api, AssetTipExtrinsicParams, XtStatus};
 
 #[cfg(feature = "staking-xt")]
-fn main() {
+#[tokio::main]
+async fn main() {
 	env_logger::init();
 	let from = AccountKeyring::Alice.pair();
 	let client = JsonrpseeClient::with_default_url().unwrap();

--- a/examples/sudo.rs
+++ b/examples/sudo.rs
@@ -24,7 +24,8 @@ use substrate_api_client::{
 	GenericAddress, UncheckedExtrinsicV4, XtStatus,
 };
 
-fn main() {
+#[tokio::main]
+async fn main() {
 	env_logger::init();
 
 	// initialize api and set the signer (sender) that is used to sign the extrinsics

--- a/examples/sudo.rs
+++ b/examples/sudo.rs
@@ -19,16 +19,9 @@
 use codec::Compact;
 use kitchensink_runtime::Runtime;
 use sp_keyring::AccountKeyring;
-
-#[cfg(feature = "ws-client")]
-use substrate_api_client::rpc::WsRpcClient;
-
-#[cfg(feature = "tungstenite-client")]
-use substrate_api_client::rpc::TungsteniteRpcClient;
-
 use substrate_api_client::{
-	compose_call, compose_extrinsic, Api, AssetTipExtrinsicParams, GenericAddress,
-	UncheckedExtrinsicV4, XtStatus,
+	compose_call, compose_extrinsic, rpc::JsonrpseeClient, Api, AssetTipExtrinsicParams,
+	GenericAddress, UncheckedExtrinsicV4, XtStatus,
 };
 
 fn main() {
@@ -36,11 +29,7 @@ fn main() {
 
 	// initialize api and set the signer (sender) that is used to sign the extrinsics
 	let sudoer = AccountKeyring::Alice.pair();
-	#[cfg(feature = "ws-client")]
-	let client = WsRpcClient::with_default_url();
-
-	#[cfg(feature = "tungstenite-client")]
-	let client = TungsteniteRpcClient::with_default_url(100);
+	let client = JsonrpseeClient::with_default_url().unwrap();
 
 	let mut api = Api::<_, _, AssetTipExtrinsicParams<Runtime>, Runtime>::new(client).unwrap();
 	api.set_signer(sudoer);

--- a/examples/transfer_using_seed.rs
+++ b/examples/transfer_using_seed.rs
@@ -21,10 +21,10 @@ use sp_core::{
 	sr25519,
 };
 use sp_runtime::MultiAddress;
-use substrate_api_client::rpc::JsonrpseeClient;
-use substrate_api_client::{Api, AssetTipExtrinsicParams, XtStatus};
+use substrate_api_client::{rpc::JsonrpseeClient, Api, AssetTipExtrinsicParams, XtStatus};
 
-fn main() {
+#[tokio::main]
+async fn main() {
 	env_logger::init();
 	// Alice's seed: subkey inspect //Alice.
 	let alice: sr25519::Pair = Pair::from_string(

--- a/examples/transfer_with_tungstenite_client.rs
+++ b/examples/transfer_with_tungstenite_client.rs
@@ -21,8 +21,7 @@ use sp_core::{
 	sr25519,
 };
 use sp_runtime::MultiAddress;
-use substrate_api_client::rpc::JsonrpseeClient;
-use substrate_api_client::{Api, AssetTipExtrinsicParams, XtStatus};
+use substrate_api_client::{rpc::TungsteniteRpcClient, Api, AssetTipExtrinsicParams, XtStatus};
 
 fn main() {
 	env_logger::init();
@@ -35,7 +34,7 @@ fn main() {
 	println!("signer account: {}", alice.public().to_ss58check());
 
 	// Initialize api and set the signer (sender) that is used to sign the extrinsics.
-	let client = JsonrpseeClient::with_default_url().unwrap();
+	let client = TungsteniteRpcClient::with_default_url(100);
 
 	let mut api = Api::<_, _, AssetTipExtrinsicParams<Runtime>, Runtime>::new(client).unwrap();
 	api.set_signer(alice.clone());

--- a/examples/transfer_with_ws_client.rs
+++ b/examples/transfer_with_ws_client.rs
@@ -21,8 +21,7 @@ use sp_core::{
 	sr25519,
 };
 use sp_runtime::MultiAddress;
-use substrate_api_client::rpc::JsonrpseeClient;
-use substrate_api_client::{Api, AssetTipExtrinsicParams, XtStatus};
+use substrate_api_client::{rpc::WsRpcClient, Api, AssetTipExtrinsicParams, XtStatus};
 
 fn main() {
 	env_logger::init();
@@ -35,7 +34,7 @@ fn main() {
 	println!("signer account: {}", alice.public().to_ss58check());
 
 	// Initialize api and set the signer (sender) that is used to sign the extrinsics.
-	let client = JsonrpseeClient::with_default_url().unwrap();
+	let client = WsRpcClient::with_default_url();
 
 	let mut api = Api::<_, _, AssetTipExtrinsicParams<Runtime>, Runtime>::new(client).unwrap();
 	api.set_signer(alice.clone());

--- a/src/rpc/error.rs
+++ b/src/rpc/error.rs
@@ -39,7 +39,6 @@ pub enum Error {
 	Client(#[from] Box<dyn std::error::Error + Send + Sync + 'static>),
 }
 
-#[cfg(feature = "ws-client")]
 impl From<SendError<String>> for Error {
 	fn from(error: SendError<String>) -> Self {
 		Self::Send(error.0)

--- a/src/rpc/jsonrpsee_client/mod.rs
+++ b/src/rpc/jsonrpsee_client/mod.rs
@@ -1,0 +1,93 @@
+/*
+   Copyright 2019 Supercomputing Systems AG
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+	   http://www.apache.org/licenses/LICENSE-2.0
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+use crate::rpc::{Error, Request, Result, RpcParams, Subscribe};
+use futures::executor::block_on;
+use jsonrpsee::{
+	client_transport::ws::{Uri, WsTransportClientBuilder},
+	core::{
+		client::{Client, ClientBuilder, ClientT, SubscriptionClientT},
+		traits::ToRpcParams,
+	},
+};
+use serde::de::DeserializeOwned;
+use serde_json::value::RawValue;
+use std::sync::Arc;
+
+pub use subscription::SubscriptionWrapper;
+
+mod subscription;
+
+#[derive(Clone)]
+pub struct JsonrpseeClient {
+	inner: Arc<Client>,
+}
+
+impl JsonrpseeClient {
+	pub fn new(url: &str) -> Result<Self> {
+		block_on(Self::async_new(url))
+	}
+
+	pub fn with_default_url() -> Result<Self> {
+		Self::new("ws://127.0.0.1:9944")
+	}
+
+	async fn async_new(url: &str) -> Result<Self> {
+		let uri: Uri = url.parse().map_err(|e| Error::Client(Box::new(e)))?;
+		let (tx, rx) = WsTransportClientBuilder::default()
+			.build(uri)
+			.await
+			.map_err(|e| Error::Client(Box::new(e)))?;
+		let client = ClientBuilder::default()
+			.max_notifs_per_subscription(4096)
+			.build_with_tokio(tx, rx);
+		Ok(Self { inner: Arc::new(client) })
+	}
+}
+
+impl Request for JsonrpseeClient {
+	fn request<R: DeserializeOwned>(&self, method: &str, params: RpcParams) -> Result<R> {
+		// Support async: #278
+		block_on(self.inner.request(method, RpcParamsWrapper(params)))
+			.map_err(|e| Error::Client(Box::new(e)))
+	}
+}
+
+impl Subscribe for JsonrpseeClient {
+	type Subscription<Notification> = SubscriptionWrapper<Notification> where Notification: DeserializeOwned;
+
+	fn subscribe<Notification: DeserializeOwned>(
+		&self,
+		sub: &str,
+		params: RpcParams,
+		unsub: &str,
+	) -> Result<Self::Subscription<Notification>> {
+		block_on(self.inner.subscribe(sub, RpcParamsWrapper(params), unsub))
+			.map(|sub| sub.into())
+			.map_err(|e| Error::Client(Box::new(e)))
+	}
+}
+
+pub struct RpcParamsWrapper(RpcParams);
+
+impl ToRpcParams for RpcParamsWrapper {
+	fn to_rpc_params(self) -> core::result::Result<Option<Box<RawValue>>, jsonrpsee::core::Error> {
+		if let Some(json) = self.0.build() {
+			RawValue::from_string(json)
+				.map(Some)
+				.map_err(jsonrpsee::core::Error::ParseError)
+		} else {
+			Ok(None)
+		}
+	}
+}

--- a/src/rpc/jsonrpsee_client/subscription.rs
+++ b/src/rpc/jsonrpsee_client/subscription.rs
@@ -1,0 +1,41 @@
+/*
+   Copyright 2019 Supercomputing Systems AG
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+	   http://www.apache.org/licenses/LICENSE-2.0
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+use crate::rpc::{Error, HandleSubscription, Result};
+use futures::executor::block_on;
+use jsonrpsee::core::client::Subscription;
+use serde::de::DeserializeOwned;
+
+#[derive(Debug)]
+pub struct SubscriptionWrapper<Notification> {
+	inner: Subscription<Notification>,
+}
+
+// Support async: #278 (careful with no_std compatibility).
+impl<Notification: DeserializeOwned> HandleSubscription<Notification>
+	for SubscriptionWrapper<Notification>
+{
+	fn next(&mut self) -> Option<Result<Notification>> {
+		block_on(self.inner.next()).map(|result| result.map_err(|e| Error::Client(Box::new(e))))
+	}
+
+	fn unsubscribe(self) -> Result<()> {
+		block_on(self.inner.unsubscribe()).map_err(|e| Error::Client(Box::new(e)))
+	}
+}
+
+impl<Notification> From<Subscription<Notification>> for SubscriptionWrapper<Notification> {
+	fn from(inner: Subscription<Notification>) -> Self {
+		Self { inner }
+	}
+}

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -26,6 +26,11 @@ pub use tungstenite_client::client::TungsteniteRpcClient;
 #[cfg(feature = "tungstenite-client")]
 pub mod tungstenite_client;
 
+#[cfg(feature = "jsonrpsee-client")]
+pub use jsonrpsee_client::*;
+#[cfg(feature = "jsonrpsee-client")]
+pub mod jsonrpsee_client;
+
 pub mod error;
 
 pub use error::*;

--- a/src/rpc/tungstenite_client/client.rs
+++ b/src/rpc/tungstenite_client/client.rs
@@ -131,7 +131,7 @@ fn subscribe_to_server(
 	debug!("Connected to the server. Response HTTP code: {}", response.status());
 
 	// Subscribe to server
-	socket.write_message(Message::Text(json_req.to_string()))?;
+	socket.write_message(Message::Text(json_req))?;
 
 	loop {
 		let msg = read_until_text_message(&mut socket)?;
@@ -156,7 +156,7 @@ fn send_message_to_client(result_in: ThreadOut<String>, message: &str) -> Result
 		},
 		None => {
 			let message = serde_json::to_string(&value["params"]["result"])?;
-			result_in.send(message.into())?;
+			result_in.send(message)?;
 		},
 	};
 	Ok(())


### PR DESCRIPTION
For one run of the example `transfer_using_seed`:
- Without jsonrpsee: 
```
2022-12-06 13:50:54 ✨ Imported #109 (0x5083…7ff3)
2022-12-06 13:50:55 Accepting new connection 1/100
2022-12-06 13:50:55 Accepting new connection 1/100
2022-12-06 13:50:55 Accepting new connection 1/100
2022-12-06 13:50:55 Accepting new connection 1/100
2022-12-06 13:50:55 Accepting new connection 1/100
2022-12-06 13:50:55 Accepting new connection 1/100
2022-12-06 13:50:55 Accepting new connection 1/100
2022-12-06 13:50:57 🙌 Starting consensus session on top of parent 0x50835f1edb77c9e2d5f90336bd7e25c581b9cf6051a39f90425d9cb1f37f7ff3
2022-12-06 13:50:57 🎁 Prepared block for proposing at 110 (0 ms) [hash: 0xa57c1ca6755f5fb5e5a9d2bab7d6e4cbe44049400144a04c38850bd3b0d3cdd7; parent_hash: 0x5083…7ff3; extrinsics (2): [0x4d9f…c027, 0x6dda…1895]]
```
- With jsonrpsee:
```
2022-12-06 13:47:09 🔖 Pre-sealed block for proposal at 34. Hash now 0x2346ae46a27fde75d557ca187b634f3de23e25aab109e0876343f2f25e68611d, previously 0xb78844a25c88c5befeb5d91cc84ba675d5902dcd552719ab0097846be12b20b7.
2022-12-06 13:47:09 ✨ Imported #34 (0x2346…611d)
2022-12-06 13:47:09 Accepting new connection 1/100
2022-12-06 13:47:12 🙌 Starting consensus session on top of parent 0x2346ae46a27fde75d557ca187b634f3de23e25aab109e0876343f2f25e68611d
```

closes #303
closes #133
closes #134 because jsonrpsee supports timeouts:  https://github.com/paritytech/jsonrpsee/blob/3a159638ed6c8ad4c80ad80bea74ef1d13f2f503/core/src/client/async_client/mod.rs#L98-L103