### PR TITLE
Fix bugs and remove unused Clone / Debug enforcements

### DIFF
--- a/primitives/src/types.rs
+++ b/primitives/src/types.rs
@@ -115,7 +115,8 @@ impl<Balance: AtLeast32BitUnsigned + Copy> FeeDetails<Balance> {
 // https://github.com/paritytech/substrate/blob/a1c1286d2ca6360a16d772cc8bea2190f77f4d8f/frame/transaction-payment/src/types.rs#L92-L116
 #[derive(Eq, PartialEq, Encode, Decode, Default, Debug)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))][cfg_attr(
+#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
+#[cfg_attr(
 	feature = "std",
 	serde(bound(serialize = "Balance: std::fmt::Display, Weight: Serialize"))
 )]

--- a/primitives/src/types.rs
+++ b/primitives/src/types.rs
@@ -91,6 +91,7 @@ impl<Balance: AtLeast32BitUnsigned + Copy> InclusionFee<Balance> {
 pub struct FeeDetails<Balance> {
 	/// The minimum fee for a transaction to be included in a block.
 	pub inclusion_fee: Option<InclusionFee<Balance>>,
+	#[cfg_attr(feature = "std", serde(skip))]
 	pub tip: Balance,
 }
 
@@ -114,8 +115,15 @@ impl<Balance: AtLeast32BitUnsigned + Copy> FeeDetails<Balance> {
 // https://github.com/paritytech/substrate/blob/a1c1286d2ca6360a16d772cc8bea2190f77f4d8f/frame/transaction-payment/src/types.rs#L92-L116
 #[derive(Eq, PartialEq, Encode, Decode, Default, Debug)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
-pub struct RuntimeDispatchInfo<Balance, Weight = sp_weights::Weight> {
+#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))][cfg_attr(
+	feature = "std",
+	serde(bound(serialize = "Balance: std::fmt::Display, Weight: Serialize"))
+)]
+#[cfg_attr(
+	feature = "std",
+	serde(bound(deserialize = "Balance: std::str::FromStr, Weight: Deserialize<'de>"))
+)]
+pub struct RuntimeDispatchInfo<Balance, Weight = sp_weights::OldWeight> {
 	/// Weight of this dispatch.
 	pub weight: Weight,
 	/// Class of this dispatch.
@@ -124,7 +132,27 @@ pub struct RuntimeDispatchInfo<Balance, Weight = sp_weights::Weight> {
 	///
 	/// This does not include a tip or anything else that
 	/// depends on the signature (i.e. depends on a `SignedExtension`).
+	#[cfg_attr(feature = "std", serde(with = "serde_balance"))]
 	pub partial_fee: Balance,
+}
+
+#[cfg(feature = "std")]
+mod serde_balance {
+	use serde::{Deserialize, Deserializer, Serializer};
+
+	pub fn serialize<S: Serializer, T: std::fmt::Display>(
+		t: &T,
+		serializer: S,
+	) -> Result<S::Ok, S::Error> {
+		serializer.serialize_str(&t.to_string())
+	}
+
+	pub fn deserialize<'de, D: Deserializer<'de>, T: std::str::FromStr>(
+		deserializer: D,
+	) -> Result<T, D::Error> {
+		let s = String::deserialize(deserializer)?;
+		s.parse::<T>().map_err(|_| serde::de::Error::custom("Parse from string failed"))
+	}
 }
 
 /// A generalized group of dispatch types.

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -47,7 +47,7 @@ pub enum XtStatus {
 	Ready = 1,
 	Broadcast = 2,
 	InBlock = 4,
-	Finalized = 7,
+	Finalized = 6,
 }
 
 /// Possible transaction status events.

--- a/src/api/rpc_api/pallet_transaction_payment.rs
+++ b/src/api/rpc_api/pallet_transaction_payment.rs
@@ -17,6 +17,7 @@ use crate::{
 };
 use ac_compose_macros::rpc_params;
 use ac_primitives::{BalancesConfig, FeeDetails, InclusionFee, RuntimeDispatchInfo};
+use core::str::FromStr;
 use sp_rpc::number::NumberOrHex;
 
 /// Interface to common calls of the substrate transaction payment pallet.
@@ -42,7 +43,7 @@ where
 	Client: Request,
 	Runtime: BalancesConfig,
 	Params: ExtrinsicParams<Runtime::Index, Runtime::Hash>,
-	Runtime::Balance: TryFrom<NumberOrHex>,
+	Runtime::Balance: TryFrom<NumberOrHex> + FromStr,
 {
 	type Balance = Runtime::Balance;
 

--- a/src/api/rpc_api/state.rs
+++ b/src/api/rpc_api/state.rs
@@ -70,7 +70,7 @@ pub trait GetStorage<Hash> {
 		at_block: Option<Hash>,
 	) -> ApiResult<Option<ReadProof<Hash>>>;
 
-	fn get_storage_map_proof<K: Encode, V: Decode + Clone>(
+	fn get_storage_map_proof<K: Encode>(
 		&self,
 		storage_prefix: &'static str,
 		storage_key_name: &'static str,
@@ -78,7 +78,7 @@ pub trait GetStorage<Hash> {
 		at_block: Option<Hash>,
 	) -> ApiResult<Option<ReadProof<Hash>>>;
 
-	fn get_storage_double_map_proof<K: Encode, Q: Encode, V: Decode + Clone>(
+	fn get_storage_double_map_proof<K: Encode, Q: Encode>(
 		&self,
 		storage_prefix: &'static str,
 		storage_key_name: &'static str,
@@ -192,7 +192,7 @@ where
 		self.get_storage_proof_by_keys(vec![storagekey], at_block)
 	}
 
-	fn get_storage_map_proof<K: Encode, V: Decode + Clone>(
+	fn get_storage_map_proof<K: Encode>(
 		&self,
 		storage_prefix: &'static str,
 		storage_key_name: &'static str,
@@ -206,7 +206,7 @@ where
 		self.get_storage_proof_by_keys(vec![storagekey], at_block)
 	}
 
-	fn get_storage_double_map_proof<K: Encode, Q: Encode, V: Decode + Clone>(
+	fn get_storage_double_map_proof<K: Encode, Q: Encode>(
 		&self,
 		storage_prefix: &'static str,
 		storage_key_name: &'static str,


### PR DESCRIPTION
Fixes several bugs noticed in #368:
- adds missing serde skips in primitives types.  These values are not serialized on substrate side, so the deserialization on the api client side needs to skip them as well.
- `XtStatus::Finalized` now matches the number of `TransactionStatus`, which is 6. Otherwise, one would have waited forever until Finalized Status.
- Removes unnecessary enforcement of Decode and Clone on unused `V` of `get_storage_map_proof` and `get_storage_double_map_proof`