### PR TITLE
Add `submit_and_watch_extrinsic_until_success` method

### DIFF
--- a/examples/examples/batch_payout.rs
+++ b/examples/examples/batch_payout.rs
@@ -97,6 +97,8 @@ async fn main() {
 			let batching = api.batch(payout_calls);
 			let results_hash = api
 				.submit_and_watch_extrinsic_until(&batching.hex_encode(), XtStatus::InBlock)
+				.unwrap()
+				.block_hash
 				.unwrap();
 			num_of_claimed_payouts += payout_calls_len;
 

--- a/examples/examples/compose_extrinsic_offline.rs
+++ b/examples/examples/compose_extrinsic_offline.rs
@@ -68,6 +68,7 @@ async fn main() {
 	let block_hash = api
 		.submit_and_watch_extrinsic_until(&xt.hex_encode(), XtStatus::InBlock)
 		.unwrap()
+		.block_hash
 		.unwrap();
-	println!("[+] Transaction got included in block {:?}", block_hash);
+	println!("[+] Extrinsic got included in block {:?}", block_hash);
 }

--- a/examples/examples/contract_instantiate_with_code.rs
+++ b/examples/examples/contract_instantiate_with_code.rs
@@ -69,8 +69,10 @@ async fn main() {
 	println!("[+] Creating a contract instance with extrinsic:\n\n{:?}\n", xt);
 	let block_hash = api
 		.submit_and_watch_extrinsic_until(&xt.hex_encode(), XtStatus::InBlock)
+		.unwrap()
+		.block_hash
 		.unwrap();
-	println!("[+] Transaction is in Block. Hash: {:?}\n", block_hash);
+	println!("[+] Extrinsic is in Block. Hash: {:?}\n", block_hash);
 
 	println!("[+] Waiting for the contracts.Instantiated event");
 
@@ -81,8 +83,8 @@ async fn main() {
 	let xt = api.contract_call(args.contract.into(), 500_000, 500_000, vec![0u8]);
 
 	println!("[+] Calling the contract with extrinsic Extrinsic:\n{:?}\n\n", xt);
-	let block_hash = api
+	let report = api
 		.submit_and_watch_extrinsic_until(&xt.hex_encode(), XtStatus::Finalized)
 		.unwrap();
-	println!("[+] Transaction got finalized. Hash: {:?}", block_hash);
+	println!("[+] Extrinsic got finalized. Extrinsic Hash: {:?}", report.extrinsic_hash);
 }

--- a/examples/examples/generic_event_callback.rs
+++ b/examples/examples/generic_event_callback.rs
@@ -67,11 +67,12 @@ async fn main() {
 	println!("[+] Composed extrinsic: {:?}\n", xt);
 
 	// Send extrinsic.
-	let tx_hash = api
+	let block_hash = api
 		.submit_and_watch_extrinsic_until(&xt.hex_encode(), XtStatus::InBlock)
 		.unwrap()
+		.block_hash
 		.unwrap();
-	println!("[+] Transaction got included. Hash: {:?}\n", tx_hash);
+	println!("[+] Transaction got included. Hash: {:?}\n", block_hash);
 
 	let args = thread_output.join().unwrap();
 

--- a/examples/examples/generic_extrinsic.rs
+++ b/examples/examples/generic_extrinsic.rs
@@ -51,8 +51,8 @@ async fn main() {
 	println!("[+] Composed Extrinsic:\n {:?}\n", xt);
 
 	// send and watch extrinsic until InBlock
-	let tx_hash = api
+	let report = api
 		.submit_and_watch_extrinsic_until(&xt.hex_encode(), XtStatus::InBlock)
 		.unwrap();
-	println!("[+] Transaction got included. Hash: {:?}", tx_hash);
+	println!("[+] Extrinsic got included. Extrinsic Hash: {:?}", report.extrinsic_hash);
 }

--- a/examples/examples/get_account_identity.rs
+++ b/examples/examples/get_account_identity.rs
@@ -64,6 +64,8 @@ async fn main() {
 	// Send and watch extrinsic until InBlock.
 	let _block_hash = api
 		.submit_and_watch_extrinsic_until(&xt.hex_encode(), XtStatus::InBlock)
+		.unwrap()
+		.block_hash
 		.unwrap();
 
 	// Get the storage value from the pallet. Check out the pallet itself to know it's type:

--- a/examples/examples/staking_payout.rs
+++ b/examples/examples/staking_payout.rs
@@ -42,9 +42,9 @@ async fn main() {
 	}
 	if exposure.total > 0_u128 {
 		let call = api.payout_stakers(idx, account);
-		let result = api
+		let report = api
 			.submit_and_watch_extrinsic_until(&call.hex_encode(), XtStatus::InBlock)
 			.unwrap();
-		println!("{:?}", result);
+		println!("{:?}", report);
 	}
 }

--- a/examples/examples/sudo.rs
+++ b/examples/examples/sudo.rs
@@ -54,6 +54,8 @@ async fn main() {
 	// send and watch extrinsic until in block
 	let block_hash = api
 		.submit_and_watch_extrinsic_until(&xt.hex_encode(), XtStatus::InBlock)
+		.unwrap()
+		.block_hash
 		.unwrap();
-	println!("[+] Transaction got included. Hash: {:?}", block_hash);
+	println!("[+] Extrinsic got included. Block Hash: {:?}", block_hash);
 }

--- a/examples/examples/transfer_using_seed.rs
+++ b/examples/examples/transfer_using_seed.rs
@@ -65,8 +65,10 @@ async fn main() {
 	// Send and watch extrinsic until in block.
 	let block_hash = api
 		.submit_and_watch_extrinsic_until(&xt.hex_encode(), XtStatus::InBlock)
+		.unwrap()
+		.block_hash
 		.unwrap();
-	println!("[+] Transaction got included. Hash: {:?}\n", block_hash);
+	println!("[+] Extrinsic got included. Hash: {:?}\n", block_hash);
 
 	// Verify that Bob's free Balance increased.
 	let bob_account_data = api.get_account_data(&bob.into()).unwrap().unwrap();

--- a/examples/examples/transfer_with_tungstenite_client.rs
+++ b/examples/examples/transfer_with_tungstenite_client.rs
@@ -64,8 +64,10 @@ fn main() {
 	// Send and watch extrinsic until in block.
 	let block_hash = api
 		.submit_and_watch_extrinsic_until(&xt.hex_encode(), XtStatus::InBlock)
+		.unwrap()
+		.block_hash
 		.unwrap();
-	println!("[+] Transaction got included. Hash: {:?}\n", block_hash);
+	println!("[+] Extrinsic got included. Hash: {:?}\n", block_hash);
 
 	// Verify that Bob's free Balance increased.
 	let bob_account_data = api.get_account_data(&bob.into()).unwrap().unwrap();

--- a/examples/examples/transfer_with_ws_client.rs
+++ b/examples/examples/transfer_with_ws_client.rs
@@ -63,8 +63,10 @@ fn main() {
 	// Send and watch extrinsic until in block.
 	let block_hash = api
 		.submit_and_watch_extrinsic_until(&xt.hex_encode(), XtStatus::InBlock)
+		.unwrap()
+		.block_hash
 		.unwrap();
-	println!("[+] Transaction got included. Hash: {:?}\n", block_hash);
+	println!("[+] Extrinsic got included. Hash: {:?}\n", block_hash);
 
 	// Verify that Bob's free Balance increased.
 	let bob_account_data = api.get_account_data(&bob.into()).unwrap().unwrap();

--- a/src/api/error.rs
+++ b/src/api/error.rs
@@ -59,6 +59,10 @@ pub enum Error {
 	Extrinsic(String),
 	#[error("Stream ended unexpectedly")]
 	NoStream,
+	#[error("Expected a block hash")]
+	NoBlockHash,
+	#[error("Did not find any block")]
+	NoBlock,
 	#[error(transparent)]
 	Other(#[from] Box<dyn std::error::Error + Send + Sync + 'static>),
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -25,7 +25,7 @@ pub mod rpc_api;
 
 use serde::{Deserialize, Serialize};
 pub struct TransactionReport<Hash> {
-	pub tx_hash: Hash,
+	pub xt_hash: Hash,
 	pub block_hash: Option<Hash>,
 	pub status: TransactionStatus<Hash, Hash>,
 	pub events: Option<Events<Hash>>,
@@ -33,12 +33,12 @@ pub struct TransactionReport<Hash> {
 
 impl<Hash> TransactionReport<Hash> {
 	pub fn new(
-		tx_hash: Hash,
+		xt_hash: Hash,
 		block_hash: Option<Hash>,
 		status: TransactionStatus<Hash, Hash>,
 		events: Option<Events<Hash>>,
 	) -> Self {
-		Self { tx_hash, block_hash, status, events }
+		Self { xt_hash, block_hash, status, events }
 	}
 }
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -24,6 +24,23 @@ pub mod error;
 pub mod rpc_api;
 
 use serde::{Deserialize, Serialize};
+pub struct TransactionReport<Hash> {
+	pub tx_hash: Hash,
+	pub block_hash: Option<Hash>,
+	pub status: TransactionStatus<Hash, Hash>,
+	pub events: Option<Events<Hash>>,
+}
+
+impl<Hash> TransactionReport<Hash> {
+	pub fn new(
+		tx_hash: Hash,
+		block_hash: Option<Hash>,
+		status: TransactionStatus<Hash, Hash>,
+		events: Option<Events<Hash>>,
+	) -> Self {
+		Self { tx_hash, block_hash, status, events }
+	}
+}
 
 /// Simplified TransactionStatus to allow the user to choose until when to watch
 /// an extrinsic.
@@ -92,6 +109,10 @@ impl<Hash, BlockHash> TransactionStatus<Hash, BlockHash> {
 				| TransactionStatus::FinalityTimeout(_)
 				| TransactionStatus::Finalized(_)
 		)
+	}
+
+	pub fn is_final(&self) -> bool {
+		matches!(self, TransactionStatus::FinalityTimeout(_) | TransactionStatus::Finalized(_))
 	}
 }
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -24,21 +24,32 @@ pub mod error;
 pub mod rpc_api;
 
 use serde::{Deserialize, Serialize};
-pub struct TransactionReport<Hash> {
-	pub xt_hash: Hash,
+
+/// Extrinsic report returned upon a submit_and_watch request.
+/// Holds as much information as available.
+#[derive(Debug, Clone)]
+pub struct ExtrinsicReport<Hash> {
+	// Hash of the extrinsic.
+	pub extrinsic_hash: Hash,
+	// Block hash of the block the extrinsic was included in.
+	// Only available if watched until at least `InBlock`.
 	pub block_hash: Option<Hash>,
+	// Last known Transaction Status.
 	pub status: TransactionStatus<Hash, Hash>,
+	// Events assosciated to the extrinsic.
+	// Only available if explicitly stated, because
+	// extra node queries are necessary to fetch the events.
 	pub events: Option<Vec<EventDetails>>,
 }
 
-impl<Hash> TransactionReport<Hash> {
+impl<Hash> ExtrinsicReport<Hash> {
 	pub fn new(
-		xt_hash: Hash,
+		extrinsic_hash: Hash,
 		block_hash: Option<Hash>,
 		status: TransactionStatus<Hash, Hash>,
 		events: Option<Vec<EventDetails>>,
 	) -> Self {
-		Self { xt_hash, block_hash, status, events }
+		Self { extrinsic_hash, block_hash, status, events }
 	}
 }
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -28,7 +28,7 @@ pub struct TransactionReport<Hash> {
 	pub xt_hash: Hash,
 	pub block_hash: Option<Hash>,
 	pub status: TransactionStatus<Hash, Hash>,
-	pub events: Option<Events<Hash>>,
+	pub events: Option<Vec<EventDetails>>,
 }
 
 impl<Hash> TransactionReport<Hash> {
@@ -36,7 +36,7 @@ impl<Hash> TransactionReport<Hash> {
 		xt_hash: Hash,
 		block_hash: Option<Hash>,
 		status: TransactionStatus<Hash, Hash>,
-		events: Option<Events<Hash>>,
+		events: Option<Vec<EventDetails>>,
 	) -> Self {
 		Self { xt_hash, block_hash, status, events }
 	}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -23,6 +23,7 @@ pub mod api_client;
 pub mod error;
 pub mod rpc_api;
 
+use ac_node_api::EventDetails;
 use serde::{Deserialize, Serialize};
 
 /// Extrinsic report returned upon a submit_and_watch request.

--- a/src/api/rpc_api/author.rs
+++ b/src/api/rpc_api/author.rs
@@ -17,11 +17,19 @@ use crate::{
 	api::{Error, Result},
 	rpc::{HandleSubscription, Request, Subscribe},
 	Api, TransactionStatus, XtStatus,
+	TransactionReport, GetBlock,
+	TransactionStatus, XtStatus, Events, GetStorage, Phase,
 };
 use ac_compose_macros::rpc_params;
 use ac_primitives::{ExtrinsicParams, FrameSystemConfig};
 use log::*;
 use serde::de::DeserializeOwned;
+use sp_runtime::traits::Hash as HashTrait;
+use sp_runtime::traits::Block as BlockTrait;
+use sp_runtime::traits::GetRuntimeBlockType;
+use codec::Encode;
+use crate::utils;
+use crate::FromHexString;
 
 pub type TransactionSubscriptionFor<Client, Hash> =
 	<Client as Subscribe>::Subscription<TransactionStatus<Hash, Hash>>;
@@ -64,20 +72,35 @@ where
 	) -> Result<TransactionSubscriptionFor<Client, Hash>>;
 
 	/// Submit an extrinsic and watch in until the desired status is reached,
-	/// if no error is encountered previously. This method is blocking.
+	/// if no error is encountered previously.
+	// This method is blocking.
 	fn submit_and_watch_extrinsic_until(
 		&self,
 		xthex_prefixed: &str,
 		watch_until: XtStatus,
+	) -> Result<TransactionReport<Hash>>;
+
+	/// Submit an extrinsic and watch in until
+	/// - wait_for_finalized = false => InBlock
+	/// - wait_for_finalized = false => Finalized
+	/// and check if the extrinsic has been successful or not.
+	// This method is blocking.
+	fn submit_and_watch_extrinsic_until_success(
+		&self,
+		xthex_prefixed: &str,
+		wait_for_finalized: bool,
 	) -> Result<Option<Hash>>;
 }
 
 impl<Signer, Client, Params, Runtime> SubmitAndWatch<Client, Runtime::Hash>
 	for Api<Signer, Client, Params, Runtime>
 where
-	Client: Subscribe,
+	Client: Subscribe + Request,
 	Params: ExtrinsicParams<Runtime::Index, Runtime::Hash>,
-	Runtime: FrameSystemConfig,
+	Runtime: FrameSystemConfig + GetRuntimeBlockType,
+	Runtime::RuntimeBlock: BlockTrait + DeserializeOwned,
+	Runtime::Hashing: HashTrait<Output = Runtime::Hash>,
+	Runtime::Hash: FromHexString,
 {
 	fn submit_and_watch_extrinsic(
 		&self,
@@ -96,15 +119,18 @@ where
 		&self,
 		xthex_prefixed: &str,
 		watch_until: XtStatus,
-	) -> Result<Option<Runtime::Hash>> {
+		) -> Result<TransactionReport<Runtime::Hash>> {
+		let tx_hash = Runtime::Hashing::hash_of(&xthex_prefixed.encode());
 		let mut subscription: TransactionSubscriptionFor<Client, Runtime::Hash> =
 			self.submit_and_watch_extrinsic(xthex_prefixed)?;
+
 		while let Some(transaction_status) = subscription.next() {
 			let transaction_status = transaction_status?;
 			if transaction_status.is_supported() {
 				if transaction_status.as_u8() >= watch_until as u8 {
 					subscription.unsubscribe()?;
-					return Ok(return_block_hash_if_available(transaction_status))
+					let block_hash = get_maybe_block_hash(transaction_status);
+					return Ok(TransactionReport::new(tx_hash, block_hash, transaction_status, None))
 				}
 			} else {
 				subscription.unsubscribe()?;
@@ -117,9 +143,59 @@ where
 		}
 		Err(Error::NoStream)
 	}
+
+
+		/// Submit an extrinsic and watch in until inBlock or Finalized is reached,
+	/// if no error is encountered previously. This method is blocking.
+	fn submit_and_watch_extrinsic_until_success(
+		&self,
+		xthex_prefixed: &str,
+		wait_for_finalized: bool,
+	) -> Result<Option<Runtime::Hash>> {
+		let xt_status = match wait_for_finalized {
+			true => XtStatus::Finalized,
+			false => XtStatus::InBlock,
+		};
+		let mut report = self.submit_and_watch_extrinsic_until(xthex_prefixed, xt_status)?;
+
+		// Retrieve block details from node.
+		let block_hash = report.block_hash.ok_or(Error::NoBlockHash)?;
+		let block = self.get_block(Some(block_hash))?.ok_or(Error::NoBlock)?;
+		let xt_index = block.extrinsics().iter().position(|xt|
+			let xt_hash = Runtime::Hashing::hash_of(&xt.encode())
+			report.xt_hash == xt_hash
+		).ok_or(Error::Extrinsic("Could not find extrinsic hash".to_string()))?;
+
+		// Fetch events from this block.
+		let key = utils::storage_key("System", "Events");
+		let event_bytes = self.get_opaque_storage_by_key_hash(key, Some(block_hash))?.ok_or(Error::NoBlock)?;
+		let events = Events::<Runtime::Hash>::new(
+			self.metadata().clone(),
+			Default::default(),
+			event_bytes,
+		);
+
+		// Filter events associated to our extrinsic.
+		let associated_events = events.iter().filter(|ev | { ev.map(ev.phase() == Phase::ApplyExtrinsic(xt_index as u32))?})?;
+
+		for event in associated_events.iter() {
+			if extrinsic_has_failed(&event_details) {
+				let dispatch_error =
+					DispatchError::decode_from(event_details.field_bytes(), self.metadata());
+				return Err(Error::Dispatch(dispatch_error))
+			}
+		}
+
+		report.events = Some(associated_events)
+		Ok(report)
+
+
+	}
+
+
 }
 
-fn return_block_hash_if_available<Hash, BlockHash>(
+fn get_maybe_block_hash<Hash, BlockHash>(
 	transcation_status: TransactionStatus<Hash, BlockHash>,
 ) -> Option<BlockHash> {
 	match transcation_status {

--- a/src/api/rpc_api/author.rs
+++ b/src/api/rpc_api/author.rs
@@ -139,8 +139,6 @@ where
 		Err(Error::NoStream)
 	}
 
-	/// Submit an extrinsic and watch in until inBlock or Finalized is reached,
-	/// if no error is encountered previously. This method is blocking.
 	fn submit_and_watch_extrinsic_until_success(
 		&self,
 		xthex_prefixed: &str,

--- a/src/api/rpc_api/chain.rs
+++ b/src/api/rpc_api/chain.rs
@@ -20,8 +20,7 @@ use ac_compose_macros::rpc_params;
 use ac_primitives::{ExtrinsicParams, FrameSystemConfig};
 use log::*;
 use serde::de::DeserializeOwned;
-use sp_core::Pair;
-use sp_runtime::{generic::SignedBlock, traits::GetRuntimeBlockType, MultiSignature};
+use sp_runtime::{generic::SignedBlock, traits::GetRuntimeBlockType};
 
 pub trait GetHeader<Hash> {
 	type Header;
@@ -78,8 +77,6 @@ pub trait GetBlock<Number, Hash> {
 impl<Signer, Client, Params, Runtime> GetBlock<Runtime::BlockNumber, Runtime::Hash>
 	for Api<Signer, Client, Params, Runtime>
 where
-	Signer: Pair,
-	MultiSignature: From<Signer::Signature>,
 	Client: Request,
 	Runtime: FrameSystemConfig + GetRuntimeBlockType,
 	Params: ExtrinsicParams<Runtime::Index, Runtime::Hash>,

--- a/src/api/rpc_api/mod.rs
+++ b/src/api/rpc_api/mod.rs
@@ -15,6 +15,7 @@ pub use self::{
 	author::*, chain::*, frame_system::*, pallet_balances::*, pallet_transaction_payment::*,
 	state::*, subscribe_events::*,
 };
+use ac_node_api::EventDetails;
 
 pub mod author;
 pub mod chain;

--- a/src/api/rpc_api/mod.rs
+++ b/src/api/rpc_api/mod.rs
@@ -23,3 +23,7 @@ pub mod pallet_balances;
 pub mod pallet_transaction_payment;
 pub mod state;
 pub mod subscribe_events;
+
+pub(crate) fn extrinsic_has_failed(event_details: &EventDetails) -> bool {
+	event_details.pallet_name() == "System" && event_details.variant_name() == "ExtrinsicFailed"
+}

--- a/src/api/rpc_api/subscribe_events.rs
+++ b/src/api/rpc_api/subscribe_events.rs
@@ -12,7 +12,7 @@
 */
 
 use crate::{
-	api::{error::Error, Api, Result},
+	api::{error::Error, rpc_api::extrinsic_has_failed, Api, Result},
 	rpc::{HandleSubscription, Subscribe},
 };
 use ac_node_api::{events::EventDetails, DispatchError, Events, StaticEvent};
@@ -96,8 +96,4 @@ where
 		}
 		Err(Error::NoStream)
 	}
-}
-
-fn extrinsic_has_failed(event_details: &EventDetails) -> bool {
-	event_details.pallet_name() == "System" && event_details.variant_name() == "ExtrinsicFailed"
 }

--- a/testing/examples/author_tests.rs
+++ b/testing/examples/author_tests.rs
@@ -60,8 +60,8 @@ async fn main() {
 
 	thread::sleep(Duration::from_secs(6)); // Wait a little to avoid transaction too low priority error.
 	let xt2 = api.balance_transfer(bob.clone(), 1000).hex_encode();
-	let none = api.submit_and_watch_extrinsic_until(&xt2, XtStatus::Ready).unwrap();
-	assert!(none.is_none());
+	let report = api.submit_and_watch_extrinsic_until(&xt2, XtStatus::Ready).unwrap();
+	assert!(report.block_hash.is_none());
 	println!("Success: submit_and_watch_extrinsic_until Ready");
 
 	thread::sleep(Duration::from_secs(6)); // Wait a little to avoid transaction too low priority error.
@@ -70,6 +70,7 @@ async fn main() {
 	let _some_hash = api
 		.submit_and_watch_extrinsic_until(&xt3, XtStatus::Broadcast)
 		.unwrap()
+		.block_hash
 		.unwrap();
 	println!("Success: submit_and_watch_extrinsic_until Broadcast");
 
@@ -77,8 +78,11 @@ async fn main() {
 	thread::sleep(Duration::from_secs(6)); // Wait a little to avoid transaction too low priority error.
 	let xt4 = api2.balance_transfer(bob.clone(), 1000).hex_encode();
 	let until_in_block_handle = thread::spawn(move || {
-		let _block_hash =
-			api2.submit_and_watch_extrinsic_until(&xt4, XtStatus::InBlock).unwrap().unwrap();
+		let _block_hash = api2
+			.submit_and_watch_extrinsic_until(&xt4, XtStatus::InBlock)
+			.unwrap()
+			.block_hash
+			.unwrap();
 		println!("Success: submit_and_watch_extrinsic_until InBlock");
 	});
 
@@ -89,6 +93,7 @@ async fn main() {
 		let _block_hash = api3
 			.submit_and_watch_extrinsic_until(&xt5, XtStatus::Finalized)
 			.unwrap()
+			.block_hash
 			.unwrap();
 		println!("Success: submit_and_watch_extrinsic_until Finalized");
 	});

--- a/testing/examples/author_tests.rs
+++ b/testing/examples/author_tests.rs
@@ -88,7 +88,7 @@ async fn main() {
 
 	let api3 = api.clone();
 	thread::sleep(Duration::from_secs(6)); // Wait a little to avoid transaction too low priority error.
-	let xt5 = api.balance_transfer(bob, 1000).hex_encode();
+	let xt5 = api.balance_transfer(bob.clone(), 1000).hex_encode();
 	let until_finalized_handle = thread::spawn(move || {
 		let _block_hash = api3
 			.submit_and_watch_extrinsic_until(&xt5, XtStatus::Finalized)
@@ -97,6 +97,17 @@ async fn main() {
 			.unwrap();
 		println!("Success: submit_and_watch_extrinsic_until Finalized");
 	});
+
+	// Test Success
+	thread::sleep(Duration::from_secs(6)); // Wait a little to avoid transaction too low priority error.
+	let xt6 = api.balance_transfer(bob, 1000).hex_encode();
+
+	let events = api
+		.submit_and_watch_extrinsic_until_success(&xt6, false)
+		.unwrap()
+		.events
+		.unwrap();
+	println!("Success: Found events: {:?}", events);
 
 	watch_handle.join().unwrap();
 	until_in_block_handle.join().unwrap();


### PR DESCRIPTION
Allows to watch an extrinsic and automatically checks if the extrinsic was successful or not, by retrieving and checking the associated events.

❗ Breaks `submit_and_watch_extrinsic_until` interface: The return value has been changed to `ExtrinsicReport` which includes the extrinsic hash, block hash, transaction status and, possibly, the associated events.

- [ ] add tests. (Wait for merge of #368)

closes #288 