### PR TITLE
Make api no_std compatible and clean up pub re-exports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4793,16 +4793,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-rpc"
-version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#9ce75afde9ada98a69e4ab3abbbfb7fa8202d72b"
-dependencies = [
- "rustc-hash",
- "serde",
- "sp-core",
-]
-
-[[package]]
 name = "sp-runtime"
 version = "7.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=master#9ce75afde9ada98a69e4ab3abbbfb7fa8202d72b"
@@ -5170,7 +5160,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-core",
- "sp-rpc",
  "sp-runtime",
  "sp-runtime-interface",
  "sp-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,11 +40,12 @@ sp-core = { default-features = false, features = ["full_crypto"], git = "https:/
 sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master" }
 sp-runtime-interface = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master" }
 sp-std = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master" }
+sp-version = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master" }
 
 # substrate std / wasm only
 frame-support = { optional = true, git = "https://github.com/paritytech/substrate.git", branch = "master" }
 sp-rpc = { optional = true, git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sp-version = { optional = true, git = "https://github.com/paritytech/substrate.git", branch = "master" }
+
 
 # local deps
 ac-compose-macros = { path = "compose-macros", default-features = false }
@@ -78,10 +79,10 @@ std = [
     "sp-runtime/std",
     "sp-runtime-interface/std",
     "sp-std/std",
+    "sp-version/std",
     # substrate std
     "frame-support",
     "sp-rpc",
-    "sp-version",
     # local deps
     "ac-compose-macros/std",
     "ac-node-api/std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,6 @@ std = [
     "sp-version/std",
     # substrate std
     "frame-support",
-    "sp-rpc",
     # local deps
     "ac-compose-macros/std",
     "ac-node-api/std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,6 @@ sp-version = { default-features = false, git = "https://github.com/paritytech/su
 
 # substrate std / wasm only
 frame-support = { optional = true, git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sp-rpc = { optional = true, git = "https://github.com/paritytech/substrate.git", branch = "master" }
 
 # local deps
 ac-compose-macros = { path = "compose-macros", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,6 @@ sp-version = { default-features = false, git = "https://github.com/paritytech/su
 frame-support = { optional = true, git = "https://github.com/paritytech/substrate.git", branch = "master" }
 sp-rpc = { optional = true, git = "https://github.com/paritytech/substrate.git", branch = "master" }
 
-
 # local deps
 ac-compose-macros = { path = "compose-macros", default-features = false }
 ac-node-api = { path = "node-api", default-features = false }

--- a/compose-macros/src/lib.rs
+++ b/compose-macros/src/lib.rs
@@ -21,9 +21,7 @@
 
 // re-export for macro resolution
 pub use ac_primitives as primitives;
-#[cfg(feature = "std")]
 pub use codec;
-#[cfg(feature = "std")]
 pub use log;
 pub use rpc::*;
 pub use sp_core;
@@ -98,7 +96,6 @@ macro_rules! compose_extrinsic_offline {
 /// * 'args' - Optional sequence of arguments of the call. They are not checked against the metadata.
 /// As of now the user needs to check himself that the correct arguments are supplied.
 #[macro_export]
-#[cfg(feature = "std")]
 macro_rules! compose_extrinsic {
 	($api: expr,
 	$module: expr,

--- a/examples/examples/benchmark_bulk_xt.rs
+++ b/examples/examples/benchmark_bulk_xt.rs
@@ -21,7 +21,7 @@
 use kitchensink_runtime::{BalancesCall, Runtime, RuntimeCall};
 use sp_keyring::AccountKeyring;
 use substrate_api_client::{
-	compose_extrinsic_offline, Api, AssetTipExtrinsicParams, JsonrpseeClient, SubmitExtrinsic,
+	compose_extrinsic_offline, rpc::JsonrpseeClient, Api, AssetTipExtrinsicParams, SubmitExtrinsic,
 	UncheckedExtrinsicV4,
 };
 

--- a/examples/examples/event_callback.rs
+++ b/examples/examples/event_callback.rs
@@ -20,7 +20,8 @@ use kitchensink_runtime::Runtime;
 use log::debug;
 use sp_core::{sr25519, H256 as Hash};
 use substrate_api_client::{
-	rpc::JsonrpseeClient, Api, AssetTipExtrinsicParams, HandleSubscription, SubscribeFrameSystem,
+	rpc::{HandleSubscription, JsonrpseeClient},
+	Api, AssetTipExtrinsicParams, SubscribeFrameSystem,
 };
 
 // This module depends on node_runtime.

--- a/examples/examples/get_blocks.rs
+++ b/examples/examples/get_blocks.rs
@@ -19,8 +19,8 @@
 use kitchensink_runtime::Runtime;
 use sp_core::sr25519;
 use substrate_api_client::{
-	rpc::JsonrpseeClient, Api, AssetTipExtrinsicParams, GetBlock, GetHeader, HandleSubscription,
-	SubscribeChain,
+	rpc::{HandleSubscription, JsonrpseeClient},
+	Api, AssetTipExtrinsicParams, GetBlock, GetHeader, SubscribeChain,
 };
 
 #[tokio::main]

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -22,11 +22,13 @@ extern crate alloc;
 pub use extrinsic_params::*;
 pub use extrinsics::*;
 pub use pallet_traits::*;
+pub use rpc_numbers::*;
 pub use rpc_params::RpcParams;
 pub use types::*;
 
 pub mod extrinsic_params;
 pub mod extrinsics;
 pub mod pallet_traits;
+pub mod rpc_numbers;
 pub mod rpc_params;
 pub mod types;

--- a/primitives/src/rpc_numbers.rs
+++ b/primitives/src/rpc_numbers.rs
@@ -1,0 +1,112 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2017-2022 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A number type that can be serialized both as a number or a string that encodes a number in a
+//! string.
+
+// Copy pasted file from substrate. sp_rpc is not no_std compatible.
+// https://github.com/paritytech/substrate/blob/cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5/primitives/rpc/src/number.rs
+use core::fmt::Debug;
+use serde::{Deserialize, Serialize};
+use sp_core::U256;
+
+/// A number type that can be serialized both as a number or a string that encodes a number in a
+/// string.
+///
+/// We allow two representations of the block number as input. Either we deserialize to the type
+/// that is specified in the block type or we attempt to parse given hex value.
+///
+/// The primary motivation for having this type is to avoid overflows when using big integers in
+/// JavaScript (which we consider as an important RPC API consumer).
+#[derive(Copy, Clone, Serialize, Deserialize, Debug, PartialEq)]
+#[serde(untagged)]
+pub enum NumberOrHex {
+	/// The number represented directly.
+	Number(u64),
+	/// Hex representation of the number.
+	Hex(U256),
+}
+
+impl Default for NumberOrHex {
+	fn default() -> Self {
+		Self::Number(Default::default())
+	}
+}
+
+impl NumberOrHex {
+	/// Converts this number into an U256.
+	pub fn into_u256(self) -> U256 {
+		match self {
+			NumberOrHex::Number(n) => n.into(),
+			NumberOrHex::Hex(h) => h,
+		}
+	}
+}
+
+impl From<u32> for NumberOrHex {
+	fn from(n: u32) -> Self {
+		NumberOrHex::Number(n.into())
+	}
+}
+
+impl From<u64> for NumberOrHex {
+	fn from(n: u64) -> Self {
+		NumberOrHex::Number(n)
+	}
+}
+
+impl From<u128> for NumberOrHex {
+	fn from(n: u128) -> Self {
+		NumberOrHex::Hex(n.into())
+	}
+}
+
+impl From<U256> for NumberOrHex {
+	fn from(n: U256) -> Self {
+		NumberOrHex::Hex(n)
+	}
+}
+
+/// An error type that signals an out-of-range conversion attempt.
+pub struct TryFromIntError(pub(crate) ());
+
+impl TryFrom<NumberOrHex> for u32 {
+	type Error = TryFromIntError;
+	fn try_from(num_or_hex: NumberOrHex) -> Result<u32, Self::Error> {
+		num_or_hex.into_u256().try_into().map_err(|_| TryFromIntError(()))
+	}
+}
+
+impl TryFrom<NumberOrHex> for u64 {
+	type Error = TryFromIntError;
+	fn try_from(num_or_hex: NumberOrHex) -> Result<u64, Self::Error> {
+		num_or_hex.into_u256().try_into().map_err(|_| TryFromIntError(()))
+	}
+}
+
+impl TryFrom<NumberOrHex> for u128 {
+	type Error = TryFromIntError;
+	fn try_from(num_or_hex: NumberOrHex) -> Result<u128, Self::Error> {
+		num_or_hex.into_u256().try_into().map_err(|_| TryFromIntError(()))
+	}
+}
+
+impl From<NumberOrHex> for U256 {
+	fn from(num_or_hex: NumberOrHex) -> U256 {
+		num_or_hex.into_u256()
+	}
+}

--- a/src/api/api_client.rs
+++ b/src/api/api_client.rs
@@ -18,15 +18,12 @@ pub use crate::{
 	},
 	utils::FromHexString,
 };
-pub use frame_metadata::RuntimeMetadataPrefixed;
-pub use serde_json::Value;
-pub use sp_core::{crypto::Pair, storage::StorageKey};
-pub use sp_runtime::{
+use sp_core::{crypto::Pair, storage::StorageKey};
+use sp_runtime::{
 	generic::SignedBlock,
 	traits::{Block, Header, IdentifyAccount},
 	AccountId32, MultiSignature, MultiSigner,
 };
-pub use sp_std::prelude::*;
 
 use crate::{rpc::Request, GetAccountInformation};
 use ac_compose_macros::rpc_params;
@@ -34,6 +31,7 @@ use ac_node_api::metadata::Metadata;
 use ac_primitives::{ExtrinsicParams, FrameSystemConfig};
 use codec::Decode;
 use core::convert::TryFrom;
+use frame_metadata::RuntimeMetadataPrefixed;
 use log::{debug, info};
 use sp_core::Bytes;
 use sp_version::RuntimeVersion;

--- a/src/api/api_client.rs
+++ b/src/api/api_client.rs
@@ -36,7 +36,7 @@ use sp_version::RuntimeVersion;
 ///
 /// ```no_run
 /// use substrate_api_client::{
-///     Api, ApiClientError, ApiResult, FromHexString,  Request, rpc::Error as RpcClientError,  XtStatus, PlainTipExtrinsicParams, rpc::Result as RpcResult
+///     Api, FromHexString,  rpc::Request, rpc::Error as RpcClientError,  XtStatus, PlainTipExtrinsicParams, rpc::Result as RpcResult
 /// };
 /// use serde::de::DeserializeOwned;
 /// use ac_primitives::RpcParams;

--- a/src/api/api_client.rs
+++ b/src/api/api_client.rs
@@ -11,21 +11,12 @@
    limitations under the License.
 */
 
-pub use crate::{
-	api::{
-		error::{ApiResult, Error as ApiClientError},
-		XtStatus,
-	},
+use crate::{
+	api::error::{ApiResult, Error as ApiClientError},
+	rpc::Request,
 	utils::FromHexString,
+	GetAccountInformation,
 };
-use sp_core::{crypto::Pair, storage::StorageKey};
-use sp_runtime::{
-	generic::SignedBlock,
-	traits::{Block, Header, IdentifyAccount},
-	AccountId32, MultiSignature, MultiSigner,
-};
-
-use crate::{rpc::Request, GetAccountInformation};
 use ac_compose_macros::rpc_params;
 use ac_node_api::metadata::Metadata;
 use ac_primitives::{ExtrinsicParams, FrameSystemConfig};
@@ -33,7 +24,8 @@ use codec::Decode;
 use core::convert::TryFrom;
 use frame_metadata::RuntimeMetadataPrefixed;
 use log::{debug, info};
-use sp_core::Bytes;
+use sp_core::{crypto::Pair, Bytes};
+use sp_runtime::MultiSignature;
 use sp_version::RuntimeVersion;
 
 /// Api to talk with substrate-nodes

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -15,24 +15,11 @@
 
 */
 
-pub use crate::{
-	api::error::{ApiResult, Error as ApiClientError},
-	utils::FromHexString,
-};
-pub use ac_primitives::FeeDetails;
-pub use api_client::Api;
-pub use frame_metadata::RuntimeMetadataPrefixed;
+pub use api_client::*;
+pub use error::*;
 pub use rpc_api::*;
-pub use serde_json::Value;
-pub use sp_core::{crypto::Pair, storage::StorageKey};
-pub use sp_runtime::{
-	generic::SignedBlock,
-	traits::{Block, Header, IdentifyAccount},
-	AccountId32 as AccountId, MultiSignature, MultiSigner,
-};
-pub use sp_std::prelude::*;
-pub use sp_version::RuntimeVersion;
 
+use crate::api::error::{ApiResult, Error as ApiClientError};
 use serde::{Deserialize, Serialize};
 
 pub mod api_client;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -16,10 +16,9 @@
 */
 
 pub use api_client::*;
-pub use error::*;
+pub use error::{ApiResult, Error};
 pub use rpc_api::*;
 
-use crate::api::error::{ApiResult, Error as ApiClientError};
 use serde::{Deserialize, Serialize};
 
 pub mod api_client;

--- a/src/api/rpc_api/author.rs
+++ b/src/api/rpc_api/author.rs
@@ -15,8 +15,8 @@
 
 use crate::{
 	api::{error::Error, ApiResult},
-	rpc::HandleSubscription,
-	Api, Request, Subscribe, TransactionStatus, XtStatus,
+	rpc::{HandleSubscription, Request, Subscribe},
+	Api, TransactionStatus, XtStatus,
 };
 use ac_compose_macros::rpc_params;
 use ac_primitives::{ExtrinsicParams, FrameSystemConfig};

--- a/src/api/rpc_api/frame_system.rs
+++ b/src/api/rpc_api/frame_system.rs
@@ -15,11 +15,10 @@
 
 use crate::{
 	api::{Api, ApiResult, GetStorage},
-	rpc::Subscribe,
-	utils, Request,
+	rpc::{Request, Subscribe},
+	utils,
 };
 use ac_compose_macros::rpc_params;
-pub use ac_node_api::{events::EventDetails, StaticEvent};
 use ac_primitives::{AccountInfo, ExtrinsicParams, FrameSystemConfig};
 use log::*;
 use serde::de::DeserializeOwned;

--- a/src/api/rpc_api/pallet_transaction_payment.rs
+++ b/src/api/rpc_api/pallet_transaction_payment.rs
@@ -16,10 +16,8 @@ use crate::{
 	ExtrinsicParams,
 };
 use ac_compose_macros::rpc_params;
-use ac_primitives::{BalancesConfig, FeeDetails, InclusionFee, RuntimeDispatchInfo};
+use ac_primitives::{BalancesConfig, FeeDetails, InclusionFee, NumberOrHex, RuntimeDispatchInfo};
 use core::str::FromStr;
-use sp_rpc::number::NumberOrHex;
-
 /// Interface to common calls of the substrate transaction payment pallet.
 pub trait GetTransactionPayment<Hash> {
 	type Balance;

--- a/src/api/rpc_api/pallet_transaction_payment.rs
+++ b/src/api/rpc_api/pallet_transaction_payment.rs
@@ -11,7 +11,7 @@
    limitations under the License.
 */
 use crate::{
-	api::{Api, ApiClientError, ApiResult},
+	api::{Api, ApiResult, Error},
 	rpc::Request,
 	ExtrinsicParams,
 };
@@ -83,7 +83,7 @@ fn convert_fee_details<Balance: TryFrom<NumberOrHex>>(
 	} else {
 		None
 	};
-	let tip = details.tip.try_into().map_err(|_| ApiClientError::TryFromIntError)?;
+	let tip = details.tip.try_into().map_err(|_| Error::TryFromIntError)?;
 	Ok(FeeDetails { inclusion_fee, tip })
 }
 
@@ -91,11 +91,11 @@ fn inclusion_fee_with_balance<Balance: TryFrom<NumberOrHex>>(
 	inclusion_fee: InclusionFee<NumberOrHex>,
 ) -> ApiResult<InclusionFee<Balance>> {
 	Ok(InclusionFee {
-		base_fee: inclusion_fee.base_fee.try_into().map_err(|_| ApiClientError::TryFromIntError)?,
-		len_fee: inclusion_fee.len_fee.try_into().map_err(|_| ApiClientError::TryFromIntError)?,
+		base_fee: inclusion_fee.base_fee.try_into().map_err(|_| Error::TryFromIntError)?,
+		len_fee: inclusion_fee.len_fee.try_into().map_err(|_| Error::TryFromIntError)?,
 		adjusted_weight_fee: inclusion_fee
 			.adjusted_weight_fee
 			.try_into()
-			.map_err(|_| ApiClientError::TryFromIntError)?,
+			.map_err(|_| Error::TryFromIntError)?,
 	})
 }

--- a/src/api/rpc_api/state.rs
+++ b/src/api/rpc_api/state.rs
@@ -10,9 +10,12 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 */
-use crate::{api::ApiResult, rpc::Subscribe, utils, Api, MetadataError, ReadProof, Request};
+use crate::{
+	api::ApiResult,
+	rpc::{Request, Subscribe},
+	utils, Api, MetadataError, ReadProof,
+};
 use ac_compose_macros::rpc_params;
-pub use ac_node_api::{events::EventDetails, StaticEvent};
 use ac_primitives::{ExtrinsicParams, FrameSystemConfig};
 use codec::{Decode, Encode};
 use log::*;

--- a/src/api/rpc_api/subscribe_events.rs
+++ b/src/api/rpc_api/subscribe_events.rs
@@ -15,7 +15,7 @@ use crate::{
 	api::{error::Error, Api, ApiResult},
 	rpc::{HandleSubscription, Subscribe},
 };
-pub use ac_node_api::{events::EventDetails, StaticEvent};
+use ac_node_api::{events::EventDetails, StaticEvent};
 use ac_node_api::{DispatchError, Events};
 use ac_primitives::{ExtrinsicParams, FrameSystemConfig};
 use log::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,18 +19,17 @@
 
 extern crate alloc;
 
-pub use ac_compose_macros::{compose_call, compose_extrinsic, compose_extrinsic_offline};
+pub use ac_compose_macros::*;
 pub use ac_node_api::*;
 pub use ac_primitives::*;
 
+pub use utils::*;
 pub mod utils;
 
 // std only features:
 
 #[cfg(feature = "std")]
 pub use crate::api::*;
-#[cfg(feature = "std")]
-pub use crate::rpc::*;
 #[cfg(feature = "std")]
 pub mod api;
 #[cfg(feature = "std")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![feature(assert_matches)]
 
+extern crate alloc;
+
 pub use ac_compose_macros::{compose_call, compose_extrinsic_offline};
 pub use ac_node_api::*;
 pub use ac_primitives::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,16 +22,13 @@ extern crate alloc;
 pub use ac_compose_macros::*;
 pub use ac_node_api::*;
 pub use ac_primitives::*;
-
+pub use api::*;
 pub use utils::*;
+
+pub mod api;
 pub mod utils;
 
 // std only features:
-
-#[cfg(feature = "std")]
-pub use api::*;
-#[cfg(feature = "std")]
-pub mod api;
 #[cfg(feature = "std")]
 pub mod extrinsic;
 #[cfg(feature = "std")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@
 
 extern crate alloc;
 
-pub use ac_compose_macros::{compose_call, compose_extrinsic_offline};
+pub use ac_compose_macros::{compose_call, compose_extrinsic, compose_extrinsic_offline};
 pub use ac_node_api::*;
 pub use ac_primitives::*;
 
@@ -31,9 +31,6 @@ pub mod utils;
 pub use crate::api::*;
 #[cfg(feature = "std")]
 pub use crate::rpc::*;
-#[cfg(feature = "std")]
-pub use ac_compose_macros::compose_extrinsic;
-
 #[cfg(feature = "std")]
 pub mod api;
 #[cfg(feature = "std")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ pub mod utils;
 // std only features:
 
 #[cfg(feature = "std")]
-pub use crate::api::*;
+pub use api::*;
 #[cfg(feature = "std")]
 pub mod api;
 #[cfg(feature = "std")]

--- a/src/rpc/jsonrpsee_client/mod.rs
+++ b/src/rpc/jsonrpsee_client/mod.rs
@@ -78,7 +78,7 @@ impl Subscribe for JsonrpseeClient {
 	}
 }
 
-pub struct RpcParamsWrapper(RpcParams);
+struct RpcParamsWrapper(RpcParams);
 
 impl ToRpcParams for RpcParamsWrapper {
 	fn to_rpc_params(self) -> core::result::Result<Option<Box<RawValue>>, jsonrpsee::core::Error> {

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -15,25 +15,22 @@
 
 */
 
-#[cfg(feature = "ws-client")]
-pub use ws_client::WsRpcClient;
-#[cfg(feature = "ws-client")]
-pub mod ws_client;
-
-#[cfg(feature = "tungstenite-client")]
-pub use tungstenite_client::client::TungsteniteRpcClient;
-
-#[cfg(feature = "tungstenite-client")]
-pub mod tungstenite_client;
+pub use error::*;
+pub mod error;
 
 #[cfg(feature = "jsonrpsee-client")]
 pub use jsonrpsee_client::*;
+#[cfg(feature = "tungstenite-client")]
+pub use tungstenite_client::*;
+#[cfg(feature = "ws-client")]
+pub use ws_client::*;
+
 #[cfg(feature = "jsonrpsee-client")]
 pub mod jsonrpsee_client;
-
-pub mod error;
-
-pub use error::*;
+#[cfg(feature = "tungstenite-client")]
+pub mod tungstenite_client;
+#[cfg(feature = "ws-client")]
+pub mod ws_client;
 
 use ac_primitives::RpcParams;
 use serde::de::DeserializeOwned;

--- a/src/rpc/tungstenite_client/client.rs
+++ b/src/rpc/tungstenite_client/client.rs
@@ -14,10 +14,9 @@
    limitations under the License.
 
 */
-use crate::{
-	rpc::{to_json_req, Error as RpcClientError, Result},
-	tungstenite_client::subscription::TungsteniteSubscriptionWrapper,
-	Request, Subscribe,
+use crate::rpc::{
+	to_json_req, tungstenite_client::subscription::TungsteniteSubscriptionWrapper,
+	Error as RpcClientError, Request, Result, Subscribe,
 };
 use ac_primitives::RpcParams;
 use log::*;

--- a/src/rpc/tungstenite_client/mod.rs
+++ b/src/rpc/tungstenite_client/mod.rs
@@ -15,5 +15,8 @@
 
 */
 
+pub use client::*;
+pub use subscription::*;
+
 pub mod client;
 pub mod subscription;

--- a/src/rpc/ws_client/client.rs
+++ b/src/rpc/ws_client/client.rs
@@ -19,10 +19,9 @@ use super::{subscription::WsSubscriptionWrapper, HandleMessage};
 use crate::{
 	rpc::{
 		to_json_req,
-		ws_client::{RequestHandler, RpcClient, SubscriptionHandler},
+		ws_client::{MessageContext, RequestHandler, RpcClient, SubscriptionHandler},
 		Request, Result, Subscribe,
 	},
-	ws_client::MessageContext,
 	RpcParams,
 };
 use serde::de::DeserializeOwned;

--- a/src/rpc/ws_client/mod.rs
+++ b/src/rpc/ws_client/mod.rs
@@ -42,6 +42,8 @@ pub(crate) trait HandleMessage {
 	) -> core::result::Result<Self::Result, Self::Error>;
 }
 
+// Clippy says request is never used, even though it is..
+#[allow(dead_code)]
 pub(crate) struct MessageContext<ThreadMessage> {
 	pub out: Sender,
 	pub request: String,

--- a/src/rpc/ws_client/mod.rs
+++ b/src/rpc/ws_client/mod.rs
@@ -30,7 +30,7 @@ type RpcResult<T> = Result<T, RpcClientError>;
 pub type RpcMessage = RpcResult<String>;
 
 #[allow(clippy::result_large_err)]
-pub trait HandleMessage {
+pub(crate) trait HandleMessage {
 	type ThreadMessage;
 	type Error;
 	type Context;
@@ -42,8 +42,7 @@ pub trait HandleMessage {
 	) -> core::result::Result<Self::Result, Self::Error>;
 }
 
-#[derive(Debug, Clone)]
-pub struct MessageContext<ThreadMessage> {
+pub(crate) struct MessageContext<ThreadMessage> {
 	pub out: Sender,
 	pub request: String,
 	pub result: ThreadOut<ThreadMessage>,
@@ -51,7 +50,7 @@ pub struct MessageContext<ThreadMessage> {
 }
 
 #[derive(Debug, Clone)]
-pub struct RpcClient<MessageHandler, ThreadMessage> {
+pub(crate) struct RpcClient<MessageHandler, ThreadMessage> {
 	pub out: Sender,
 	pub request: String,
 	pub result: ThreadOut<ThreadMessage>,
@@ -86,7 +85,7 @@ where
 }
 
 #[derive(Default, Debug, PartialEq, Eq, Clone)]
-pub struct RequestHandler;
+pub(crate) struct RequestHandler;
 
 impl HandleMessage for RequestHandler {
 	type ThreadMessage = RpcMessage;
@@ -114,7 +113,7 @@ impl HandleMessage for RequestHandler {
 }
 
 #[derive(Default, Debug, PartialEq, Eq, Clone)]
-pub struct SubscriptionHandler {}
+pub(crate) struct SubscriptionHandler {}
 
 impl HandleMessage for SubscriptionHandler {
 	type ThreadMessage = String;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -15,11 +15,7 @@
 
 */
 
-#[cfg(not(feature = "std"))]
-extern crate alloc;
-#[cfg(not(feature = "std"))]
-use alloc::{string::String, vec::Vec};
-
+use crate::alloc::{string::String, vec::Vec};
 use hex::FromHexError;
 use sp_core::{storage::StorageKey, twox_128, H256};
 


### PR DESCRIPTION
❗ Breaking changes: some imports need to be imported differently now. Previously, everything has been pub in a quite unordered manner. This is now a little more ordered:
- everything in the `api` folder can be imported like usual directly with `substrate-api-client::xxx`
- the rpc folder now needs to be specified accordingly. E.g. `substrate-api-client::rpc::xxx`
With this exports of same named struct / traits is avoided (like `Error`).
- Most public reexports have been deleted. Reasoning: Because clippy does not detect unused pubs, they were growing very outdated and were not even used any more in the api-client (like the `json::Value`).


