### PR TITLE
Update .toml version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "ac-primitives"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "frame-system",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,7 @@ dependencies = [
 
 [[package]]
 name = "ac-compose-macros"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "ac-primitives",
  "log",
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "ac-node-api"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "ac-primitives",
  "bitvec",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "ac-primitives"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "frame-system",
  "hex",
@@ -5123,7 +5123,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-api-client"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "ac-compose-macros",
  "ac-node-api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-api-client"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Supercomputing Systems AG <info@scs.ch>"]
 license = "Apache-2.0"
 edition = "2021"

--- a/compose-macros/Cargo.toml
+++ b/compose-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ac-compose-macros"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Supercomputing Systems AG <info@scs.ch>"]
 license = "Apache-2.0"
 edition = "2021"

--- a/node-api/Cargo.toml
+++ b/node-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ac-node-api"
-version = "0.2.1"
+version = "0.2.2"
 license = "Apache-2.0"
 edition = "2021"
 

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ac-primitives"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Supercomputing Systems AG <info@scs.ch>"]
 license = "Apache-2.0"
 edition = "2021"

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ac-primitives"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Supercomputing Systems AG <info@scs.ch>"]
 license = "Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
I think it's time for the next tag `v0.9.0` :)

Lots happened, such as Trait introduction for the RpcClient and Api Client, almost full `no_std` support, introduction of jsonrpsee client and tungsenite client, new features, and so on.

Changes from now to tag v0.8.0 can be looked up here: https://github.com/scs/substrate-api-client/compare/v0.8.0...master#

Summary:
 - `ac-compose-macros` has new features (full no_std and rpc_params), no breaking changes.
 - `ac-examples` got newly created
 - `ac-node-api` implements new functions (such as `check_if_failed`), no breaking changes.
 - `ac-primitives`: removed of `hex_encode` function as well as enforcing Serializing in no_std. Therefore, breaking changes were introduced.
 - `api-client` : Lots of breaking changes.