### PR TITLE
Make Api `no_std` compatible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,6 +51,7 @@ dependencies = [
 name = "ac-node-api"
 version = "0.2.1"
 dependencies = [
+ "ac-primitives",
  "bitvec",
  "derive_more",
  "either",
@@ -65,7 +66,6 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "sp-runtime-interface",
- "sp-std",
 ]
 
 [[package]]
@@ -74,20 +74,21 @@ version = "0.3.0"
 dependencies = [
  "frame-system",
  "hex",
+ "impl-serde",
  "node-template-runtime",
  "pallet-assets",
  "pallet-balances",
  "pallet-contracts",
  "pallet-staking",
  "parity-scale-codec",
+ "primitive-types",
  "scale-info",
  "serde",
  "serde_json",
  "sp-core",
  "sp-runtime",
  "sp-staking",
- "sp-std",
- "sp-weights",
+ "sp-version",
 ]
 
 [[package]]
@@ -4790,16 +4791,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-rpc"
-version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#ce025f3a989d165225c0f2f7ab497cf53319dd6d"
-dependencies = [
- "rustc-hash",
- "serde",
- "sp-core",
-]
-
-[[package]]
 name = "sp-runtime"
 version = "7.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=master#ce025f3a989d165225c0f2f7ab497cf53319dd6d"
@@ -5148,11 +5139,8 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-core",
- "sp-rpc",
  "sp-runtime",
  "sp-runtime-interface",
- "sp-std",
- "sp-version",
  "thiserror-core",
  "tungstenite",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,12 +42,9 @@ frame-metadata = { default-features = false, git = "https://github.com/paritytec
 sp-core = { default-features = false, features = ["full_crypto"], git = "https://github.com/paritytech/substrate.git", branch = "master" }
 sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master" }
 sp-runtime-interface = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sp-std = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master" }
 
 # substrate std / wasm only
 frame-support = { optional = true, git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sp-rpc = { optional = true, git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sp-version = { optional = true, git = "https://github.com/paritytech/substrate.git", branch = "master" }
 
 # local deps
 ac-compose-macros = { path = "compose-macros", default-features = false }
@@ -79,11 +76,8 @@ std = [
     "sp-core/std",
     "sp-runtime/std",
     "sp-runtime-interface/std",
-    "sp-std/std",
     # substrate std
     "frame-support",
-    "sp-rpc",
-    "sp-version",
     # local deps
     "ac-compose-macros/std",
     "ac-node-api/std",

--- a/node-api/Cargo.toml
+++ b/node-api/Cargo.toml
@@ -19,11 +19,14 @@ serde_json = { version = "1.0.79", default-features = false, features = ["alloc"
 frame-metadata = { default-features = false, git = "https://github.com/paritytech/frame-metadata", features = ["v14", "serde_full", "decode"] }
 sp-core = { default-features = false, features = ["full_crypto"], git = "https://github.com/paritytech/substrate.git", branch = "master" }
 sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sp-std = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master" }
 
 # need to add this for `no_std`
 sp-application-crypto = { default-features = false, git = "https://github.com/paritytech/substrate.git", features = ["full_crypto"], branch = "master" }
 sp-runtime-interface = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master" }
+
+# local
+ac-primitives = { path = "../primitives", default-features = false }
+
 
 [features]
 default = ["std"]
@@ -44,8 +47,9 @@ std = [
     "frame-metadata/std",
     "sp-core/std",
     "sp-runtime/std",
-    "sp-std/std",
     # no_std support
     "sp-application-crypto/std",
     "sp-runtime-interface/std",
+    # local
+    "ac-primitives/std",
 ]

--- a/node-api/src/lib.rs
+++ b/node-api/src/lib.rs
@@ -16,8 +16,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate alloc;
-use alloc::{borrow::ToOwned, vec::Vec};
 
+use alloc::{borrow::ToOwned, vec::Vec};
 use codec::{Decode, Encode};
 
 pub use decoder::*;

--- a/node-api/src/metadata.rs
+++ b/node-api/src/metadata.rs
@@ -11,22 +11,20 @@
 //! This file is mostly subxt.
 
 use crate::{alloc::borrow::ToOwned, storage::GetStorageTypes, Encoded};
+use ac_primitives::StorageKey;
 use codec::{Decode, Encode, Error as CodecError};
 use frame_metadata::{
 	PalletConstantMetadata, RuntimeMetadata, RuntimeMetadataLastVersion, RuntimeMetadataPrefixed,
 	StorageEntryMetadata, META_RESERVED,
 };
 use scale_info::{form::PortableForm, PortableRegistry, Type};
-use sp_core::storage::StorageKey;
 
 #[cfg(feature = "std")]
 use serde::Serialize;
 
 // We use `BTreeMap` because we can't use `HashMap` in `no_std`.
-use sp_std::collections::btree_map::BTreeMap;
-
-#[cfg(not(feature = "std"))]
 use alloc::{
+	collections::btree_map::BTreeMap,
 	string::{String, ToString},
 	vec,
 	vec::Vec,

--- a/node-api/src/metadata.rs
+++ b/node-api/src/metadata.rs
@@ -22,8 +22,8 @@ use scale_info::{form::PortableForm, PortableRegistry, Type};
 #[cfg(feature = "std")]
 use serde::Serialize;
 
-// We use `BTreeMap` because we can't use `HashMap` in `no_std`.
 use alloc::{
+	// We use `BTreeMap` because we can't use `HashMap` in `no_std`.
 	collections::btree_map::BTreeMap,
 	string::{String, ToString},
 	vec,

--- a/node-api/src/storage.rs
+++ b/node-api/src/storage.rs
@@ -14,14 +14,12 @@
 //! For querying runtime storage.
 
 use crate::metadata::MetadataError;
+use ac_primitives::StorageKey;
+use alloc::{borrow::ToOwned, vec::Vec};
 use codec::Encode;
+use core::marker::PhantomData;
 use frame_metadata::{StorageEntryMetadata, StorageEntryType, StorageHasher};
 use scale_info::form::PortableForm;
-use sp_core::storage::StorageKey;
-use sp_std::marker::PhantomData;
-
-#[cfg(not(feature = "std"))]
-use alloc::{borrow::ToOwned, vec::Vec};
 
 #[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd)]
 pub struct StorageValue {

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -8,6 +8,8 @@ edition = "2021"
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ['derive'] }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
+impl-serde = { version = "0.4", default-features = false }
+primitive-types = { version = "0.12.1", default-features = false, features = ["serde_no_std", "scale-info"] }
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
@@ -16,8 +18,7 @@ serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 sp-core = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master" }
 sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master" }
 sp-staking = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sp-std = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sp-weights = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master" }
+sp-version = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master" }
 
 # substrate std / wasm only
 frame-system = { optional = true, git = "https://github.com/paritytech/substrate.git", branch = "master" }
@@ -34,6 +35,7 @@ default = ["std"]
 std = [
     "codec/std",
     "hex/std",
+    "primitive-types/std",
     "scale-info/std",
     "serde/std",
     "serde_json/std",
@@ -41,8 +43,7 @@ std = [
     "sp-core/std",
     "sp-runtime/std",
     "sp-staking/std",
-    "sp-std/std",
-    "sp-weights/std",
+    "sp-version/std",
     # substrate std
     "frame-system",
     "pallet-assets",

--- a/primitives/src/extrinsic_params.rs
+++ b/primitives/src/extrinsic_params.rs
@@ -16,12 +16,11 @@
 */
 
 use codec::{Decode, Encode};
-use core::marker::PhantomData;
+use core::{hash::Hash as HashTrait, marker::PhantomData};
 use sp_runtime::{
 	generic::Era,
 	traits::{BlakeTwo256, Hash},
 };
-use sp_std::{hash::Hash as HashTrait, prelude::*};
 
 pub type BalanceFor<Runtime> = <Runtime as crate::BalancesConfig>::Balance;
 pub type AssetBalanceFor<Runtime> = <Runtime as crate::AssetsConfig>::Balance;

--- a/primitives/src/extrinsics.rs
+++ b/primitives/src/extrinsics.rs
@@ -19,9 +19,10 @@
 
 extern crate alloc;
 
+use alloc::vec::Vec;
 use codec::{Decode, Encode, Error, Input};
+use core::fmt;
 use sp_runtime::MultiSignature;
-use sp_std::{fmt, prelude::*};
 
 pub use sp_runtime::{AccountId32 as AccountId, MultiAddress};
 
@@ -121,7 +122,7 @@ where
 
 /// Same function as in primitives::generic. Needed to be copied as it is private there.
 fn encode_with_vec_prefix<T: Encode, F: Fn(&mut Vec<u8>)>(encoder: F) -> Vec<u8> {
-	let size = sp_std::mem::size_of::<T>();
+	let size = core::mem::size_of::<T>();
 	let reserve = match size {
 		0..=0b0011_1111 => 1,
 		0b0100_0000..=0b0011_1111_1111_1111 => 2,

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -22,11 +22,15 @@ extern crate alloc;
 pub use extrinsic_params::*;
 pub use extrinsics::*;
 pub use pallet_traits::*;
+pub use rpc_numbers::*;
 pub use rpc_params::RpcParams;
+pub use serde_impls::*;
 pub use types::*;
 
 pub mod extrinsic_params;
 pub mod extrinsics;
 pub mod pallet_traits;
+pub mod rpc_numbers;
 pub mod rpc_params;
+pub mod serde_impls;
 pub mod types;

--- a/primitives/src/pallet_traits/frame_system_config.rs
+++ b/primitives/src/pallet_traits/frame_system_config.rs
@@ -17,9 +17,10 @@
 use codec::{Codec, Decode, EncodeLike, FullCodec, MaxEncodedLen};
 use core::fmt::Debug;
 use scale_info::TypeInfo;
+use serde::{de::DeserializeOwned, Serialize};
 use sp_runtime::traits::{
-	self, AtLeast32Bit, AtLeast32BitUnsigned, Bounded, CheckEqual, Dispatchable, Get, Hash,
-	MaybeSerializeDeserialize, Member, SimpleBitOps, StaticLookup,
+	self, AtLeast32Bit, AtLeast32BitUnsigned, Bounded, CheckEqual, Dispatchable, Get, Hash, Member,
+	SimpleBitOps, StaticLookup,
 };
 
 /// Simplifed Frame system Config trait. Needed because substrate pallets compile to wasm
@@ -37,7 +38,8 @@ pub trait FrameSystemConfig {
 		+ TypeInfo
 		+ Dispatchable<RuntimeOrigin = Self::RuntimeOrigin>
 		+ Debug;
-	type Index: MaybeSerializeDeserialize
+	type Index: Serialize
+		+ DeserializeOwned
 		+ Debug
 		+ Default
 		+ AtLeast32Bit
@@ -50,14 +52,15 @@ pub trait FrameSystemConfig {
 		+ Eq
 		+ Debug
 		+ TypeInfo
-		+ MaybeSerializeDeserialize
+		+ Serialize
+		+ DeserializeOwned
 		+ Debug
 		+ AtLeast32BitUnsigned
 		+ Default
 		+ Bounded
 		+ Copy
-		+ sp_std::hash::Hash
-		+ sp_std::str::FromStr
+		+ core::hash::Hash
+		+ core::str::FromStr
 		+ MaxEncodedLen
 		+ TypeInfo;
 	type Hash: Codec
@@ -66,14 +69,15 @@ pub trait FrameSystemConfig {
 		+ Eq
 		+ Debug
 		+ TypeInfo
-		+ MaybeSerializeDeserialize
+		+ Serialize
+		+ DeserializeOwned
 		+ Debug
 		+ SimpleBitOps
 		+ Ord
 		+ Default
 		+ Copy
 		+ CheckEqual
-		+ sp_std::hash::Hash
+		+ core::hash::Hash
 		+ AsRef<[u8]>
 		+ AsMut<[u8]>
 		+ MaxEncodedLen;
@@ -85,7 +89,8 @@ pub trait FrameSystemConfig {
 		+ Debug
 		+ TypeInfo
 		+ Member
-		+ MaybeSerializeDeserialize
+		+ Serialize
+		+ DeserializeOwned
 		+ Debug
 		+ Ord
 		+ MaxEncodedLen;

--- a/primitives/src/pallet_traits/frame_system_config.rs
+++ b/primitives/src/pallet_traits/frame_system_config.rs
@@ -14,6 +14,7 @@
    limitations under the License.
 
 */
+
 use codec::{Codec, Decode, EncodeLike, FullCodec, MaxEncodedLen};
 use core::fmt::Debug;
 use scale_info::TypeInfo;
@@ -38,6 +39,8 @@ pub trait FrameSystemConfig {
 		+ TypeInfo
 		+ Dispatchable<RuntimeOrigin = Self::RuntimeOrigin>
 		+ Debug;
+	/// This type enforces the (de)serialization implementation
+	/// also in no-std mode (unlike substrates MaybeSerializeDeserialize).
 	type Index: Serialize
 		+ DeserializeOwned
 		+ Debug
@@ -46,6 +49,8 @@ pub trait FrameSystemConfig {
 		+ Copy
 		+ MaxEncodedLen
 		+ Decode;
+	/// This type enforces the (de)serialization implementation
+	/// also in no-std mode (unlike substrates MaybeSerializeDeserialize).
 	type BlockNumber: Codec
 		+ EncodeLike
 		+ Clone
@@ -63,6 +68,10 @@ pub trait FrameSystemConfig {
 		+ core::str::FromStr
 		+ MaxEncodedLen
 		+ TypeInfo;
+	/// This type enforces the (de)serialization implementation
+	/// also in no-std mode (unlike substrates MaybeSerializeDeserialize).
+	/// A type redefinition might be necessary in no-std.
+	/// See primitives/serde_impls for examples
 	type Hash: Codec
 		+ EncodeLike
 		+ Clone
@@ -82,6 +91,10 @@ pub trait FrameSystemConfig {
 		+ AsMut<[u8]>
 		+ MaxEncodedLen;
 	type Hashing: Hash<Output = Self::Hash> + TypeInfo;
+	/// This type enforces the (de)serialization implementation
+	/// also in no-std mode (unlike substrates MaybeSerializeDeserialize).
+	/// A type redefinition might be necessary in no-std.
+	/// See primitives/serde_impls for examples.
 	type AccountId: Codec
 		+ EncodeLike
 		+ Clone

--- a/primitives/src/pallet_traits/pallet_assets_config.rs
+++ b/primitives/src/pallet_traits/pallet_assets_config.rs
@@ -23,6 +23,8 @@ use sp_runtime::traits::{AtLeast32BitUnsigned, Get, Member};
 /// in no_std mode.
 pub trait AssetsConfig: crate::FrameSystemConfig {
 	type RuntimeEvent;
+	/// This type enforces the (de)serialization implementation
+	/// also in no-std mode (unlike substrates MaybeSerializeDeserialize).
 	type Balance: AtLeast32BitUnsigned
 		+ Default
 		+ Copy
@@ -31,6 +33,8 @@ pub trait AssetsConfig: crate::FrameSystemConfig {
 		+ MaxEncodedLen
 		+ TypeInfo;
 	type RemoveItemsLimit: Get<u32>;
+	/// This type enforces the (de)serialization implementation
+	/// also in no-std mode (unlike substrates MaybeSerializeDeserialize).
 	type AssetId: Member + Copy + Serialize + DeserializeOwned + MaxEncodedLen;
 	type AssetIdParameter: Copy + From<Self::AssetId> + Into<Self::AssetId> + MaxEncodedLen;
 	type Currency;

--- a/primitives/src/pallet_traits/pallet_assets_config.rs
+++ b/primitives/src/pallet_traits/pallet_assets_config.rs
@@ -16,7 +16,8 @@
 */
 use codec::MaxEncodedLen;
 use scale_info::TypeInfo;
-use sp_runtime::traits::{AtLeast32BitUnsigned, Get, MaybeSerializeDeserialize, Member};
+use serde::{de::DeserializeOwned, Serialize};
+use sp_runtime::traits::{AtLeast32BitUnsigned, Get, Member};
 
 /// Simplifed pallet assets Config trait. Needed because substrate pallets compile to wasm
 /// in no_std mode.
@@ -25,11 +26,12 @@ pub trait AssetsConfig: crate::FrameSystemConfig {
 	type Balance: AtLeast32BitUnsigned
 		+ Default
 		+ Copy
-		+ MaybeSerializeDeserialize
+		+ Serialize
+		+ DeserializeOwned
 		+ MaxEncodedLen
 		+ TypeInfo;
 	type RemoveItemsLimit: Get<u32>;
-	type AssetId: Member + Copy + MaybeSerializeDeserialize + MaxEncodedLen;
+	type AssetId: Member + Copy + Serialize + DeserializeOwned + MaxEncodedLen;
 	type AssetIdParameter: Copy + From<Self::AssetId> + Into<Self::AssetId> + MaxEncodedLen;
 	type Currency;
 	type CreateOrigin;

--- a/primitives/src/pallet_traits/pallet_balances_config.rs
+++ b/primitives/src/pallet_traits/pallet_balances_config.rs
@@ -16,8 +16,9 @@
 */
 use codec::{Codec, EncodeLike, MaxEncodedLen};
 use scale_info::TypeInfo;
+use serde::{de::DeserializeOwned, Serialize};
 use sp_runtime::{
-	traits::{AtLeast32BitUnsigned, Get, MaybeSerializeDeserialize, Member},
+	traits::{AtLeast32BitUnsigned, Get, Member},
 	FixedPointOperand,
 };
 
@@ -30,7 +31,8 @@ pub trait BalancesConfig: crate::FrameSystemConfig {
 		+ AtLeast32BitUnsigned
 		+ Default
 		+ Copy
-		+ MaybeSerializeDeserialize
+		+ Serialize
+		+ DeserializeOwned
 		+ MaxEncodedLen
 		+ TypeInfo
 		+ FixedPointOperand;

--- a/primitives/src/pallet_traits/pallet_balances_config.rs
+++ b/primitives/src/pallet_traits/pallet_balances_config.rs
@@ -25,6 +25,8 @@ use sp_runtime::{
 /// Simplifed pallet balances Config trait. Needed because substrate pallets compile to wasm
 /// in no_std mode.
 pub trait BalancesConfig: crate::FrameSystemConfig {
+	/// This type enforces the (de)serialization implementation
+	/// also in no-std mode (unlike substrates MaybeSerializeDeserialize).
 	type Balance: Codec
 		+ EncodeLike
 		+ Member

--- a/primitives/src/pallet_traits/pallet_staking_config.rs
+++ b/primitives/src/pallet_traits/pallet_staking_config.rs
@@ -17,8 +17,9 @@
 use crate::FrameSystemConfig;
 use codec::MaxEncodedLen;
 use scale_info::TypeInfo;
+use serde::{de::DeserializeOwned, Serialize};
 use sp_runtime::{
-	traits::{AtLeast32BitUnsigned, Get, MaybeSerializeDeserialize},
+	traits::{AtLeast32BitUnsigned, Get},
 	Perbill,
 };
 use sp_staking::{EraIndex, SessionIndex};
@@ -33,7 +34,8 @@ pub trait StakingConfig: FrameSystemConfig {
 	type CurrencyBalance: AtLeast32BitUnsigned
 		+ codec::FullCodec
 		+ Copy
-		+ MaybeSerializeDeserialize
+		+ Serialize
+		+ DeserializeOwned
 		+ core::fmt::Debug
 		+ Default
 		+ From<u64>

--- a/primitives/src/pallet_traits/pallet_staking_config.rs
+++ b/primitives/src/pallet_traits/pallet_staking_config.rs
@@ -31,6 +31,8 @@ pub type BalanceOf<T> = <T as StakingConfig>::CurrencyBalance;
 /// in no_std mode.
 pub trait StakingConfig: FrameSystemConfig {
 	type Currency;
+	/// This type enforces the (de)serialization implementation
+	/// also in no-std mode (unlike substrates MaybeSerializeDeserialize).
 	type CurrencyBalance: AtLeast32BitUnsigned
 		+ codec::FullCodec
 		+ Copy

--- a/primitives/src/rpc_numbers.rs
+++ b/primitives/src/rpc_numbers.rs
@@ -1,0 +1,113 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2017-2022 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A number type that can be serialized both as a number or a string that encodes a number in a
+//! string.
+
+// Copied the whole file from substrate, as sp_rpc is not no_std compatible.
+// https://github.com/paritytech/substrate/blob/cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5/primitives/rpc/src/number.rs
+
+use core::fmt::Debug;
+use primitive_types::U256;
+use serde::{Deserialize, Serialize};
+
+/// A number type that can be serialized both as a number or a string that encodes a number in a
+/// string.
+///
+/// We allow two representations of the block number as input. Either we deserialize to the type
+/// that is specified in the block type or we attempt to parse given hex value.
+///
+/// The primary motivation for having this type is to avoid overflows when using big integers in
+/// JavaScript (which we consider as an important RPC API consumer).
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum NumberOrHex {
+	/// The number represented directly.
+	Number(u64),
+	/// Hex representation of the number.
+	Hex(U256),
+}
+
+impl Default for NumberOrHex {
+	fn default() -> Self {
+		Self::Number(Default::default())
+	}
+}
+
+impl NumberOrHex {
+	/// Converts this number into an U256.
+	pub fn into_u256(self) -> U256 {
+		match self {
+			NumberOrHex::Number(n) => n.into(),
+			NumberOrHex::Hex(h) => h,
+		}
+	}
+}
+
+impl From<u32> for NumberOrHex {
+	fn from(n: u32) -> Self {
+		NumberOrHex::Number(n.into())
+	}
+}
+
+impl From<u64> for NumberOrHex {
+	fn from(n: u64) -> Self {
+		NumberOrHex::Number(n)
+	}
+}
+
+impl From<u128> for NumberOrHex {
+	fn from(n: u128) -> Self {
+		NumberOrHex::Hex(n.into())
+	}
+}
+
+impl From<U256> for NumberOrHex {
+	fn from(n: U256) -> Self {
+		NumberOrHex::Hex(n)
+	}
+}
+
+/// An error type that signals an out-of-range conversion attempt.
+pub struct TryFromIntError(pub(crate) ());
+
+impl TryFrom<NumberOrHex> for u32 {
+	type Error = TryFromIntError;
+	fn try_from(num_or_hex: NumberOrHex) -> Result<u32, Self::Error> {
+		num_or_hex.into_u256().try_into().map_err(|_| TryFromIntError(()))
+	}
+}
+
+impl TryFrom<NumberOrHex> for u64 {
+	type Error = TryFromIntError;
+	fn try_from(num_or_hex: NumberOrHex) -> Result<u64, Self::Error> {
+		num_or_hex.into_u256().try_into().map_err(|_| TryFromIntError(()))
+	}
+}
+
+impl TryFrom<NumberOrHex> for u128 {
+	type Error = TryFromIntError;
+	fn try_from(num_or_hex: NumberOrHex) -> Result<u128, Self::Error> {
+		num_or_hex.into_u256().try_into().map_err(|_| TryFromIntError(()))
+	}
+}
+
+impl From<NumberOrHex> for U256 {
+	fn from(num_or_hex: NumberOrHex) -> U256 {
+		num_or_hex.into_u256()
+	}
+}

--- a/primitives/src/rpc_params.rs
+++ b/primitives/src/rpc_params.rs
@@ -24,7 +24,7 @@
 // IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-//! RPC parameters, orginally belonging to jsonrpsee:
+//! RPC parameters, originally belonging to jsonrpsee:
 //! https://github.com/paritytech/jsonrpsee
 //! It is copied & pasted here to avoid std dependencies.
 
@@ -133,8 +133,8 @@ impl ParamsBuilder {
 		Some(unsafe { String::from_utf8_unchecked(self.bytes) })
 	}
 
-	#[cfg(feature = "std")]
 	/// Insert a plain value into the builder without heap allocation.
+	#[cfg(feature = "std")]
 	pub(crate) fn insert<P: Serialize>(&mut self, value: P) -> Result<()> {
 		self.maybe_initialize();
 
@@ -188,6 +188,15 @@ mod tests {
 		let mut params = RpcParams::new();
 		params.insert(Some(0)).unwrap();
 		params.insert(0).unwrap();
+		let built_params = params.build().unwrap();
+		assert_eq!(built_params, "[0,0]".to_string());
+	}
+
+	#[test]
+	fn insert_with_allocation_multiple_params_works() {
+		let mut params = RpcParams::new();
+		params.insert_with_allocation(Some(0)).unwrap();
+		params.insert_with_allocation(0).unwrap();
 		let built_params = params.build().unwrap();
 		assert_eq!(built_params, "[0,0]".to_string());
 	}

--- a/primitives/src/serde_impls.rs
+++ b/primitives/src/serde_impls.rs
@@ -1,0 +1,462 @@
+/*
+   Copyright 2019 Supercomputing Systems AG
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+	   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+*/
+
+//! Re-defintion of substrate primitives that do not implement
+//! (De)Serialization in no_std. They can be converted to
+//! the original substrate types with From / Into.
+//! This may be omitted, if substrate allows serde impls also in no_std: https://github.com/paritytech/substrate/issues/12994
+
+use alloc::{string::String, vec::Vec};
+use codec::{Decode, Encode};
+use impl_serde::serialize::{from_hex, FromHexError};
+use scale_info::TypeInfo;
+use serde::{Deserialize, Serialize};
+use sp_core::RuntimeDebug;
+use sp_runtime::Justification;
+use sp_version::{ApiId, ApisVec};
+
+/// Hex-serialized shim for `Vec<u8>`.
+// https://github.com/paritytech/substrate/blob/5aaf5f42a7850f00b15a14f635b67061d831ac2d/primitives/core/src/lib.rs#L131
+#[derive(PartialEq, Eq, Clone, RuntimeDebug, Serialize, Deserialize, Hash, PartialOrd, Ord)]
+pub struct Bytes(#[serde(with = "impl_serde::serialize")] pub Vec<u8>);
+
+impl From<Vec<u8>> for Bytes {
+	fn from(s: Vec<u8>) -> Self {
+		Bytes(s)
+	}
+}
+
+impl core::str::FromStr for Bytes {
+	type Err = FromHexError;
+
+	fn from_str(s: &str) -> Result<Self, Self::Err> {
+		from_hex(s).map(Bytes)
+	}
+}
+
+impl From<Bytes> for sp_core::Bytes {
+	fn from(bytes: Bytes) -> Self {
+		Self(bytes.0)
+	}
+}
+
+impl From<sp_core::Bytes> for Bytes {
+	fn from(bytes: sp_core::Bytes) -> Self {
+		Self(bytes.0)
+	}
+}
+
+/// Storage key.
+// https://github.com/paritytech/substrate/blob/cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5/primitives/storage/src/lib.rs#L41-L43
+#[derive(
+	PartialEq,
+	Eq,
+	RuntimeDebug,
+	Serialize,
+	Deserialize,
+	Hash,
+	PartialOrd,
+	Ord,
+	Clone,
+	Encode,
+	Decode,
+)]
+pub struct StorageKey(#[serde(with = "impl_serde::serialize")] pub Vec<u8>);
+
+impl AsRef<[u8]> for StorageKey {
+	fn as_ref(&self) -> &[u8] {
+		self.0.as_ref()
+	}
+}
+
+impl From<StorageKey> for sp_core::storage::StorageKey {
+	fn from(storage_key: StorageKey) -> Self {
+		Self(storage_key.0)
+	}
+}
+
+impl From<sp_core::storage::StorageKey> for StorageKey {
+	fn from(storage_key: sp_core::storage::StorageKey) -> Self {
+		Self(storage_key.0)
+	}
+}
+
+/// Storage data associated to a [`StorageKey`].
+// https://github.com/paritytech/substrate/blob/cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5/primitives/storage/src/lib.rs#L148-L150
+#[derive(
+	PartialEq,
+	Eq,
+	RuntimeDebug,
+	Serialize,
+	Deserialize,
+	Hash,
+	PartialOrd,
+	Ord,
+	Clone,
+	Encode,
+	Decode,
+	Default,
+)]
+pub struct StorageData(#[serde(with = "impl_serde::serialize")] pub Vec<u8>);
+
+impl From<StorageData> for sp_core::storage::StorageData {
+	fn from(storage_data: StorageData) -> Self {
+		Self(storage_data.0)
+	}
+}
+
+impl From<sp_core::storage::StorageData> for StorageData {
+	fn from(storage_data: sp_core::storage::StorageData) -> Self {
+		Self(storage_data.0)
+	}
+}
+
+/// Storage change set
+#[derive(RuntimeDebug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct StorageChangeSet<Hash> {
+	/// Block hash
+	pub block: Hash,
+	/// A list of changes
+	pub changes: Vec<(StorageKey, Option<StorageData>)>,
+}
+
+impl<Hash> From<StorageChangeSet<Hash>> for sp_core::storage::StorageChangeSet<Hash> {
+	fn from(storage_change_set: StorageChangeSet<Hash>) -> Self {
+		Self {
+			block: storage_change_set.block,
+			changes: storage_change_set
+				.changes
+				.iter()
+				.map(|(key, maybe_data)| {
+					(key.clone().into(), maybe_data.as_ref().map(|data| data.clone().into()))
+				})
+				.collect(),
+		}
+	}
+}
+
+impl<Hash> From<sp_core::storage::StorageChangeSet<Hash>> for StorageChangeSet<Hash> {
+	fn from(storage_change_set: sp_core::storage::StorageChangeSet<Hash>) -> Self {
+		Self {
+			block: storage_change_set.block,
+			changes: storage_change_set
+				.changes
+				.into_iter()
+				.map(|(key, maybe_data)| {
+					let key: StorageKey = key.into();
+					let maybe_data: Option<StorageData> = maybe_data.map(|data| data.into());
+					(key, maybe_data)
+				})
+				.collect(),
+		}
+	}
+}
+
+/// Runtime version.
+/// This should not be thought of as classic Semver (major/minor/tiny).
+/// This triplet have different semantics and mis-interpretation could cause problems.
+/// In particular: bug fixes should result in an increment of `spec_version` and possibly
+/// `authoring_version`, absolutely not `impl_version` since they change the semantics of the
+/// runtime.
+// https://github.com/paritytech/substrate/blob/1b3ddae9dec6e7653b5d6ef0179df1af831f46f0/primitives/version/src/lib.rs#L152-L215
+// FIXME: For now RuntimeVersion conversion is not implemented to the substrate RuntimeVersion.
+// It's a little more complicated because of the RuntimeString, which is different in no_std than in std mode.
+#[derive(
+	Clone, PartialEq, Eq, Default, sp_runtime::RuntimeDebug, TypeInfo, Serialize, Deserialize,
+)]
+#[serde(rename_all = "camelCase")]
+pub struct RuntimeVersion {
+	/// Identifies the different Substrate runtimes. There'll be at least polkadot and node.
+	/// A different on-chain spec_name to that of the native runtime would normally result
+	/// in node not attempting to sync or author blocks.
+	pub spec_name: String,
+
+	/// Name of the implementation of the spec. This is of little consequence for the node
+	/// and serves only to differentiate code of different implementation teams. For this
+	/// codebase, it will be parity-polkadot. If there were a non-Rust implementation of the
+	/// Polkadot runtime (e.g. C++), then it would identify itself with an accordingly different
+	/// `impl_name`.
+	pub impl_name: String,
+
+	/// `authoring_version` is the version of the authorship interface. An authoring node
+	/// will not attempt to author blocks unless this is equal to its native runtime.
+	pub authoring_version: u32,
+
+	/// Version of the runtime specification. A full-node will not attempt to use its native
+	/// runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
+	/// `spec_version` and `authoring_version` are the same between Wasm and native.
+	pub spec_version: u32,
+
+	/// Version of the implementation of the specification. Nodes are free to ignore this; it
+	/// serves only as an indication that the code is different; as long as the other two versions
+	/// are the same then while the actual code may be different, it is nonetheless required to
+	/// do the same thing.
+	/// Non-consensus-breaking optimizations are about the only changes that could be made which
+	/// would result in only the `impl_version` changing.
+	pub impl_version: u32,
+
+	/// List of supported API "features" along with their versions.
+	#[serde(
+		serialize_with = "apis_serialize::serialize",
+		deserialize_with = "apis_serialize::deserialize"
+	)]
+	pub apis: ApisVec,
+	//pub apis: alloc::borrow::Cow<'static, [([u8; 8], u32)]>,
+	/// All existing dispatches are fully compatible when this number doesn't change. If this
+	/// number changes, then `spec_version` must change, also.
+	///
+	/// This number must change when an existing dispatchable (module ID, dispatch ID) is changed,
+	/// either through an alteration in its user-level semantics, a parameter
+	/// added/removed/changed, a dispatchable being removed, a module being removed, or a
+	/// dispatchable/module changing its index.
+	///
+	/// It need *not* change when a new module is added or when a dispatchable is added.
+	pub transaction_version: u32,
+
+	/// Version of the state implementation used by this runtime.
+	/// Use of an incorrect version is consensus breaking.
+	pub state_version: u8,
+}
+/// Abstraction over a substrate block and justification.
+// https://github.com/paritytech/substrate/blob/fafc8e0ba8c98bd22b47913ded414e74a0fcb67f/primitives/runtime/src/generic/block.rs
+#[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
+pub struct SignedBlock<Block> {
+	/// Full block.
+	pub block: Block,
+	/// Block justification.
+	pub justifications: Option<Justifications>,
+}
+
+impl<Block> From<sp_runtime::generic::SignedBlock<Block>> for SignedBlock<Block> {
+	fn from(signed_block: sp_runtime::generic::SignedBlock<Block>) -> Self {
+		Self {
+			block: signed_block.block,
+			justifications: signed_block.justifications.map(|justifactions| justifactions.into()),
+		}
+	}
+}
+
+impl<Block> From<SignedBlock<Block>> for sp_runtime::generic::SignedBlock<Block> {
+	fn from(signed_block: SignedBlock<Block>) -> Self {
+		Self {
+			block: signed_block.block,
+			justifications: signed_block.justifications.map(|justifactions| justifactions.into()),
+		}
+	}
+}
+
+/// Collection of justifications for a given block, multiple justifications may
+/// be provided by different consensus engines for the same block.
+// https://github.com/paritytech/substrate/blob/fafc8e0ba8c98bd22b47913ded414e74a0fcb67f/primitives/runtime/src/lib.rs#L125-L127
+#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, Serialize, Deserialize)]
+pub struct Justifications(pub Vec<Justification>);
+
+impl From<sp_runtime::Justifications> for Justifications {
+	fn from(justifications: sp_runtime::Justifications) -> Self {
+		let mut justification_vec = Vec::new();
+		for justification in justifications.iter() {
+			justification_vec.push(justification.clone());
+		}
+		Self(justification_vec)
+	}
+}
+
+impl From<Justifications> for sp_runtime::Justifications {
+	fn from(justifications: Justifications) -> Self {
+		let first_justifaction = justifications.0[0].clone();
+		let mut sp_runtime_justifications: sp_runtime::Justifications = first_justifaction.into();
+		for justification in justifications.0 {
+			sp_runtime_justifications.append(justification);
+		}
+		sp_runtime_justifications
+	}
+}
+
+/// The old weight type.
+// https://github.com/paritytech/substrate/blob/d0540a79967cb06cd7598a4965c7c06afc788b0c/primitives/weights/src/lib.rs#L78
+#[derive(
+	Decode,
+	Encode,
+	PartialEq,
+	Eq,
+	Clone,
+	Copy,
+	RuntimeDebug,
+	Default,
+	TypeInfo,
+	Serialize,
+	Deserialize,
+)]
+#[serde(transparent)]
+pub struct OldWeight(pub u64);
+
+// Copied from sp_version (only available in std in the substrate version).
+// https://github.com/paritytech/substrate/blob/1b3ddae9dec6e7653b5d6ef0179df1af831f46f0/primitives/version/src/lib.rs#L392-L393
+mod apis_serialize {
+	use super::*;
+	use impl_serde::serialize as bytes;
+	use serde::{de, ser::SerializeTuple, Serializer};
+
+	#[derive(Serialize)]
+	struct ApiId<'a>(#[serde(serialize_with = "serialize_bytesref")] &'a super::ApiId, &'a u32);
+
+	pub fn serialize<S>(apis: &ApisVec, ser: S) -> Result<S::Ok, S::Error>
+	where
+		S: Serializer,
+	{
+		let len = apis.len();
+		let mut seq = ser.serialize_tuple(len)?;
+		for (api, ver) in &**apis {
+			seq.serialize_element(&ApiId(api, ver))?;
+		}
+		seq.end()
+	}
+
+	pub fn serialize_bytesref<S>(&apis: &&super::ApiId, ser: S) -> Result<S::Ok, S::Error>
+	where
+		S: Serializer,
+	{
+		bytes::serialize(apis, ser)
+	}
+
+	#[derive(Deserialize)]
+	struct ApiIdOwned(#[serde(deserialize_with = "deserialize_bytes")] super::ApiId, u32);
+
+	pub fn deserialize<'de, D>(deserializer: D) -> Result<ApisVec, D::Error>
+	where
+		D: de::Deserializer<'de>,
+	{
+		struct Visitor;
+		impl<'de> de::Visitor<'de> for Visitor {
+			type Value = ApisVec;
+
+			fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
+				formatter.write_str("a sequence of api id and version tuples")
+			}
+
+			fn visit_seq<V>(self, mut visitor: V) -> Result<Self::Value, V::Error>
+			where
+				V: de::SeqAccess<'de>,
+			{
+				let mut apis = Vec::new();
+				while let Some(value) = visitor.next_element::<ApiIdOwned>()? {
+					apis.push((value.0, value.1));
+				}
+				Ok(apis.into())
+			}
+		}
+		deserializer.deserialize_seq(Visitor)
+	}
+
+	pub fn deserialize_bytes<'de, D>(d: D) -> Result<super::ApiId, D::Error>
+	where
+		D: de::Deserializer<'de>,
+	{
+		let mut arr = [0; 8];
+		bytes::deserialize_check_len(d, bytes::ExpectedLen::Exact(&mut arr[..]))?;
+		Ok(arr)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use codec::Encode;
+	use core::str::FromStr;
+	use primitive_types::H256;
+
+	#[test]
+	fn from_substrate_bytes_to_bytes_works() {
+		let string = "0x12341560";
+		let bytes = Bytes::from_str(string).unwrap();
+		let substrate_bytes: sp_core::Bytes = bytes.clone().into();
+		let original_bytes: Bytes = substrate_bytes.into();
+
+		assert_eq!(original_bytes, bytes);
+	}
+
+	#[test]
+	fn from_substrate_storage_data_to_storage_data_works() {
+		let test_vec = "test_string".encode();
+		let storage_data = StorageData(test_vec);
+		let substrate_storage_data: sp_core::storage::StorageData = storage_data.clone().into();
+		let original_storage_data: StorageData = substrate_storage_data.into();
+
+		assert_eq!(original_storage_data, storage_data);
+	}
+
+	#[test]
+	fn from_substrate_storage_key_to_storage_key_works() {
+		let test_vec = "test_string".encode();
+		let storage_key = StorageKey(test_vec);
+		let substrate_storage_key: sp_core::storage::StorageKey = storage_key.clone().into();
+		let original_storage_key: StorageKey = substrate_storage_key.into();
+
+		assert_eq!(original_storage_key, storage_key);
+	}
+
+	#[test]
+	fn from_substrate_change_set_to_change_set_works() {
+		let test_vec = "test_data".encode();
+		let storage_data = StorageData(test_vec);
+		let test_vec = "test_key".encode();
+		let storage_key = StorageKey(test_vec);
+		let changes = vec![(storage_key, Some(storage_data))];
+		let hash = H256::random();
+
+		let change_set = StorageChangeSet { block: hash, changes: changes.clone() };
+
+		let substrate_change_set: sp_core::storage::StorageChangeSet<H256> = change_set.into();
+		let original_change_set: StorageChangeSet<H256> = substrate_change_set.into();
+
+		assert_eq!(original_change_set.block, hash);
+		assert_eq!(original_change_set.changes, changes);
+	}
+
+	#[test]
+	fn from_substrate_justifications_to_justification_works() {
+		let encoded_justifcation = "test_string".encode();
+		let consensus_engine_id: [u8; 4] = [1, 2, 3, 4];
+		let justification: Justification = (consensus_engine_id, encoded_justifcation);
+		let justifications = Justifications(vec![justification]);
+
+		let substrate_justifications: sp_runtime::Justifications = justifications.clone().into();
+		let original_justifications: Justifications = substrate_justifications.into();
+
+		assert_eq!(original_justifications, justifications);
+	}
+
+	#[test]
+	fn from_substrate_signed_block_to_signed_block_works() {
+		let block = "test_string".encode();
+		let encoded_justifcation = "test_string".encode();
+		let consensus_engine_id: [u8; 4] = [1, 2, 3, 4];
+		let justification: Justification = (consensus_engine_id, encoded_justifcation);
+		let justifications = Some(Justifications(vec![justification]));
+
+		let signed_block = SignedBlock { block, justifications };
+
+		let substrate_signed_block: sp_runtime::generic::SignedBlock<Vec<u8>> =
+			signed_block.clone().into();
+		let original_signed_block: SignedBlock<Vec<u8>> = substrate_signed_block.into();
+
+		assert_eq!(original_signed_block, signed_block);
+	}
+}

--- a/primitives/src/types.rs
+++ b/primitives/src/types.rs
@@ -48,9 +48,8 @@ pub struct AccountInfo<Index, AccountData> {
 
 /// The base fee and adjusted weight and length fees constitute the _inclusion fee_.
 // https://github.com/paritytech/substrate/blob/a1c1286d2ca6360a16d772cc8bea2190f77f4d8f/frame/transaction-payment/src/types.rs#L29-L60
-#[derive(Encode, Decode, Clone, Eq, PartialEq)]
-#[cfg_attr(feature = "std", derive(Debug, Serialize, Deserialize))]
-#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
+#[derive(Encode, Decode, Clone, Eq, PartialEq, Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
 pub struct InclusionFee<Balance> {
 	/// This is the minimum amount a user pays for a transaction. It is declared
 	/// as a base _weight_ in the runtime and converted to a fee using `WeightToFee`.
@@ -85,13 +84,13 @@ impl<Balance: AtLeast32BitUnsigned + Copy> InclusionFee<Balance> {
 ///   - `tip`: If included in the transaction, the tip will be added on top. Only signed
 ///     transactions can have a tip.
 // https://github.com/paritytech/substrate/blob/a1c1286d2ca6360a16d772cc8bea2190f77f4d8f/frame/transaction-payment/src/types.rs#L62-L90
-#[derive(Encode, Decode, Clone, Eq, PartialEq)]
-#[cfg_attr(feature = "std", derive(Debug, Serialize, Deserialize))]
-#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
+#[derive(Encode, Decode, Clone, Eq, PartialEq, Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
 pub struct FeeDetails<Balance> {
 	/// The minimum fee for a transaction to be included in a block.
 	pub inclusion_fee: Option<InclusionFee<Balance>>,
-	#[cfg_attr(feature = "std", serde(skip))]
+	//#[cfg_attr(feature = "std", serde(skip))]
+	#[serde(skip)]
 	pub tip: Balance,
 }
 
@@ -113,18 +112,11 @@ impl<Balance: AtLeast32BitUnsigned + Copy> FeeDetails<Balance> {
 /// Information related to a dispatchable's class, weight, and fee that can be queried from the
 /// runtime.
 // https://github.com/paritytech/substrate/blob/a1c1286d2ca6360a16d772cc8bea2190f77f4d8f/frame/transaction-payment/src/types.rs#L92-L116
-#[derive(Eq, PartialEq, Encode, Decode, Default, Debug)]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
-#[cfg_attr(
-	feature = "std",
-	serde(bound(serialize = "Balance: std::fmt::Display, Weight: Serialize"))
-)]
-#[cfg_attr(
-	feature = "std",
-	serde(bound(deserialize = "Balance: std::str::FromStr, Weight: Deserialize<'de>"))
-)]
-pub struct RuntimeDispatchInfo<Balance, Weight = sp_weights::OldWeight> {
+#[derive(Eq, PartialEq, Encode, Decode, Default, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(bound(serialize = "Balance: core::fmt::Display, Weight: Serialize"))]
+#[serde(bound(deserialize = "Balance: core::str::FromStr, Weight: Deserialize<'de>"))]
+pub struct RuntimeDispatchInfo<Balance, Weight = crate::serde_impls::OldWeight> {
 	/// Weight of this dispatch.
 	pub weight: Weight,
 	/// Class of this dispatch.
@@ -133,25 +125,26 @@ pub struct RuntimeDispatchInfo<Balance, Weight = sp_weights::OldWeight> {
 	///
 	/// This does not include a tip or anything else that
 	/// depends on the signature (i.e. depends on a `SignedExtension`).
-	#[cfg_attr(feature = "std", serde(with = "serde_balance"))]
+	//#[cfg_attr(feature = "std", serde(with = "serde_balance"))]
+	#[serde(with = "serde_balance")]
 	pub partial_fee: Balance,
 }
 
-#[cfg(feature = "std")]
 mod serde_balance {
+	use alloc::string::ToString;
 	use serde::{Deserialize, Deserializer, Serializer};
 
-	pub fn serialize<S: Serializer, T: std::fmt::Display>(
+	pub fn serialize<S: Serializer, T: core::fmt::Display>(
 		t: &T,
 		serializer: S,
 	) -> Result<S::Ok, S::Error> {
 		serializer.serialize_str(&t.to_string())
 	}
 
-	pub fn deserialize<'de, D: Deserializer<'de>, T: std::str::FromStr>(
+	pub fn deserialize<'de, D: Deserializer<'de>, T: core::str::FromStr>(
 		deserializer: D,
 	) -> Result<T, D::Error> {
-		let s = String::deserialize(deserializer)?;
+		let s = alloc::string::String::deserialize(deserializer)?;
 		s.parse::<T>().map_err(|_| serde::de::Error::custom("Parse from string failed"))
 	}
 }
@@ -161,9 +154,10 @@ mod serde_balance {
 /// NOTE whenever upgrading the enum make sure to also update
 /// [DispatchClass::all] and [DispatchClass::non_mandatory] helper functions.
 // https://github.com/paritytech/substrate/blob/a1c1286d2ca6360a16d772cc8bea2190f77f4d8f/frame/support/src/dispatch.rs#L133-L177
-#[derive(PartialEq, Eq, Clone, Copy, Encode, Decode, RuntimeDebug, TypeInfo)]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
+#[derive(
+	PartialEq, Eq, Clone, Copy, Encode, Decode, RuntimeDebug, TypeInfo, Serialize, Deserialize,
+)]
+#[serde(rename_all = "camelCase")]
 pub enum DispatchClass {
 	/// A normal dispatch.
 	Normal,

--- a/primitives/src/types.rs
+++ b/primitives/src/types.rs
@@ -89,7 +89,6 @@ impl<Balance: AtLeast32BitUnsigned + Copy> InclusionFee<Balance> {
 pub struct FeeDetails<Balance> {
 	/// The minimum fee for a transaction to be included in a block.
 	pub inclusion_fee: Option<InclusionFee<Balance>>,
-	//#[cfg_attr(feature = "std", serde(skip))]
 	#[serde(skip)]
 	pub tip: Balance,
 }
@@ -125,7 +124,6 @@ pub struct RuntimeDispatchInfo<Balance, Weight = crate::serde_impls::OldWeight> 
 	///
 	/// This does not include a tip or anything else that
 	/// depends on the signature (i.e. depends on a `SignedExtension`).
-	//#[cfg_attr(feature = "std", serde(with = "serde_balance"))]
 	#[serde(with = "serde_balance")]
 	pub partial_fee: Balance,
 }

--- a/src/api/api_client.rs
+++ b/src/api/api_client.rs
@@ -19,14 +19,13 @@ use crate::{
 };
 use ac_compose_macros::rpc_params;
 use ac_node_api::metadata::Metadata;
-use ac_primitives::{ExtrinsicParams, FrameSystemConfig};
+use ac_primitives::{Bytes, ExtrinsicParams, FrameSystemConfig, RuntimeVersion};
 use codec::Decode;
 use core::convert::TryFrom;
 use frame_metadata::RuntimeMetadataPrefixed;
 use log::{debug, info};
-use sp_core::{crypto::Pair, Bytes};
+use sp_core::Pair;
 use sp_runtime::MultiSignature;
-use sp_version::RuntimeVersion;
 
 /// Api to talk with substrate-nodes
 ///

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -24,6 +24,8 @@ pub mod error;
 pub mod rpc_api;
 
 use ac_node_api::EventDetails;
+use ac_primitives::Bytes;
+use alloc::{string::String, vec::Vec};
 use serde::{Deserialize, Serialize};
 
 /// Extrinsic report returned upon a submit_and_watch request.
@@ -137,5 +139,5 @@ pub struct ReadProof<Hash> {
 	/// Block hash used to generate the proof
 	pub at: Hash,
 	/// A proof used to prove that storage entries are included in the storage trie
-	pub proof: Vec<sp_core::Bytes>,
+	pub proof: Vec<Bytes>,
 }

--- a/src/api/rpc_api/author.rs
+++ b/src/api/rpc_api/author.rs
@@ -21,6 +21,7 @@ use crate::{
 };
 use ac_compose_macros::rpc_params;
 use ac_primitives::{ExtrinsicParams, FrameSystemConfig};
+use alloc::{format, string::String};
 use log::*;
 use serde::de::DeserializeOwned;
 use sp_runtime::traits::Hash as HashTrait;

--- a/src/api/rpc_api/author.rs
+++ b/src/api/rpc_api/author.rs
@@ -21,7 +21,7 @@ use crate::{
 };
 use ac_compose_macros::rpc_params;
 use ac_primitives::{ExtrinsicParams, FrameSystemConfig};
-use alloc::{format, string::String};
+use alloc::{format, vec::Vec};
 use log::*;
 use serde::de::DeserializeOwned;
 use sp_runtime::traits::Hash as HashTrait;

--- a/src/api/rpc_api/chain.rs
+++ b/src/api/rpc_api/chain.rs
@@ -17,10 +17,10 @@ use crate::{
 	FromHexString,
 };
 use ac_compose_macros::rpc_params;
-use ac_primitives::{ExtrinsicParams, FrameSystemConfig};
+use ac_primitives::{ExtrinsicParams, FrameSystemConfig, SignedBlock};
 use log::*;
 use serde::de::DeserializeOwned;
-use sp_runtime::{generic::SignedBlock, traits::GetRuntimeBlockType};
+use sp_runtime::traits::GetRuntimeBlockType;
 
 pub trait GetHeader<Hash> {
 	type Header;
@@ -119,7 +119,6 @@ where
 		self.get_block_hash(number).map(|h| self.get_signed_block(h))?
 	}
 }
-
 pub trait SubscribeChain<Client, Hash>
 where
 	Client: Subscribe,

--- a/src/api/rpc_api/frame_system.rs
+++ b/src/api/rpc_api/frame_system.rs
@@ -19,13 +19,13 @@ use crate::{
 	utils,
 };
 use ac_compose_macros::rpc_params;
-use ac_primitives::{AccountInfo, ExtrinsicParams, FrameSystemConfig};
+use ac_primitives::{
+	AccountInfo, ExtrinsicParams, FrameSystemConfig, StorageChangeSet, StorageKey,
+};
+use alloc::vec;
 use log::*;
 use serde::de::DeserializeOwned;
-use sp_core::{
-	storage::{StorageChangeSet, StorageKey},
-	Pair,
-};
+use sp_core::Pair;
 use sp_runtime::MultiSignature;
 
 pub trait GetAccountInformation<AccountId> {

--- a/src/api/rpc_api/pallet_transaction_payment.rs
+++ b/src/api/rpc_api/pallet_transaction_payment.rs
@@ -18,6 +18,7 @@ use crate::{
 };
 use ac_compose_macros::rpc_params;
 use ac_primitives::{BalancesConfig, FeeDetails, InclusionFee, NumberOrHex, RuntimeDispatchInfo};
+use alloc::vec::Vec;
 use core::str::FromStr;
 /// Interface to common calls of the substrate transaction payment pallet.
 pub trait GetTransactionPayment<Hash> {

--- a/src/api/rpc_api/pallet_transaction_payment.rs
+++ b/src/api/rpc_api/pallet_transaction_payment.rs
@@ -17,10 +17,8 @@ use crate::{
 	ExtrinsicParams,
 };
 use ac_compose_macros::rpc_params;
-use ac_primitives::{BalancesConfig, FeeDetails, InclusionFee, RuntimeDispatchInfo};
+use ac_primitives::{BalancesConfig, FeeDetails, InclusionFee, NumberOrHex, RuntimeDispatchInfo};
 use core::str::FromStr;
-use sp_rpc::number::NumberOrHex;
-
 /// Interface to common calls of the substrate transaction payment pallet.
 pub trait GetTransactionPayment<Hash> {
 	type Balance;

--- a/src/api/rpc_api/state.rs
+++ b/src/api/rpc_api/state.rs
@@ -16,11 +16,13 @@ use crate::{
 	utils, Api, MetadataError, ReadProof,
 };
 use ac_compose_macros::rpc_params;
-use ac_primitives::{ExtrinsicParams, FrameSystemConfig};
+use ac_primitives::{
+	ExtrinsicParams, FrameSystemConfig, StorageChangeSet, StorageData, StorageKey,
+};
+use alloc::{string::String, vec, vec::Vec};
 use codec::{Decode, Encode};
 use log::*;
 use serde::de::DeserializeOwned;
-use sp_core::storage::{StorageChangeSet, StorageData, StorageKey};
 
 /// Generic interface to substrate storage.
 pub trait GetStorage<Hash> {
@@ -255,7 +257,6 @@ where
 		Ok(Decode::decode(&mut c.value.as_slice())?)
 	}
 }
-
 pub trait SubscribeState<Client, Hash>
 where
 	Client: Subscribe,

--- a/src/api/rpc_api/subscribe_events.rs
+++ b/src/api/rpc_api/subscribe_events.rs
@@ -16,10 +16,9 @@ use crate::{
 	rpc::{HandleSubscription, Subscribe},
 };
 use ac_node_api::{events::EventDetails, Events, StaticEvent};
-use ac_primitives::{ExtrinsicParams, FrameSystemConfig};
+use ac_primitives::{ExtrinsicParams, FrameSystemConfig, StorageChangeSet};
 use log::*;
 use serde::de::DeserializeOwned;
-use sp_core::storage::StorageChangeSet;
 
 // FIXME: This should rather be implemented directly on the
 // Subscription return value, rather than the api. Or directly

--- a/src/extrinsic/balances.rs
+++ b/src/extrinsic/balances.rs
@@ -22,6 +22,7 @@ use ac_compose_macros::compose_extrinsic;
 use ac_primitives::{
 	BalancesConfig, CallIndex, ExtrinsicParams, GenericAddress, UncheckedExtrinsicV4,
 };
+use alloc::borrow::ToOwned;
 use codec::{Compact, Encode};
 use serde::de::DeserializeOwned;
 use sp_core::crypto::Pair;
@@ -40,7 +41,6 @@ pub type BalanceTransferXt<SignedExtra, Balance> =
 pub type BalanceSetBalanceXt<SignedExtra, Balance> =
 	UncheckedExtrinsicV4<BalanceSetBalanceFn<Balance>, SignedExtra>;
 
-#[cfg(feature = "std")]
 impl<Signer, Client, Params, Runtime> Api<Signer, Client, Params, Runtime>
 where
 	Signer: Pair,

--- a/src/extrinsic/common.rs
+++ b/src/extrinsic/common.rs
@@ -17,6 +17,7 @@
 
 //! Common types.
 
+use alloc::vec::Vec;
 use codec::{Decode, Encode};
 use sp_runtime::AccountId32;
 

--- a/src/extrinsic/contracts.rs
+++ b/src/extrinsic/contracts.rs
@@ -24,11 +24,11 @@ use ac_primitives::{
 	BalancesConfig, CallIndex, ContractsConfig, ExtrinsicParams, FrameSystemConfig, GenericAddress,
 	UncheckedExtrinsicV4,
 };
+use alloc::vec::Vec;
 use codec::{Compact, Encode};
 use serde::de::DeserializeOwned;
 use sp_core::crypto::Pair;
 use sp_runtime::{traits::GetRuntimeBlockType, MultiSignature, MultiSigner};
-use sp_std::prelude::*;
 
 pub const CONTRACTS_MODULE: &str = "Contracts";
 pub const CONTRACTS_PUT_CODE: &str = "put_code";

--- a/src/extrinsic/utility.rs
+++ b/src/extrinsic/utility.rs
@@ -21,6 +21,7 @@ use super::common::Batch;
 use crate::{rpc::Request, Api};
 use ac_compose_macros::compose_extrinsic;
 use ac_primitives::{BalancesConfig, CallIndex, ExtrinsicParams, UncheckedExtrinsicV4};
+use alloc::{borrow::ToOwned, vec::Vec};
 use codec::Encode;
 use sp_core::Pair;
 use sp_runtime::{traits::GetRuntimeBlockType, MultiSignature, MultiSigner};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,17 +23,10 @@ extern crate alloc;
 pub use ac_compose_macros::*;
 pub use ac_node_api::*;
 pub use ac_primitives::*;
+pub use api::*;
 pub use utils::*;
 
+pub mod api;
+pub mod extrinsic;
 pub mod rpc;
 pub mod utils;
-
-// std only features:
-
-#[cfg(feature = "std")]
-pub use api::*;
-
-#[cfg(feature = "std")]
-pub mod api;
-#[cfg(feature = "std")]
-pub mod extrinsic;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -15,9 +15,10 @@
 
 */
 
+use ac_primitives::StorageKey;
 use alloc::{string::String, vec::Vec};
 use hex::FromHexError;
-use sp_core::{storage::StorageKey, twox_128, H256};
+use sp_core::{twox_128, H256};
 
 pub fn storage_key(module: &str, storage_key_name: &str) -> StorageKey {
 	let mut key = twox_128(module.as_bytes()).to_vec();


### PR DESCRIPTION
🌈  Featuring added `no_std` compatibility for the full `Api` included traits and the implementations (except for the rpc clients)
- removes `sp-std` dependency. Whenever possible, depend on `core` or `alloc` directly. The `std` version itself points to them as well. No need for an extra library to do that,
- Introduces a lot of substrate types in `primitives/serde_impls` to implement serde also in `no_std`. Wherever sensible, the conversion from substrate type and redefined type has been implemented with `From`. So the newly self-implemented types should not pose a big problem for the user.  Another good thing: If substrate updates the types, this will be noticed quite fast via the unit tests.
- Removed `MaybeSerializeDeserialize` because this only enforces (De)Serialization only in `std` mode.
- Reimplemented `NumberOrHex` because  `sp-rpc` is not `no_std` compatible. 
- Removed some unused error types in `src/api/error.rs`



closes #279 
