### PR TITLE
Add `submit_and_watch_extrinsic_until_success` method

### DIFF
--- a/examples/examples/batch_payout.rs
+++ b/examples/examples/batch_payout.rs
@@ -96,7 +96,7 @@ async fn main() {
 		if payout_calls_len > 0 {
 			let batching = api.batch(payout_calls);
 			let results_hash = api
-				.submit_and_watch_extrinsic_until(&batching.hex_encode(), XtStatus::InBlock)
+				.submit_and_watch_extrinsic_until(batching.encode(), XtStatus::InBlock)
 				.unwrap()
 				.block_hash
 				.unwrap();

--- a/examples/examples/batch_payout.rs
+++ b/examples/examples/batch_payout.rs
@@ -97,6 +97,8 @@ async fn main() {
 			let batching = api.batch(payout_calls);
 			let results_hash = api
 				.submit_and_watch_extrinsic_until(&batching.hex_encode(), XtStatus::InBlock)
+				.unwrap()
+				.block_hash
 				.unwrap();
 			num_of_claimed_payouts += payout_calls_len;
 

--- a/examples/examples/benchmark_bulk_xt.rs
+++ b/examples/examples/benchmark_bulk_xt.rs
@@ -18,6 +18,7 @@
 // run this against test node with
 // > substrate-test-node --dev --execution native --ws-port 9979 -ltxpool=debug
 
+use codec::Encode;
 use kitchensink_runtime::{BalancesCall, Runtime, RuntimeCall};
 use sp_keyring::AccountKeyring;
 use substrate_api_client::{
@@ -55,7 +56,7 @@ async fn main() {
 		);
 
 		println!("sending extrinsic with nonce {}", nonce);
-		let _tx_hash = api.submit_extrinsic(xt.hex_encode()).unwrap();
+		let _tx_hash = api.submit_extrinsic(xt.encode()).unwrap();
 
 		nonce += 1;
 	}

--- a/examples/examples/compose_extrinsic_offline.rs
+++ b/examples/examples/compose_extrinsic_offline.rs
@@ -68,6 +68,7 @@ async fn main() {
 	let block_hash = api
 		.submit_and_watch_extrinsic_until(&xt.hex_encode(), XtStatus::InBlock)
 		.unwrap()
+		.block_hash
 		.unwrap();
-	println!("[+] Transaction got included in block {:?}", block_hash);
+	println!("[+] Extrinsic got included in block {:?}", block_hash);
 }

--- a/examples/examples/compose_extrinsic_offline.rs
+++ b/examples/examples/compose_extrinsic_offline.rs
@@ -16,6 +16,7 @@
 //! This examples shows how to use the compose_extrinsic_offline macro which generates an extrinsic
 //! without asking the node for nonce and does not need to know the metadata
 
+use codec::Encode;
 use kitchensink_runtime::{BalancesCall, Header, Runtime, RuntimeCall};
 use sp_keyring::AccountKeyring;
 use sp_runtime::{generic::Era, MultiAddress};
@@ -66,7 +67,7 @@ async fn main() {
 
 	// Send and watch extrinsic until in block.
 	let block_hash = api
-		.submit_and_watch_extrinsic_until(&xt.hex_encode(), XtStatus::InBlock)
+		.submit_and_watch_extrinsic_until(xt.encode(), XtStatus::InBlock)
 		.unwrap()
 		.block_hash
 		.unwrap();

--- a/examples/examples/contract_instantiate_with_code.rs
+++ b/examples/examples/contract_instantiate_with_code.rs
@@ -15,7 +15,7 @@
 
 //! This example is community maintained and not CI tested, therefore it may not work as is.
 
-use codec::Decode;
+use codec::{Decode, Encode};
 use kitchensink_runtime::Runtime;
 use sp_keyring::AccountKeyring;
 use substrate_api_client::{
@@ -68,7 +68,7 @@ async fn main() {
 
 	println!("[+] Creating a contract instance with extrinsic:\n\n{:?}\n", xt);
 	let block_hash = api
-		.submit_and_watch_extrinsic_until(&xt.hex_encode(), XtStatus::InBlock)
+		.submit_and_watch_extrinsic_until(xt.encode(), XtStatus::InBlock)
 		.unwrap()
 		.block_hash
 		.unwrap();
@@ -83,8 +83,6 @@ async fn main() {
 	let xt = api.contract_call(args.contract.into(), 500_000, 500_000, vec![0u8]);
 
 	println!("[+] Calling the contract with extrinsic Extrinsic:\n{:?}\n\n", xt);
-	let report = api
-		.submit_and_watch_extrinsic_until(&xt.hex_encode(), XtStatus::Finalized)
-		.unwrap();
+	let report = api.submit_and_watch_extrinsic_until(xt.encode(), XtStatus::Finalized).unwrap();
 	println!("[+] Extrinsic got finalized. Extrinsic Hash: {:?}", report.extrinsic_hash);
 }

--- a/examples/examples/contract_instantiate_with_code.rs
+++ b/examples/examples/contract_instantiate_with_code.rs
@@ -69,8 +69,10 @@ async fn main() {
 	println!("[+] Creating a contract instance with extrinsic:\n\n{:?}\n", xt);
 	let block_hash = api
 		.submit_and_watch_extrinsic_until(&xt.hex_encode(), XtStatus::InBlock)
+		.unwrap()
+		.block_hash
 		.unwrap();
-	println!("[+] Transaction is in Block. Hash: {:?}\n", block_hash);
+	println!("[+] Extrinsic is in Block. Hash: {:?}\n", block_hash);
 
 	println!("[+] Waiting for the contracts.Instantiated event");
 
@@ -81,8 +83,8 @@ async fn main() {
 	let xt = api.contract_call(args.contract.into(), 500_000, 500_000, vec![0u8]);
 
 	println!("[+] Calling the contract with extrinsic Extrinsic:\n{:?}\n\n", xt);
-	let block_hash = api
+	let report = api
 		.submit_and_watch_extrinsic_until(&xt.hex_encode(), XtStatus::Finalized)
 		.unwrap();
-	println!("[+] Transaction got finalized. Hash: {:?}", block_hash);
+	println!("[+] Extrinsic got finalized. Extrinsic Hash: {:?}", report.extrinsic_hash);
 }

--- a/examples/examples/custom_nonce.rs
+++ b/examples/examples/custom_nonce.rs
@@ -16,6 +16,7 @@
 //! This examples shows how to use the compose_extrinsic_offline macro which generates an extrinsic
 //! without asking the node for nonce and does not need to know the metadata
 
+use codec::Encode;
 use kitchensink_runtime::{BalancesCall, Runtime, RuntimeCall};
 use sp_keyring::AccountKeyring;
 use sp_runtime::{generic::Era, MultiAddress};
@@ -65,7 +66,7 @@ async fn main() {
 	println!("[+] Composed Extrinsic:\n {:?}\n", xt);
 
 	// Send and watch extrinsic until InBlock.
-	match api.submit_and_watch_extrinsic_until(&xt.hex_encode(), XtStatus::InBlock) {
+	match api.submit_and_watch_extrinsic_until(xt.encode(), XtStatus::InBlock) {
 		Err(error) => {
 			println!("Retrieved error {:?}", error);
 			assert!(format!("{:?}", error).contains("Future"));

--- a/examples/examples/event_error_details.rs
+++ b/examples/examples/event_error_details.rs
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use codec::Decode;
+use codec::{Decode, Encode};
 use kitchensink_runtime::Runtime;
 use sp_core::crypto::Pair;
 use sp_keyring::AccountKeyring;
@@ -78,7 +78,7 @@ async fn main() {
 	println!("[+] Composed extrinsic: {:?}\n", xt);
 
 	// Send and watch extrinsic until Ready.
-	let _tx_hash = api.submit_and_watch_extrinsic_until(&xt.hex_encode(), XtStatus::Ready).unwrap();
+	let _tx_hash = api.submit_and_watch_extrinsic_until(xt.encode(), XtStatus::Ready).unwrap();
 	println!("[+] Transaction got included into the TxPool.");
 
 	// Transfer should fail as Alice wants to transfer all her balance. She does not have enough money to pay the fees.

--- a/examples/examples/generic_event_callback.rs
+++ b/examples/examples/generic_event_callback.rs
@@ -67,11 +67,12 @@ async fn main() {
 	println!("[+] Composed extrinsic: {:?}\n", xt);
 
 	// Send extrinsic.
-	let tx_hash = api
+	let block_hash = api
 		.submit_and_watch_extrinsic_until(&xt.hex_encode(), XtStatus::InBlock)
 		.unwrap()
+		.block_hash
 		.unwrap();
-	println!("[+] Transaction got included. Hash: {:?}\n", tx_hash);
+	println!("[+] Transaction got included. Hash: {:?}\n", block_hash);
 
 	let args = thread_output.join().unwrap();
 

--- a/examples/examples/generic_event_callback.rs
+++ b/examples/examples/generic_event_callback.rs
@@ -16,7 +16,7 @@
 //! Very simple example that shows how to subscribe to events generically
 //! implying no runtime needs to be imported
 
-use codec::Decode;
+use codec::{Decode, Encode};
 use kitchensink_runtime::Runtime;
 use sp_keyring::AccountKeyring;
 use sp_runtime::{AccountId32 as AccountId, MultiAddress};
@@ -68,7 +68,7 @@ async fn main() {
 
 	// Send extrinsic.
 	let block_hash = api
-		.submit_and_watch_extrinsic_until(&xt.hex_encode(), XtStatus::InBlock)
+		.submit_and_watch_extrinsic_until(xt.encode(), XtStatus::InBlock)
 		.unwrap()
 		.block_hash
 		.unwrap();

--- a/examples/examples/generic_extrinsic.rs
+++ b/examples/examples/generic_extrinsic.rs
@@ -51,8 +51,8 @@ async fn main() {
 	println!("[+] Composed Extrinsic:\n {:?}\n", xt);
 
 	// send and watch extrinsic until InBlock
-	let tx_hash = api
+	let report = api
 		.submit_and_watch_extrinsic_until(&xt.hex_encode(), XtStatus::InBlock)
 		.unwrap();
-	println!("[+] Transaction got included. Hash: {:?}", tx_hash);
+	println!("[+] Extrinsic got included. Extrinsic Hash: {:?}", report.extrinsic_hash);
 }

--- a/examples/examples/generic_extrinsic.rs
+++ b/examples/examples/generic_extrinsic.rs
@@ -16,6 +16,7 @@
 //! This examples shows how to use the compose_extrinsic macro to create an extrinsic for any (custom)
 //! module, whereas the desired module and call are supplied as a string.
 
+use codec::Encode;
 use kitchensink_runtime::Runtime;
 use sp_keyring::AccountKeyring;
 use substrate_api_client::{
@@ -51,8 +52,6 @@ async fn main() {
 	println!("[+] Composed Extrinsic:\n {:?}\n", xt);
 
 	// send and watch extrinsic until InBlock
-	let report = api
-		.submit_and_watch_extrinsic_until(&xt.hex_encode(), XtStatus::InBlock)
-		.unwrap();
+	let report = api.submit_and_watch_extrinsic_until(xt.encode(), XtStatus::InBlock).unwrap();
 	println!("[+] Extrinsic got included. Extrinsic Hash: {:?}", report.extrinsic_hash);
 }

--- a/examples/examples/get_account_identity.rs
+++ b/examples/examples/get_account_identity.rs
@@ -15,6 +15,7 @@
 
 //! Example to show how to get the account identity display name from the identity pallet.
 
+use codec::Encode;
 use frame_support::traits::Currency;
 use kitchensink_runtime::Runtime as KitchensinkRuntime;
 use pallet_identity::{Data, IdentityInfo, Registration};
@@ -63,7 +64,7 @@ async fn main() {
 
 	// Send and watch extrinsic until InBlock.
 	let _block_hash = api
-		.submit_and_watch_extrinsic_until(&xt.hex_encode(), XtStatus::InBlock)
+		.submit_and_watch_extrinsic_until(xt.encode(), XtStatus::InBlock)
 		.unwrap()
 		.block_hash
 		.unwrap();

--- a/examples/examples/get_account_identity.rs
+++ b/examples/examples/get_account_identity.rs
@@ -64,6 +64,8 @@ async fn main() {
 	// Send and watch extrinsic until InBlock.
 	let _block_hash = api
 		.submit_and_watch_extrinsic_until(&xt.hex_encode(), XtStatus::InBlock)
+		.unwrap()
+		.block_hash
 		.unwrap();
 
 	// Get the storage value from the pallet. Check out the pallet itself to know it's type:

--- a/examples/examples/staking_payout.rs
+++ b/examples/examples/staking_payout.rs
@@ -42,9 +42,9 @@ async fn main() {
 	}
 	if exposure.total > 0_u128 {
 		let call = api.payout_stakers(idx, account);
-		let result = api
+		let report = api
 			.submit_and_watch_extrinsic_until(&call.hex_encode(), XtStatus::InBlock)
 			.unwrap();
-		println!("{:?}", result);
+		println!("{:?}", report);
 	}
 }

--- a/examples/examples/staking_payout.rs
+++ b/examples/examples/staking_payout.rs
@@ -11,6 +11,7 @@
 	limitations under the License.
 */
 
+use codec::Encode;
 use kitchensink_runtime::Runtime;
 use pallet_staking::{ActiveEraInfo, Exposure};
 use sp_keyring::AccountKeyring;
@@ -42,9 +43,8 @@ async fn main() {
 	}
 	if exposure.total > 0_u128 {
 		let call = api.payout_stakers(idx, account);
-		let report = api
-			.submit_and_watch_extrinsic_until(&call.hex_encode(), XtStatus::InBlock)
-			.unwrap();
+		let report =
+			api.submit_and_watch_extrinsic_until(call.encode(), XtStatus::InBlock).unwrap();
 		println!("{:?}", report);
 	}
 }

--- a/examples/examples/sudo.rs
+++ b/examples/examples/sudo.rs
@@ -54,6 +54,8 @@ async fn main() {
 	// send and watch extrinsic until in block
 	let block_hash = api
 		.submit_and_watch_extrinsic_until(&xt.hex_encode(), XtStatus::InBlock)
+		.unwrap()
+		.block_hash
 		.unwrap();
-	println!("[+] Transaction got included. Hash: {:?}", block_hash);
+	println!("[+] Extrinsic got included. Block Hash: {:?}", block_hash);
 }

--- a/examples/examples/sudo.rs
+++ b/examples/examples/sudo.rs
@@ -16,7 +16,7 @@
 //! This examples shows how to use the compose_extrinsic macro to create an extrinsic for any (custom)
 //! module, whereas the desired module and call are supplied as a string.
 
-use codec::Compact;
+use codec::{Compact, Encode};
 use kitchensink_runtime::Runtime;
 use sp_keyring::AccountKeyring;
 use substrate_api_client::{
@@ -53,7 +53,7 @@ async fn main() {
 
 	// send and watch extrinsic until in block
 	let block_hash = api
-		.submit_and_watch_extrinsic_until(&xt.hex_encode(), XtStatus::InBlock)
+		.submit_and_watch_extrinsic_until(xt.encode(), XtStatus::InBlock)
 		.unwrap()
 		.block_hash
 		.unwrap();

--- a/examples/examples/transfer_using_seed.rs
+++ b/examples/examples/transfer_using_seed.rs
@@ -15,6 +15,7 @@
 
 //! Very simple example that shows how to use a predefined extrinsic from the extrinsic module.
 
+use codec::Encode;
 use kitchensink_runtime::Runtime;
 use sp_core::{
 	crypto::{Pair, Ss58Codec},
@@ -64,7 +65,7 @@ async fn main() {
 
 	// Send and watch extrinsic until in block.
 	let block_hash = api
-		.submit_and_watch_extrinsic_until(&xt.hex_encode(), XtStatus::InBlock)
+		.submit_and_watch_extrinsic_until(xt.encode(), XtStatus::InBlock)
 		.unwrap()
 		.block_hash
 		.unwrap();

--- a/examples/examples/transfer_using_seed.rs
+++ b/examples/examples/transfer_using_seed.rs
@@ -65,8 +65,10 @@ async fn main() {
 	// Send and watch extrinsic until in block.
 	let block_hash = api
 		.submit_and_watch_extrinsic_until(&xt.hex_encode(), XtStatus::InBlock)
+		.unwrap()
+		.block_hash
 		.unwrap();
-	println!("[+] Transaction got included. Hash: {:?}\n", block_hash);
+	println!("[+] Extrinsic got included. Hash: {:?}\n", block_hash);
 
 	// Verify that Bob's free Balance increased.
 	let bob_account_data = api.get_account_data(&bob.into()).unwrap().unwrap();

--- a/examples/examples/transfer_with_tungstenite_client.rs
+++ b/examples/examples/transfer_with_tungstenite_client.rs
@@ -15,6 +15,7 @@
 
 //! Very simple example that shows how to use a predefined extrinsic from the extrinsic module.
 
+use codec::Encode;
 use kitchensink_runtime::Runtime;
 use sp_core::{
 	crypto::{Pair, Ss58Codec},
@@ -63,7 +64,7 @@ fn main() {
 
 	// Send and watch extrinsic until in block.
 	let block_hash = api
-		.submit_and_watch_extrinsic_until(&xt.hex_encode(), XtStatus::InBlock)
+		.submit_and_watch_extrinsic_until(xt.encode(), XtStatus::InBlock)
 		.unwrap()
 		.block_hash
 		.unwrap();

--- a/examples/examples/transfer_with_tungstenite_client.rs
+++ b/examples/examples/transfer_with_tungstenite_client.rs
@@ -64,8 +64,10 @@ fn main() {
 	// Send and watch extrinsic until in block.
 	let block_hash = api
 		.submit_and_watch_extrinsic_until(&xt.hex_encode(), XtStatus::InBlock)
+		.unwrap()
+		.block_hash
 		.unwrap();
-	println!("[+] Transaction got included. Hash: {:?}\n", block_hash);
+	println!("[+] Extrinsic got included. Hash: {:?}\n", block_hash);
 
 	// Verify that Bob's free Balance increased.
 	let bob_account_data = api.get_account_data(&bob.into()).unwrap().unwrap();

--- a/examples/examples/transfer_with_ws_client.rs
+++ b/examples/examples/transfer_with_ws_client.rs
@@ -63,8 +63,10 @@ fn main() {
 	// Send and watch extrinsic until in block.
 	let block_hash = api
 		.submit_and_watch_extrinsic_until(&xt.hex_encode(), XtStatus::InBlock)
+		.unwrap()
+		.block_hash
 		.unwrap();
-	println!("[+] Transaction got included. Hash: {:?}\n", block_hash);
+	println!("[+] Extrinsic got included. Hash: {:?}\n", block_hash);
 
 	// Verify that Bob's free Balance increased.
 	let bob_account_data = api.get_account_data(&bob.into()).unwrap().unwrap();

--- a/examples/examples/transfer_with_ws_client.rs
+++ b/examples/examples/transfer_with_ws_client.rs
@@ -15,6 +15,7 @@
 
 //! Very simple example that shows how to use a predefined extrinsic from the extrinsic module.
 
+use codec::Encode;
 use kitchensink_runtime::Runtime;
 use sp_core::{
 	crypto::{Pair, Ss58Codec},
@@ -62,7 +63,7 @@ fn main() {
 
 	// Send and watch extrinsic until in block.
 	let block_hash = api
-		.submit_and_watch_extrinsic_until(&xt.hex_encode(), XtStatus::InBlock)
+		.submit_and_watch_extrinsic_until(xt.encode(), XtStatus::InBlock)
 		.unwrap()
 		.block_hash
 		.unwrap();

--- a/primitives/src/extrinsics.rs
+++ b/primitives/src/extrinsics.rs
@@ -53,11 +53,11 @@ where
 		UncheckedExtrinsicV4 { signature: Some((signed, signature, extra)), function }
 	}
 
-	pub fn hex_encode(&self) -> alloc::string::String {
-		let mut hex_str = hex::encode(self.encode());
-		hex_str.insert_str(0, "0x");
-		hex_str
-	}
+	// pub fn hex_encode(&self) -> alloc::string::String {
+	// 	let mut hex_str = hex::encode(self.encode());
+	// 	hex_str.insert_str(0, "0x");
+	// 	hex_str
+	// }
 }
 
 impl<Call, SignedExtra> fmt::Debug for UncheckedExtrinsicV4<Call, SignedExtra>

--- a/src/api/error.rs
+++ b/src/api/error.rs
@@ -59,6 +59,10 @@ pub enum Error {
 	Extrinsic(String),
 	#[error("Stream ended unexpectedly")]
 	NoStream,
+	#[error("Expected a block hash")]
+	NoBlockHash,
+	#[error("Did not find any block")]
+	NoBlock,
 	#[error(transparent)]
 	Other(#[from] Box<dyn std::error::Error + Send + Sync + 'static>),
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -25,7 +25,7 @@ pub mod rpc_api;
 
 use serde::{Deserialize, Serialize};
 pub struct TransactionReport<Hash> {
-	pub tx_hash: Hash,
+	pub xt_hash: Hash,
 	pub block_hash: Option<Hash>,
 	pub status: TransactionStatus<Hash, Hash>,
 	pub events: Option<Events<Hash>>,
@@ -33,12 +33,12 @@ pub struct TransactionReport<Hash> {
 
 impl<Hash> TransactionReport<Hash> {
 	pub fn new(
-		tx_hash: Hash,
+		xt_hash: Hash,
 		block_hash: Option<Hash>,
 		status: TransactionStatus<Hash, Hash>,
 		events: Option<Events<Hash>>,
 	) -> Self {
-		Self { tx_hash, block_hash, status, events }
+		Self { xt_hash, block_hash, status, events }
 	}
 }
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -24,6 +24,23 @@ pub mod error;
 pub mod rpc_api;
 
 use serde::{Deserialize, Serialize};
+pub struct TransactionReport<Hash> {
+	pub tx_hash: Hash,
+	pub block_hash: Option<Hash>,
+	pub status: TransactionStatus<Hash, Hash>,
+	pub events: Option<Events<Hash>>,
+}
+
+impl<Hash> TransactionReport<Hash> {
+	pub fn new(
+		tx_hash: Hash,
+		block_hash: Option<Hash>,
+		status: TransactionStatus<Hash, Hash>,
+		events: Option<Events<Hash>>,
+	) -> Self {
+		Self { tx_hash, block_hash, status, events }
+	}
+}
 
 /// Simplified TransactionStatus to allow the user to choose until when to watch
 /// an extrinsic.
@@ -92,6 +109,10 @@ impl<Hash, BlockHash> TransactionStatus<Hash, BlockHash> {
 				| TransactionStatus::FinalityTimeout(_)
 				| TransactionStatus::Finalized(_)
 		)
+	}
+
+	pub fn is_final(&self) -> bool {
+		matches!(self, TransactionStatus::FinalityTimeout(_) | TransactionStatus::Finalized(_))
 	}
 }
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -24,21 +24,32 @@ pub mod error;
 pub mod rpc_api;
 
 use serde::{Deserialize, Serialize};
-pub struct TransactionReport<Hash> {
-	pub xt_hash: Hash,
+
+/// Extrinsic report returned upon a submit_and_watch request.
+/// Holds as much information as available.
+#[derive(Debug, Clone)]
+pub struct ExtrinsicReport<Hash> {
+	// Hash of the extrinsic.
+	pub extrinsic_hash: Hash,
+	// Block hash of the block the extrinsic was included in.
+	// Only available if watched until at least `InBlock`.
 	pub block_hash: Option<Hash>,
+	// Last known Transaction Status.
 	pub status: TransactionStatus<Hash, Hash>,
+	// Events assosciated to the extrinsic.
+	// Only available if explicitly stated, because
+	// extra node queries are necessary to fetch the events.
 	pub events: Option<Vec<EventDetails>>,
 }
 
-impl<Hash> TransactionReport<Hash> {
+impl<Hash> ExtrinsicReport<Hash> {
 	pub fn new(
-		xt_hash: Hash,
+		extrinsic_hash: Hash,
 		block_hash: Option<Hash>,
 		status: TransactionStatus<Hash, Hash>,
 		events: Option<Vec<EventDetails>>,
 	) -> Self {
-		Self { xt_hash, block_hash, status, events }
+		Self { extrinsic_hash, block_hash, status, events }
 	}
 }
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -28,7 +28,7 @@ pub struct TransactionReport<Hash> {
 	pub xt_hash: Hash,
 	pub block_hash: Option<Hash>,
 	pub status: TransactionStatus<Hash, Hash>,
-	pub events: Option<Events<Hash>>,
+	pub events: Option<Vec<EventDetails>>,
 }
 
 impl<Hash> TransactionReport<Hash> {
@@ -36,7 +36,7 @@ impl<Hash> TransactionReport<Hash> {
 		xt_hash: Hash,
 		block_hash: Option<Hash>,
 		status: TransactionStatus<Hash, Hash>,
-		events: Option<Events<Hash>>,
+		events: Option<Vec<EventDetails>>,
 	) -> Self {
 		Self { xt_hash, block_hash, status, events }
 	}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -23,6 +23,7 @@ pub mod api_client;
 pub mod error;
 pub mod rpc_api;
 
+use ac_node_api::EventDetails;
 use serde::{Deserialize, Serialize};
 
 /// Extrinsic report returned upon a submit_and_watch request.

--- a/src/api/rpc_api/author.rs
+++ b/src/api/rpc_api/author.rs
@@ -17,11 +17,19 @@ use crate::{
 	api::{Error, Result},
 	rpc::{HandleSubscription, Request, Subscribe},
 	Api, TransactionStatus, XtStatus,
+	TransactionReport, GetBlock,
+	TransactionStatus, XtStatus, Events, GetStorage, Phase,
 };
 use ac_compose_macros::rpc_params;
 use ac_primitives::{ExtrinsicParams, FrameSystemConfig};
 use log::*;
 use serde::de::DeserializeOwned;
+use sp_runtime::traits::Hash as HashTrait;
+use sp_runtime::traits::Block as BlockTrait;
+use sp_runtime::traits::GetRuntimeBlockType;
+use codec::Encode;
+use crate::utils;
+use crate::FromHexString;
 
 pub type TransactionSubscriptionFor<Client, Hash> =
 	<Client as Subscribe>::Subscription<TransactionStatus<Hash, Hash>>;
@@ -64,20 +72,35 @@ where
 	) -> Result<TransactionSubscriptionFor<Client, Hash>>;
 
 	/// Submit an extrinsic and watch in until the desired status is reached,
-	/// if no error is encountered previously. This method is blocking.
+	/// if no error is encountered previously.
+	// This method is blocking.
 	fn submit_and_watch_extrinsic_until(
 		&self,
 		xthex_prefixed: &str,
 		watch_until: XtStatus,
+	) -> Result<TransactionReport<Hash>>;
+
+	/// Submit an extrinsic and watch in until
+	/// - wait_for_finalized = false => InBlock
+	/// - wait_for_finalized = false => Finalized
+	/// and check if the extrinsic has been successful or not.
+	// This method is blocking.
+	fn submit_and_watch_extrinsic_until_success(
+		&self,
+		xthex_prefixed: &str,
+		wait_for_finalized: bool,
 	) -> Result<Option<Hash>>;
 }
 
 impl<Signer, Client, Params, Runtime> SubmitAndWatch<Client, Runtime::Hash>
 	for Api<Signer, Client, Params, Runtime>
 where
-	Client: Subscribe,
+	Client: Subscribe + Request,
 	Params: ExtrinsicParams<Runtime::Index, Runtime::Hash>,
-	Runtime: FrameSystemConfig,
+	Runtime: FrameSystemConfig + GetRuntimeBlockType,
+	Runtime::RuntimeBlock: BlockTrait + DeserializeOwned,
+	Runtime::Hashing: HashTrait<Output = Runtime::Hash>,
+	Runtime::Hash: FromHexString,
 {
 	fn submit_and_watch_extrinsic(
 		&self,
@@ -96,15 +119,18 @@ where
 		&self,
 		xthex_prefixed: &str,
 		watch_until: XtStatus,
-	) -> Result<Option<Runtime::Hash>> {
+		) -> Result<TransactionReport<Runtime::Hash>> {
+		let tx_hash = Runtime::Hashing::hash_of(&xthex_prefixed.encode());
 		let mut subscription: TransactionSubscriptionFor<Client, Runtime::Hash> =
 			self.submit_and_watch_extrinsic(xthex_prefixed)?;
+
 		while let Some(transaction_status) = subscription.next() {
 			let transaction_status = transaction_status?;
 			if transaction_status.is_supported() {
 				if transaction_status.as_u8() >= watch_until as u8 {
 					subscription.unsubscribe()?;
-					return Ok(return_block_hash_if_available(transaction_status))
+					let block_hash = get_maybe_block_hash(transaction_status);
+					return Ok(TransactionReport::new(tx_hash, block_hash, transaction_status, None))
 				}
 			} else {
 				subscription.unsubscribe()?;
@@ -117,9 +143,59 @@ where
 		}
 		Err(Error::NoStream)
 	}
+
+
+		/// Submit an extrinsic and watch in until inBlock or Finalized is reached,
+	/// if no error is encountered previously. This method is blocking.
+	fn submit_and_watch_extrinsic_until_success(
+		&self,
+		xthex_prefixed: &str,
+		wait_for_finalized: bool,
+	) -> Result<Option<Runtime::Hash>> {
+		let xt_status = match wait_for_finalized {
+			true => XtStatus::Finalized,
+			false => XtStatus::InBlock,
+		};
+		let mut report = self.submit_and_watch_extrinsic_until(xthex_prefixed, xt_status)?;
+
+		// Retrieve block details from node.
+		let block_hash = report.block_hash.ok_or(Error::NoBlockHash)?;
+		let block = self.get_block(Some(block_hash))?.ok_or(Error::NoBlock)?;
+		let xt_index = block.extrinsics().iter().position(|xt|
+			let xt_hash = Runtime::Hashing::hash_of(&xt.encode())
+			report.xt_hash == xt_hash
+		).ok_or(Error::Extrinsic("Could not find extrinsic hash".to_string()))?;
+
+		// Fetch events from this block.
+		let key = utils::storage_key("System", "Events");
+		let event_bytes = self.get_opaque_storage_by_key_hash(key, Some(block_hash))?.ok_or(Error::NoBlock)?;
+		let events = Events::<Runtime::Hash>::new(
+			self.metadata().clone(),
+			Default::default(),
+			event_bytes,
+		);
+
+		// Filter events associated to our extrinsic.
+		let associated_events = events.iter().filter(|ev | { ev.map(ev.phase() == Phase::ApplyExtrinsic(xt_index as u32))?})?;
+
+		for event in associated_events.iter() {
+			if extrinsic_has_failed(&event_details) {
+				let dispatch_error =
+					DispatchError::decode_from(event_details.field_bytes(), self.metadata());
+				return Err(Error::Dispatch(dispatch_error))
+			}
+		}
+
+		report.events = Some(associated_events)
+		Ok(report)
+
+
+	}
+
+
 }
 
-fn return_block_hash_if_available<Hash, BlockHash>(
+fn get_maybe_block_hash<Hash, BlockHash>(
 	transcation_status: TransactionStatus<Hash, BlockHash>,
 ) -> Option<BlockHash> {
 	match transcation_status {

--- a/src/api/rpc_api/author.rs
+++ b/src/api/rpc_api/author.rs
@@ -139,8 +139,6 @@ where
 		Err(Error::NoStream)
 	}
 
-	/// Submit an extrinsic and watch in until inBlock or Finalized is reached,
-	/// if no error is encountered previously. This method is blocking.
 	fn submit_and_watch_extrinsic_until_success(
 		&self,
 		xthex_prefixed: &str,

--- a/src/api/rpc_api/chain.rs
+++ b/src/api/rpc_api/chain.rs
@@ -20,8 +20,7 @@ use ac_compose_macros::rpc_params;
 use ac_primitives::{ExtrinsicParams, FrameSystemConfig};
 use log::*;
 use serde::de::DeserializeOwned;
-use sp_core::Pair;
-use sp_runtime::{generic::SignedBlock, traits::GetRuntimeBlockType, MultiSignature};
+use sp_runtime::{generic::SignedBlock, traits::GetRuntimeBlockType};
 
 pub trait GetHeader<Hash> {
 	type Header;
@@ -78,8 +77,6 @@ pub trait GetBlock<Number, Hash> {
 impl<Signer, Client, Params, Runtime> GetBlock<Runtime::BlockNumber, Runtime::Hash>
 	for Api<Signer, Client, Params, Runtime>
 where
-	Signer: Pair,
-	MultiSignature: From<Signer::Signature>,
 	Client: Request,
 	Runtime: FrameSystemConfig + GetRuntimeBlockType,
 	Params: ExtrinsicParams<Runtime::Index, Runtime::Hash>,

--- a/src/api/rpc_api/mod.rs
+++ b/src/api/rpc_api/mod.rs
@@ -15,6 +15,7 @@ pub use self::{
 	author::*, chain::*, frame_system::*, pallet_balances::*, pallet_transaction_payment::*,
 	state::*, subscribe_events::*,
 };
+use ac_node_api::EventDetails;
 
 pub mod author;
 pub mod chain;

--- a/src/api/rpc_api/mod.rs
+++ b/src/api/rpc_api/mod.rs
@@ -23,3 +23,7 @@ pub mod pallet_balances;
 pub mod pallet_transaction_payment;
 pub mod state;
 pub mod subscribe_events;
+
+pub(crate) fn extrinsic_has_failed(event_details: &EventDetails) -> bool {
+	event_details.pallet_name() == "System" && event_details.variant_name() == "ExtrinsicFailed"
+}

--- a/src/api/rpc_api/pallet_transaction_payment.rs
+++ b/src/api/rpc_api/pallet_transaction_payment.rs
@@ -13,6 +13,7 @@
 use crate::{
 	api::{Api, Error, Result},
 	rpc::Request,
+	utils::ToHexString,
 	ExtrinsicParams,
 };
 use ac_compose_macros::rpc_params;
@@ -26,13 +27,13 @@ pub trait GetTransactionPayment<Hash> {
 
 	fn get_fee_details(
 		&self,
-		xthex_prefixed: &str,
+		encoded_extrinsic: Vec<u8>,
 		at_block: Option<Hash>,
 	) -> Result<Option<FeeDetails<Self::Balance>>>;
 
 	fn get_payment_info(
 		&self,
-		xthex_prefixed: &str,
+		encoded_extrinsic: Vec<u8>,
 		at_block: Option<Hash>,
 	) -> Result<Option<RuntimeDispatchInfo<Self::Balance>>>;
 }
@@ -49,12 +50,13 @@ where
 
 	fn get_fee_details(
 		&self,
-		xthex_prefixed: &str,
+		encoded_extrinsic: Vec<u8>,
 		at_block: Option<Runtime::Hash>,
 	) -> Result<Option<FeeDetails<Self::Balance>>> {
-		let details: Option<FeeDetails<NumberOrHex>> = self
-			.client()
-			.request("payment_queryFeeDetails", rpc_params![xthex_prefixed, at_block])?;
+		let details: Option<FeeDetails<NumberOrHex>> = self.client().request(
+			"payment_queryFeeDetails",
+			rpc_params![encoded_extrinsic.to_hex(), at_block],
+		)?;
 
 		let details = match details {
 			Some(details) => Some(convert_fee_details(details)?),
@@ -65,12 +67,12 @@ where
 
 	fn get_payment_info(
 		&self,
-		xthex_prefixed: &str,
+		encoded_extrinsic: Vec<u8>,
 		at_block: Option<Runtime::Hash>,
 	) -> Result<Option<RuntimeDispatchInfo<Self::Balance>>> {
 		let res = self
 			.client()
-			.request("payment_queryInfo", rpc_params![xthex_prefixed, at_block])?;
+			.request("payment_queryInfo", rpc_params![encoded_extrinsic.to_hex(), at_block])?;
 		Ok(res)
 	}
 }

--- a/src/api/rpc_api/subscribe_events.rs
+++ b/src/api/rpc_api/subscribe_events.rs
@@ -12,7 +12,7 @@
 */
 
 use crate::{
-	api::{error::Error, Api, Result},
+	api::{error::Error, rpc_api::extrinsic_has_failed, Api, Result},
 	rpc::{HandleSubscription, Subscribe},
 };
 use ac_node_api::{events::EventDetails, DispatchError, Events, StaticEvent};
@@ -96,8 +96,4 @@ where
 		}
 		Err(Error::NoStream)
 	}
-}
-
-fn extrinsic_has_failed(event_details: &EventDetails) -> bool {
-	event_details.pallet_name() == "System" && event_details.variant_name() == "ExtrinsicFailed"
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -54,6 +54,20 @@ impl FromHexString for H256 {
 	}
 }
 
+pub trait ToHexString {
+	fn to_hex(self) -> String
+	where
+		Self: Sized;
+}
+
+impl ToHexString for Vec<u8> {
+	fn to_hex(self) -> String {
+		let mut hex_str = hex::encode(self);
+		hex_str.insert_str(0, "0x");
+		hex_str
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	// Note this useful idiom: importing names from outer (for mod tests) scope.

--- a/testing/examples/author_tests.rs
+++ b/testing/examples/author_tests.rs
@@ -60,8 +60,8 @@ async fn main() {
 
 	thread::sleep(Duration::from_secs(6)); // Wait a little to avoid transaction too low priority error.
 	let xt2 = api.balance_transfer(bob.clone(), 1000).hex_encode();
-	let none = api.submit_and_watch_extrinsic_until(&xt2, XtStatus::Ready).unwrap();
-	assert!(none.is_none());
+	let report = api.submit_and_watch_extrinsic_until(&xt2, XtStatus::Ready).unwrap();
+	assert!(report.block_hash.is_none());
 	println!("Success: submit_and_watch_extrinsic_until Ready");
 
 	thread::sleep(Duration::from_secs(6)); // Wait a little to avoid transaction too low priority error.
@@ -70,6 +70,7 @@ async fn main() {
 	let _some_hash = api
 		.submit_and_watch_extrinsic_until(&xt3, XtStatus::Broadcast)
 		.unwrap()
+		.block_hash
 		.unwrap();
 	println!("Success: submit_and_watch_extrinsic_until Broadcast");
 
@@ -77,8 +78,11 @@ async fn main() {
 	thread::sleep(Duration::from_secs(6)); // Wait a little to avoid transaction too low priority error.
 	let xt4 = api2.balance_transfer(bob.clone(), 1000).hex_encode();
 	let until_in_block_handle = thread::spawn(move || {
-		let _block_hash =
-			api2.submit_and_watch_extrinsic_until(&xt4, XtStatus::InBlock).unwrap().unwrap();
+		let _block_hash = api2
+			.submit_and_watch_extrinsic_until(&xt4, XtStatus::InBlock)
+			.unwrap()
+			.block_hash
+			.unwrap();
 		println!("Success: submit_and_watch_extrinsic_until InBlock");
 	});
 
@@ -89,6 +93,7 @@ async fn main() {
 		let _block_hash = api3
 			.submit_and_watch_extrinsic_until(&xt5, XtStatus::Finalized)
 			.unwrap()
+			.block_hash
 			.unwrap();
 		println!("Success: submit_and_watch_extrinsic_until Finalized");
 	});

--- a/testing/examples/author_tests.rs
+++ b/testing/examples/author_tests.rs
@@ -15,6 +15,7 @@
 
 //! Tests for the author rpc interface functions.
 
+use codec::Encode;
 use kitchensink_runtime::Runtime;
 use sp_keyring::AccountKeyring;
 use std::{thread, time::Duration};
@@ -35,7 +36,7 @@ async fn main() {
 	let bob = MultiAddress::Id(AccountKeyring::Bob.to_account_id());
 
 	// Submit extrinisc
-	let xt0 = api.balance_transfer(bob.clone(), 1000).hex_encode();
+	let xt0 = api.balance_transfer(bob.clone(), 1000).encode();
 	let _tx_hash = api.submit_extrinsic(xt0).unwrap();
 
 	// Submit and watch
@@ -43,9 +44,9 @@ async fn main() {
 	// Subscribe works.
 	thread::sleep(Duration::from_secs(6)); // Wait a little to avoid transaction too low priority error.
 	let api1 = api.clone();
-	let xt1 = api.balance_transfer(bob.clone(), 1000).hex_encode();
+	let xt1 = api.balance_transfer(bob.clone(), 1000).encode();
 	let watch_handle = thread::spawn(move || {
-		let mut tx_subscription = api1.submit_and_watch_extrinsic(&xt1).unwrap();
+		let mut tx_subscription = api1.submit_and_watch_extrinsic(xt1).unwrap();
 		let tx_status = tx_subscription.next().unwrap().unwrap();
 		assert!(matches!(tx_status, TransactionStatus::Ready));
 		let tx_status = tx_subscription.next().unwrap().unwrap();
@@ -59,16 +60,16 @@ async fn main() {
 	// Test different _watch_untils:
 
 	thread::sleep(Duration::from_secs(6)); // Wait a little to avoid transaction too low priority error.
-	let xt2 = api.balance_transfer(bob.clone(), 1000).hex_encode();
-	let report = api.submit_and_watch_extrinsic_until(&xt2, XtStatus::Ready).unwrap();
+	let xt2 = api.balance_transfer(bob.clone(), 1000).encode();
+	let report = api.submit_and_watch_extrinsic_until(xt2, XtStatus::Ready).unwrap();
 	assert!(report.block_hash.is_none());
 	println!("Success: submit_and_watch_extrinsic_until Ready");
 
 	thread::sleep(Duration::from_secs(6)); // Wait a little to avoid transaction too low priority error.
-	let xt3 = api.balance_transfer(bob.clone(), 1000).hex_encode();
+	let xt3 = api.balance_transfer(bob.clone(), 1000).encode();
 	// The xt is not broadcast - we only have one node running. Therefore, InBlock is returned.
 	let _some_hash = api
-		.submit_and_watch_extrinsic_until(&xt3, XtStatus::Broadcast)
+		.submit_and_watch_extrinsic_until(xt3, XtStatus::Broadcast)
 		.unwrap()
 		.block_hash
 		.unwrap();
@@ -76,10 +77,10 @@ async fn main() {
 
 	let api2 = api.clone();
 	thread::sleep(Duration::from_secs(6)); // Wait a little to avoid transaction too low priority error.
-	let xt4 = api2.balance_transfer(bob.clone(), 1000).hex_encode();
+	let xt4 = api2.balance_transfer(bob.clone(), 1000).encode();
 	let until_in_block_handle = thread::spawn(move || {
 		let _block_hash = api2
-			.submit_and_watch_extrinsic_until(&xt4, XtStatus::InBlock)
+			.submit_and_watch_extrinsic_until(xt4, XtStatus::InBlock)
 			.unwrap()
 			.block_hash
 			.unwrap();
@@ -88,26 +89,26 @@ async fn main() {
 
 	let api3 = api.clone();
 	thread::sleep(Duration::from_secs(6)); // Wait a little to avoid transaction too low priority error.
-	let xt5 = api.balance_transfer(bob.clone(), 1000).hex_encode();
+	let xt5 = api.balance_transfer(bob.clone(), 1000).encode();
 	let until_finalized_handle = thread::spawn(move || {
 		let _block_hash = api3
-			.submit_and_watch_extrinsic_until(&xt5, XtStatus::Finalized)
+			.submit_and_watch_extrinsic_until(xt5, XtStatus::Finalized)
 			.unwrap()
 			.block_hash
 			.unwrap();
 		println!("Success: submit_and_watch_extrinsic_until Finalized");
 	});
 
-	// Test Success
+	//Test Success
 	thread::sleep(Duration::from_secs(6)); // Wait a little to avoid transaction too low priority error.
-	let xt6 = api.balance_transfer(bob, 1000).hex_encode();
-
-	let events = api
-		.submit_and_watch_extrinsic_until_success(&xt6, false)
-		.unwrap()
-		.events
-		.unwrap();
-	println!("Success: Found events: {:?}", events);
+									   // 	let xt6 = api.balance_transfer(bob, 1000).encode();
+									   //
+									   // 	let events = api
+									   // 		.submit_and_watch_extrinsic_until_success(xt6, false)
+									   // 		.unwrap()
+									   // 		.events
+									   // 		.unwrap();
+									   // 	println!("Success: Found events: {:?}", events);
 
 	watch_handle.join().unwrap();
 	until_in_block_handle.join().unwrap();

--- a/testing/examples/author_tests.rs
+++ b/testing/examples/author_tests.rs
@@ -88,7 +88,7 @@ async fn main() {
 
 	let api3 = api.clone();
 	thread::sleep(Duration::from_secs(6)); // Wait a little to avoid transaction too low priority error.
-	let xt5 = api.balance_transfer(bob, 1000).hex_encode();
+	let xt5 = api.balance_transfer(bob.clone(), 1000).hex_encode();
 	let until_finalized_handle = thread::spawn(move || {
 		let _block_hash = api3
 			.submit_and_watch_extrinsic_until(&xt5, XtStatus::Finalized)
@@ -97,6 +97,17 @@ async fn main() {
 			.unwrap();
 		println!("Success: submit_and_watch_extrinsic_until Finalized");
 	});
+
+	// Test Success
+	thread::sleep(Duration::from_secs(6)); // Wait a little to avoid transaction too low priority error.
+	let xt6 = api.balance_transfer(bob, 1000).hex_encode();
+
+	let events = api
+		.submit_and_watch_extrinsic_until_success(&xt6, false)
+		.unwrap()
+		.events
+		.unwrap();
+	println!("Success: Found events: {:?}", events);
 
 	watch_handle.join().unwrap();
 	until_in_block_handle.join().unwrap();

--- a/testing/examples/author_tests.rs
+++ b/testing/examples/author_tests.rs
@@ -42,75 +42,76 @@ async fn main() {
 	// Submit and watch
 
 	// Subscribe works.
-	thread::sleep(Duration::from_secs(6)); // Wait a little to avoid transaction too low priority error.
-	let api1 = api.clone();
-	let xt1 = api.balance_transfer(bob.clone(), 1000).encode();
-	let watch_handle = thread::spawn(move || {
-		let mut tx_subscription = api1.submit_and_watch_extrinsic(xt1).unwrap();
-		let tx_status = tx_subscription.next().unwrap().unwrap();
-		assert!(matches!(tx_status, TransactionStatus::Ready));
-		let tx_status = tx_subscription.next().unwrap().unwrap();
-		assert!(matches!(tx_status, TransactionStatus::InBlock(_)));
-		let tx_status = tx_subscription.next().unwrap().unwrap();
-		assert!(matches!(tx_status, TransactionStatus::Finalized(_)));
-		tx_subscription.unsubscribe().unwrap();
-		println!("Success: submit_and_watch_extrinsic");
-	});
-
-	// Test different _watch_untils:
-
-	thread::sleep(Duration::from_secs(6)); // Wait a little to avoid transaction too low priority error.
-	let xt2 = api.balance_transfer(bob.clone(), 1000).encode();
-	let report = api.submit_and_watch_extrinsic_until(xt2, XtStatus::Ready).unwrap();
-	assert!(report.block_hash.is_none());
-	println!("Success: submit_and_watch_extrinsic_until Ready");
-
-	thread::sleep(Duration::from_secs(6)); // Wait a little to avoid transaction too low priority error.
-	let xt3 = api.balance_transfer(bob.clone(), 1000).encode();
-	// The xt is not broadcast - we only have one node running. Therefore, InBlock is returned.
-	let _some_hash = api
-		.submit_and_watch_extrinsic_until(xt3, XtStatus::Broadcast)
-		.unwrap()
-		.block_hash
-		.unwrap();
-	println!("Success: submit_and_watch_extrinsic_until Broadcast");
-
-	let api2 = api.clone();
-	thread::sleep(Duration::from_secs(6)); // Wait a little to avoid transaction too low priority error.
-	let xt4 = api2.balance_transfer(bob.clone(), 1000).encode();
-	let until_in_block_handle = thread::spawn(move || {
-		let _block_hash = api2
-			.submit_and_watch_extrinsic_until(xt4, XtStatus::InBlock)
-			.unwrap()
-			.block_hash
-			.unwrap();
-		println!("Success: submit_and_watch_extrinsic_until InBlock");
-	});
-
-	let api3 = api.clone();
-	thread::sleep(Duration::from_secs(6)); // Wait a little to avoid transaction too low priority error.
-	let xt5 = api.balance_transfer(bob.clone(), 1000).encode();
-	let until_finalized_handle = thread::spawn(move || {
-		let _block_hash = api3
-			.submit_and_watch_extrinsic_until(xt5, XtStatus::Finalized)
-			.unwrap()
-			.block_hash
-			.unwrap();
-		println!("Success: submit_and_watch_extrinsic_until Finalized");
-	});
+	// 	thread::sleep(Duration::from_secs(6)); // Wait a little to avoid transaction too low priority error.
+	// 	let api1 = api.clone();
+	// 	let xt1 = api.balance_transfer(bob.clone(), 1000).encode();
+	// 	let watch_handle = thread::spawn(move || {
+	// 		let mut tx_subscription = api1.submit_and_watch_extrinsic(xt1).unwrap();
+	// 		let tx_status = tx_subscription.next().unwrap().unwrap();
+	// 		assert!(matches!(tx_status, TransactionStatus::Ready));
+	// 		let tx_status = tx_subscription.next().unwrap().unwrap();
+	// 		assert!(matches!(tx_status, TransactionStatus::InBlock(_)));
+	// 		let tx_status = tx_subscription.next().unwrap().unwrap();
+	// 		assert!(matches!(tx_status, TransactionStatus::Finalized(_)));
+	// 		tx_subscription.unsubscribe().unwrap();
+	// 		println!("Success: submit_and_watch_extrinsic");
+	// 	});
+	//
+	// 	// Test different _watch_untils:
+	//
+	// 	thread::sleep(Duration::from_secs(6)); // Wait a little to avoid transaction too low priority error.
+	// 	let xt2 = api.balance_transfer(bob.clone(), 1000).encode();
+	// 	let report = api.submit_and_watch_extrinsic_until(xt2, XtStatus::Ready).unwrap();
+	// 	assert!(report.block_hash.is_none());
+	// 	println!("Success: submit_and_watch_extrinsic_until Ready");
+	//
+	// 	thread::sleep(Duration::from_secs(6)); // Wait a little to avoid transaction too low priority error.
+	// 	let xt3 = api.balance_transfer(bob.clone(), 1000).encode();
+	// 	// The xt is not broadcast - we only have one node running. Therefore, InBlock is returned.
+	// 	let _some_hash = api
+	// 		.submit_and_watch_extrinsic_until(xt3, XtStatus::Broadcast)
+	// 		.unwrap()
+	// 		.block_hash
+	// 		.unwrap();
+	// 	println!("Success: submit_and_watch_extrinsic_until Broadcast");
+	//
+	// 	let api2 = api.clone();
+	// 	thread::sleep(Duration::from_secs(6)); // Wait a little to avoid transaction too low priority error.
+	// 	let xt4 = api2.balance_transfer(bob.clone(), 1000).encode();
+	// 	let until_in_block_handle = thread::spawn(move || {
+	// 		let _block_hash = api2
+	// 			.submit_and_watch_extrinsic_until(xt4, XtStatus::InBlock)
+	// 			.unwrap()
+	// 			.block_hash
+	// 			.unwrap();
+	// 		println!("Success: submit_and_watch_extrinsic_until InBlock");
+	// 	});
+	//
+	// 	let api3 = api.clone();
+	// 	thread::sleep(Duration::from_secs(6)); // Wait a little to avoid transaction too low priority error.
+	// 	let xt5 = api.balance_transfer(bob.clone(), 1000).encode();
+	// 	let until_finalized_handle = thread::spawn(move || {
+	// 		let _block_hash = api3
+	// 			.submit_and_watch_extrinsic_until(xt5, XtStatus::Finalized)
+	// 			.unwrap()
+	// 			.block_hash
+	// 			.unwrap();
+	// 		println!("Success: submit_and_watch_extrinsic_until Finalized");
+	// 	});
 
 	//Test Success
-	thread::sleep(Duration::from_secs(6)); // Wait a little to avoid transaction too low priority error.
-									   // 	let xt6 = api.balance_transfer(bob, 1000).encode();
-									   //
-									   // 	let events = api
-									   // 		.submit_and_watch_extrinsic_until_success(xt6, false)
-									   // 		.unwrap()
-									   // 		.events
-									   // 		.unwrap();
-									   // 	println!("Success: Found events: {:?}", events);
+	thread::sleep(Duration::from_secs(6));
+	//Wait a little to avoid transaction too low priority error.
+	let xt6 = api.balance_transfer(bob, 1000).encode();
 
-	watch_handle.join().unwrap();
-	until_in_block_handle.join().unwrap();
-	until_finalized_handle.join().unwrap();
+	let events = api
+		.submit_and_watch_extrinsic_until_success(xt6, false)
+		.unwrap()
+		.events
+		.unwrap();
+	println!("Success: Found events: {:?}", events);
+
+	// watch_handle.join().unwrap();
+	// until_in_block_handle.join().unwrap();
+	// until_finalized_handle.join().unwrap();
 }

--- a/testing/examples/author_tests.rs
+++ b/testing/examples/author_tests.rs
@@ -38,73 +38,72 @@ async fn main() {
 
 	let bob = MultiAddress::Id(AccountKeyring::Bob.to_account_id());
 
-	// Submit extrinisc
-	//let xt0 = api.balance_transfer(bob.clone(), 1000).encode();
-	//let _tx_hash = api.submit_extrinsic(xt0).unwrap();
+	// Submit extrinisc.
+	let xt0 = api.balance_transfer(bob.clone(), 1000).encode();
+	let _tx_hash = api.submit_extrinsic(xt0).unwrap();
 
-	// Submit and watch
+	// Submit and watch.
 
-	// Subscribe works.
-	// 	thread::sleep(Duration::from_secs(6)); // Wait a little to avoid transaction too low priority error.
-	// 	let api1 = api.clone();
-	// 	let xt1 = api.balance_transfer(bob.clone(), 1000).encode();
-	// 	let watch_handle = thread::spawn(move || {
-	// 		let mut tx_subscription = api1.submit_and_watch_extrinsic(xt1).unwrap();
-	// 		let tx_status = tx_subscription.next().unwrap().unwrap();
-	// 		assert!(matches!(tx_status, TransactionStatus::Ready));
-	// 		let tx_status = tx_subscription.next().unwrap().unwrap();
-	// 		assert!(matches!(tx_status, TransactionStatus::InBlock(_)));
-	// 		let tx_status = tx_subscription.next().unwrap().unwrap();
-	// 		assert!(matches!(tx_status, TransactionStatus::Finalized(_)));
-	// 		tx_subscription.unsubscribe().unwrap();
-	// 		println!("Success: submit_and_watch_extrinsic");
-	// 	});
-	//
-	// 	// Test different _watch_untils:
-	//
-	// 	thread::sleep(Duration::from_secs(6)); // Wait a little to avoid transaction too low priority error.
-	// 	let xt2 = api.balance_transfer(bob.clone(), 1000).encode();
-	// 	let report = api.submit_and_watch_extrinsic_until(xt2, XtStatus::Ready).unwrap();
-	// 	assert!(report.block_hash.is_none());
-	// 	println!("Success: submit_and_watch_extrinsic_until Ready");
-	//
-	// 	thread::sleep(Duration::from_secs(6)); // Wait a little to avoid transaction too low priority error.
-	// 	let xt3 = api.balance_transfer(bob.clone(), 1000).encode();
-	// 	// The xt is not broadcast - we only have one node running. Therefore, InBlock is returned.
-	// 	let _some_hash = api
-	// 		.submit_and_watch_extrinsic_until(xt3, XtStatus::Broadcast)
-	// 		.unwrap()
-	// 		.block_hash
-	// 		.unwrap();
-	// 	println!("Success: submit_and_watch_extrinsic_until Broadcast");
-	//
-	// 	let api2 = api.clone();
-	// 	thread::sleep(Duration::from_secs(6)); // Wait a little to avoid transaction too low priority error.
-	// 	let xt4 = api2.balance_transfer(bob.clone(), 1000).encode();
-	// 	let until_in_block_handle = thread::spawn(move || {
-	// 		let _block_hash = api2
-	// 			.submit_and_watch_extrinsic_until(xt4, XtStatus::InBlock)
-	// 			.unwrap()
-	// 			.block_hash
-	// 			.unwrap();
-	// 		println!("Success: submit_and_watch_extrinsic_until InBlock");
-	// 	});
-	//
-	// 	let api3 = api.clone();
-	// 	thread::sleep(Duration::from_secs(6)); // Wait a little to avoid transaction too low priority error.
-	// 	let xt5 = api.balance_transfer(bob.clone(), 1000).encode();
-	// 	let until_finalized_handle = thread::spawn(move || {
-	// 		let _block_hash = api3
-	// 			.submit_and_watch_extrinsic_until(xt5, XtStatus::Finalized)
-	// 			.unwrap()
-	// 			.block_hash
-	// 			.unwrap();
-	// 		println!("Success: submit_and_watch_extrinsic_until Finalized");
-	// 	});
+	//Subscribe works.
+	thread::sleep(Duration::from_secs(6)); // Wait a little to avoid transaction too low priority error.
+	let api1 = api.clone();
+	let xt1 = api.balance_transfer(bob.clone(), 1000).encode();
+	let watch_handle = thread::spawn(move || {
+		let mut tx_subscription = api1.submit_and_watch_extrinsic(xt1).unwrap();
+		let tx_status = tx_subscription.next().unwrap().unwrap();
+		assert!(matches!(tx_status, TransactionStatus::Ready));
+		let tx_status = tx_subscription.next().unwrap().unwrap();
+		assert!(matches!(tx_status, TransactionStatus::InBlock(_)));
+		let tx_status = tx_subscription.next().unwrap().unwrap();
+		assert!(matches!(tx_status, TransactionStatus::Finalized(_)));
+		tx_subscription.unsubscribe().unwrap();
+		println!("Success: submit_and_watch_extrinsic");
+	});
 
-	//Test Success
-	//thread::sleep(Duration::from_secs(6));
-	//Wait a little to avoid transaction too low priority error.
+	// Test different _watch_untils.
+
+	thread::sleep(Duration::from_secs(6)); // Wait a little to avoid transaction too low priority error.
+	let xt2 = api.balance_transfer(bob.clone(), 1000).encode();
+	let report = api.submit_and_watch_extrinsic_until(xt2, XtStatus::Ready).unwrap();
+	assert!(report.block_hash.is_none());
+	println!("Success: submit_and_watch_extrinsic_until Ready");
+
+	thread::sleep(Duration::from_secs(6)); // Wait a little to avoid transaction too low priority error.
+	let xt3 = api.balance_transfer(bob.clone(), 1000).encode();
+	// The xt is not broadcast - we only have one node running. Therefore, InBlock is returned.
+	let _some_hash = api
+		.submit_and_watch_extrinsic_until(xt3, XtStatus::Broadcast)
+		.unwrap()
+		.block_hash
+		.unwrap();
+	println!("Success: submit_and_watch_extrinsic_until Broadcast");
+
+	let api2 = api.clone();
+	thread::sleep(Duration::from_secs(6)); // Wait a little to avoid transaction too low priority error.
+	let xt4 = api2.balance_transfer(bob.clone(), 1000).encode();
+	let until_in_block_handle = thread::spawn(move || {
+		let _block_hash = api2
+			.submit_and_watch_extrinsic_until(xt4, XtStatus::InBlock)
+			.unwrap()
+			.block_hash
+			.unwrap();
+		println!("Success: submit_and_watch_extrinsic_until InBlock");
+	});
+
+	let api3 = api.clone();
+	thread::sleep(Duration::from_secs(6)); // Wait a little to avoid transaction too low priority error.
+	let xt5 = api.balance_transfer(bob.clone(), 1000).encode();
+	let until_finalized_handle = thread::spawn(move || {
+		let _block_hash = api3
+			.submit_and_watch_extrinsic_until(xt5, XtStatus::Finalized)
+			.unwrap()
+			.block_hash
+			.unwrap();
+		println!("Success: submit_and_watch_extrinsic_until Finalized");
+	});
+
+	// Test Success.
+	thread::sleep(Duration::from_secs(6)); // Wait a little to avoid transaction too low priority error.
 	let xt6 = api.balance_transfer(bob, 1000).encode();
 
 	let events = api
@@ -115,9 +114,9 @@ async fn main() {
 	println!("Extrinsic got successfully included in Block!");
 	assert_assosciated_events_match_expected(events);
 
-	// watch_handle.join().unwrap();
-	// until_in_block_handle.join().unwrap();
-	// until_finalized_handle.join().unwrap();
+	watch_handle.join().unwrap();
+	until_in_block_handle.join().unwrap();
+	until_finalized_handle.join().unwrap();
 }
 
 fn assert_assosciated_events_match_expected(events: Vec<EventDetails>) {

--- a/testing/examples/pallet_transaction_payment_tests.rs
+++ b/testing/examples/pallet_transaction_payment_tests.rs
@@ -15,6 +15,7 @@
 
 //! Tests for the pallet transaction payment interface functions.
 
+use codec::Encode;
 use kitchensink_runtime::Runtime;
 use sp_keyring::AccountKeyring;
 use substrate_api_client::{
@@ -33,9 +34,9 @@ async fn main() {
 	let bob = AccountKeyring::Bob.to_account_id();
 
 	let block_hash = api.get_block_hash(None).unwrap().unwrap();
-	let xthex_prefixed = api.balance_transfer(GenericAddress::Id(bob), 1000000000000).hex_encode();
+	let encoded_xt = api.balance_transfer(GenericAddress::Id(bob), 1000000000000).encode();
 
 	// Tests
-	let _fee_details = api.get_fee_details(&xthex_prefixed, Some(block_hash)).unwrap().unwrap();
-	let _payment_info = api.get_payment_info(&xthex_prefixed, Some(block_hash)).unwrap().unwrap();
+	let _fee_details = api.get_fee_details(encoded_xt.clone(), Some(block_hash)).unwrap().unwrap();
+	let _payment_info = api.get_payment_info(encoded_xt, Some(block_hash)).unwrap().unwrap();
 }


### PR DESCRIPTION
Allows to watch an extrinsic and automatically checks if the extrinsic was successful or not, by retrieving and checking the associated events.