### PR TITLE
Make api/rpc interfaces no_std compatible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5188,7 +5188,6 @@ dependencies = [
  "kitchensink-runtime",
  "log",
  "parity-scale-codec",
- "primitive-types",
  "serde",
  "serde_json",
  "sp-core",
@@ -5197,7 +5196,7 @@ dependencies = [
  "sp-runtime-interface",
  "sp-std",
  "sp-version",
- "thiserror",
+ "thiserror-core",
  "tungstenite",
  "url",
  "ws",
@@ -5331,6 +5330,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
 dependencies = [
  "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-core"
+version = "1.0.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808e769db82353a456db04af0e76a4e211c5428516cead2b420dfa3d82cb83d3"
+dependencies = [
+ "thiserror-core-impl",
+]
+
+[[package]]
+name = "thiserror-core-impl"
+version = "1.0.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7905b4dad6617f9e81544469da6bb1c658c02c6c7e420ee953d03687db1e1cfe"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,9 +25,10 @@ log = { version = "0.4.14", default-features = false }
 serde = { version = "1.0.136", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.79", default-features = false }
 
+#FIXME: convert back to thiserror once possible #317
+thiserror = { version = "1.0", package = "thiserror-core", default-features = false }
+
 # crates.io std only
-primitive-types = { version = "0.12.1", optional = true, features = ["codec"] }
-thiserror = { version = "1.0.30", optional = true }
 url = { version = "2.0.0", optional = true }
 
 # websocket dependent features
@@ -70,9 +71,8 @@ std = [
     "log/std",
     "serde/std",
     "serde_json/std",
+    "thiserror/std",
     # crates.io std only
-    "primitive-types",
-    "thiserror",
     "url",
     # substrate no_std
     "frame-metadata/std",

--- a/compose-macros/src/lib.rs
+++ b/compose-macros/src/lib.rs
@@ -21,9 +21,7 @@
 
 // re-export for macro resolution
 pub use ac_primitives as primitives;
-#[cfg(feature = "std")]
 pub use codec;
-#[cfg(feature = "std")]
 pub use log;
 pub use rpc::*;
 pub use sp_core;
@@ -98,7 +96,6 @@ macro_rules! compose_extrinsic_offline {
 /// * 'args' - Optional sequence of arguments of the call. They are not checked against the metadata.
 /// As of now the user needs to check himself that the correct arguments are supplied.
 #[macro_export]
-#[cfg(feature = "std")]
 macro_rules! compose_extrinsic {
 	($api: expr,
 	$module: expr,

--- a/primitives/src/rpc_params.rs
+++ b/primitives/src/rpc_params.rs
@@ -144,9 +144,9 @@ impl ParamsBuilder {
 		Ok(())
 	}
 
-	#[cfg(not(feature = "std"))]
 	/// Insert a plain value into the builder with heap allocation. If available,
 	/// use the more efficient std version.
+	#[cfg(not(feature = "std"))]
 	pub(crate) fn insert<P: Serialize>(&mut self, value: P) -> Result<()> {
 		self.insert_with_allocation(value)
 	}

--- a/primitives/src/rpc_params.rs
+++ b/primitives/src/rpc_params.rs
@@ -42,7 +42,6 @@ impl RpcParams {
 	}
 
 	/// Insert a plain value into the builder.
-	#[cfg(feature = "std")]
 	pub fn insert<P: Serialize>(&mut self, value: P) -> Result<()> {
 		self.0.insert(value)
 	}
@@ -143,6 +142,13 @@ impl ParamsBuilder {
 		self.bytes.push(b',');
 
 		Ok(())
+	}
+
+	#[cfg(not(feature = "std"))]
+	/// Insert a plain value into the builder with heap allocation. If available,
+	/// use the more efficient std version.
+	pub(crate) fn insert<P: Serialize>(&mut self, value: P) -> Result<()> {
+		self.insert_with_allocation(value)
 	}
 
 	/// Insert a plain value into the builder with heap allocation. For better performance,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,12 +16,16 @@
 */
 #![cfg_attr(not(feature = "std"), no_std)]
 #![feature(assert_matches)]
+#![feature(error_in_core)]
+
+extern crate alloc;
 
 pub use ac_compose_macros::*;
 pub use ac_node_api::*;
 pub use ac_primitives::*;
 pub use utils::*;
 
+pub mod rpc;
 pub mod utils;
 
 // std only features:
@@ -33,5 +37,3 @@ pub use api::*;
 pub mod api;
 #[cfg(feature = "std")]
 pub mod extrinsic;
-#[cfg(feature = "std")]
-pub mod rpc;

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -35,6 +35,7 @@ pub mod error;
 pub use error::*;
 
 use ac_primitives::RpcParams;
+use alloc::string::{String, ToString};
 use serde::de::DeserializeOwned;
 
 /// Trait to be implemented by the ws-client for sending rpc requests and extrinsic.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -15,11 +15,7 @@
 
 */
 
-#[cfg(not(feature = "std"))]
-extern crate alloc;
-#[cfg(not(feature = "std"))]
 use alloc::{string::String, vec::Vec};
-
 use hex::FromHexError;
 use sp_core::{storage::StorageKey, twox_128, H256};
 


### PR DESCRIPTION
One step further towards `no_std` compatibility:
- `compsoe-macros` is now fully `no_std` compatible
- `api/rpc` is now fully `no_std` compatible
- remove unused `primitives-types` import in `Cargo.toml`

Drawbacks:
- `thiserror` needed to be changed to `thiserror-core`. But that should be temporary only. And better than removing it completely (I hope).
- Some errors needed to be changed from Error-Types to Strings, because they are not available in `no_std`.

one step towards  https://github.com/scs/substrate-api-client/issues/279