### PR TITLE
Fix documentation for running an example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To run an example, clone the `substrate-api-client` repository and run the desir
 ```bash
 git clone https://github.com/scs/substrate-api-client.git
 cd substrate-api-client
-cargo run -p examples --example get_storage
+cargo run -p ac-examples --example get_storage
 ```
 or download the already built binaries from Github Actions: https://github.com/scs/substrate-api-client/actions and run them without any building:
 

--- a/examples/examples/benchmark_bulk_xt.rs
+++ b/examples/examples/benchmark_bulk_xt.rs
@@ -13,7 +13,7 @@
 	limitations under the License.
 */
 
-//! This examples floats the node with a series of transactions.
+//! This example floods the node with a series of transactions.
 
 // run this against test node with
 // > substrate-test-node --dev --execution native --ws-port 9979 -ltxpool=debug

--- a/examples/examples/compose_extrinsic_offline.rs
+++ b/examples/examples/compose_extrinsic_offline.rs
@@ -13,7 +13,7 @@
 	limitations under the License.
 */
 
-//! This examples shows how to use the compose_extrinsic_offline macro which generates an extrinsic
+//! This example shows how to use the compose_extrinsic_offline macro which generates an extrinsic
 //! without asking the node for nonce and does not need to know the metadata
 
 use codec::Encode;

--- a/examples/examples/custom_nonce.rs
+++ b/examples/examples/custom_nonce.rs
@@ -13,7 +13,7 @@
 	limitations under the License.
 */
 
-//! This examples shows how to use the compose_extrinsic_offline macro which generates an extrinsic
+//! This example shows how to use the compose_extrinsic_offline macro which generates an extrinsic
 //! without asking the node for nonce and does not need to know the metadata
 
 use codec::Encode;

--- a/examples/examples/sudo.rs
+++ b/examples/examples/sudo.rs
@@ -13,7 +13,7 @@
 	limitations under the License.
 */
 
-//! This examples shows how to use the compose_extrinsic macro to create an extrinsic for any (custom)
+//! This example shows how to use the compose_extrinsic macro to create an extrinsic for any (custom)
 //! module, whereas the desired module and call are supplied as a string.
 
 use codec::{Compact, Encode};


### PR DESCRIPTION
I mostly wanted to fix the `cargo run` command for the examples, but I also fixed some minor typos along the way