### PR TITLE
Make UncheckedExtrinsicV4 generic

### DIFF
--- a/examples/examples/batch_payout.rs
+++ b/examples/examples/batch_payout.rs
@@ -12,13 +12,14 @@
 */
 
 use codec::{Decode, Encode};
-use kitchensink_runtime::Runtime;
+use kitchensink_runtime::{Runtime, Signature};
 use pallet_staking::{ActiveEraInfo, Exposure};
 use serde_json::Value;
 use sp_keyring::AccountKeyring;
 use sp_runtime::{app_crypto::Ss58Codec, AccountId32};
 use substrate_api_client::{
-	rpc::JsonrpseeClient, Api, GetStorage, PlainTipExtrinsicParams, SubmitAndWatch, XtStatus,
+	rpc::JsonrpseeClient, Api, ExtrinsicSigner, GetStorage, PlainTipExtrinsicParams,
+	SubmitAndWatch, XtStatus,
 };
 
 const MAX_BATCHED_TRANSACTION: u32 = 9;
@@ -47,7 +48,7 @@ async fn main() {
 	let alice = AccountKeyring::Alice.pair();
 	let client = JsonrpseeClient::with_default_url().unwrap();
 	let mut api = Api::<_, _, PlainTipExtrinsicParams<Runtime>, Runtime>::new(client).unwrap();
-	api.set_signer(alice);
+	api.set_signer(ExtrinsicSigner::<_, Signature, Runtime>::new(alice));
 
 	// Give a valid validator account address, given one is westend chain validator account.
 	let account =
@@ -118,7 +119,7 @@ async fn main() {
 pub fn get_last_reward(
 	account: &AccountId32,
 	api: &substrate_api_client::Api<
-		sp_core::sr25519::Pair,
+		ExtrinsicSigner<sp_core::sr25519::Pair, Signature, Runtime>,
 		JsonrpseeClient,
 		PlainTipExtrinsicParams<Runtime>,
 		Runtime,

--- a/examples/examples/benchmark_bulk_xt.rs
+++ b/examples/examples/benchmark_bulk_xt.rs
@@ -27,11 +27,11 @@ use substrate_api_client::{
 };
 
 // Define an extrinsic signer type which sets the generic types of the `GenericExtrinsicSigner`.
-// This way, the types don't have to be reassigned with every usage of this type and make
+// This way, the types don't have to be reassigned with every usage of this type and makes
 // the code better readable.
 type ExtrinsicSigner = GenericExtrinsicSigner<Pair, Signature, Runtime>;
 
-// To access the ExtrinsicAddress type of the Signer, we need to this via the trait `SignExtrinsic`.
+// To access the ExtrinsicAddress type of the Signer, we need to do this via the trait `SignExtrinsic`.
 // For better code readability, we define a simple type here and, at the same time, assign the
 // AccountId type of the `SignExtrinsic` trait.
 type ExtrinsicAddressOf<Signer> = <Signer as SignExtrinsic<AccountId>>::ExtrinsicAddress;

--- a/examples/examples/compose_extrinsic_offline.rs
+++ b/examples/examples/compose_extrinsic_offline.rs
@@ -16,12 +16,12 @@
 //! This example shows how to use the compose_extrinsic_offline macro which generates an extrinsic
 //! without asking the node for nonce and does not need to know the metadata
 
-use kitchensink_runtime::{BalancesCall, Runtime, RuntimeCall};
+use kitchensink_runtime::{BalancesCall, Runtime, RuntimeCall, Signature};
 use sp_keyring::AccountKeyring;
 use sp_runtime::{generic::Era, MultiAddress};
 use substrate_api_client::{
-	rpc::JsonrpseeClient, Api, AssetTipExtrinsicParams, GenericAdditionalParams, GetHeader,
-	SubmitAndWatch, XtStatus,
+	rpc::JsonrpseeClient, Api, AssetTipExtrinsicParams, ExtrinsicSigner, GenericAdditionalParams,
+	GetHeader, SubmitAndWatch, XtStatus,
 };
 
 #[tokio::main]
@@ -38,7 +38,7 @@ async fn main() {
 	// ! Careful: AssetTipExtrinsicParams is used here, because the substrate kitchensink runtime uses assets as tips. But for most
 	// runtimes, the PlainTipExtrinsicParams needs to be used.
 	let mut api = Api::<_, _, AssetTipExtrinsicParams<Runtime>, Runtime>::new(client).unwrap();
-	api.set_signer(signer);
+	api.set_signer(ExtrinsicSigner::<_, Signature, Runtime>::new(signer));
 
 	// Information for Era for mortal transactions (online).
 	let last_finalized_header_hash = api.get_finalized_head().unwrap().unwrap();

--- a/examples/examples/contract_instantiate_with_code.rs
+++ b/examples/examples/contract_instantiate_with_code.rs
@@ -20,7 +20,7 @@ use kitchensink_runtime::{AccountId, Runtime, Signature};
 use sp_keyring::AccountKeyring;
 use substrate_api_client::{
 	rpc::JsonrpseeClient, Api, ExtrinsicSigner, PlainTipExtrinsicParams, StaticEvent,
-	SubmitAndWatch, SubscribeEvents, SubscribeFrameSystem, XtStatus,
+	SubmitAndWatch, SubmitAndWatchUntilSuccess, SubscribeEvents, SubscribeFrameSystem, XtStatus,
 };
 
 #[allow(unused)]

--- a/examples/examples/contract_instantiate_with_code.rs
+++ b/examples/examples/contract_instantiate_with_code.rs
@@ -16,11 +16,11 @@
 //! This example is community maintained and not CI tested, therefore it may not work as is.
 
 use codec::Decode;
-use kitchensink_runtime::Runtime;
+use kitchensink_runtime::{AccountId, Runtime, Signature};
 use sp_keyring::AccountKeyring;
 use substrate_api_client::{
-	rpc::JsonrpseeClient, AccountId, Api, PlainTipExtrinsicParams, StaticEvent, SubmitAndWatch,
-	SubmitAndWatchUntilSuccess, XtStatus,
+	rpc::JsonrpseeClient, Api, ExtrinsicSigner, PlainTipExtrinsicParams, StaticEvent,
+	SubmitAndWatch, SubscribeEvents, SubscribeFrameSystem, XtStatus,
 };
 
 #[allow(unused)]
@@ -45,7 +45,7 @@ async fn main() {
 	// ! Careful: AssetTipExtrinsicParams is used here, because the substrate kitchensink runtime uses assets as tips. But for most
 	// runtimes, the PlainTipExtrinsicParams needs to be used.
 	let mut api = Api::<_, _, PlainTipExtrinsicParams<Runtime>, Runtime>::new(client).unwrap();
-	api.set_signer(signer);
+	api.set_signer(ExtrinsicSigner::<_, Signature, Runtime>::new(signer));
 
 	println!("[+] Alice's Account Nonce is {}", api.get_nonce().unwrap());
 

--- a/examples/examples/custom_nonce.rs
+++ b/examples/examples/custom_nonce.rs
@@ -16,12 +16,12 @@
 //! This example shows how to use the compose_extrinsic_offline macro which generates an extrinsic
 //! without asking the node for nonce and does not need to know the metadata
 
-use kitchensink_runtime::{BalancesCall, Runtime, RuntimeCall};
+use kitchensink_runtime::{BalancesCall, Runtime, RuntimeCall, Signature};
 use sp_keyring::AccountKeyring;
 use sp_runtime::{generic::Era, MultiAddress};
 use substrate_api_client::{
-	rpc::JsonrpseeClient, Api, AssetTipExtrinsicParams, Error, GenericAdditionalParams, GetHeader,
-	SubmitAndWatch, UnexpectedTxStatus, XtStatus,
+	rpc::JsonrpseeClient, Api, AssetTipExtrinsicParams, Error, ExtrinsicSigner,
+	GenericAdditionalParams, GetHeader, SubmitAndWatch, UnexpectedTxStatus, XtStatus,
 };
 
 #[tokio::main]
@@ -34,7 +34,7 @@ async fn main() {
 	// ! Careful: AssetTipExtrinsicParams is used here, because the substrate kitchensink runtime uses assets as tips. But for most
 	// runtimes, the PlainTipExtrinsicParams needs to be used.
 	let mut api = Api::<_, _, AssetTipExtrinsicParams<Runtime>, Runtime>::new(client).unwrap();
-	api.set_signer(signer);
+	api.set_signer(ExtrinsicSigner::<_, Signature, Runtime>::new(signer));
 
 	// Information for Era for mortal transactions.
 	let last_finalized_header_hash = api.get_finalized_head().unwrap().unwrap();

--- a/examples/examples/event_callback.rs
+++ b/examples/examples/event_callback.rs
@@ -18,7 +18,7 @@
 use codec::Decode;
 use kitchensink_runtime::Runtime;
 use log::debug;
-use sp_core::{sr25519, H256 as Hash};
+use sp_core::H256 as Hash;
 use substrate_api_client::{
 	rpc::{HandleSubscription, JsonrpseeClient},
 	Api, PlainTipExtrinsicParams, SubscribeFrameSystem,
@@ -35,8 +35,7 @@ async fn main() {
 
 	// Initialize the api.
 	let client = JsonrpseeClient::with_default_url().unwrap();
-	let api =
-		Api::<sr25519::Pair, _, PlainTipExtrinsicParams<Runtime>, Runtime>::new(client).unwrap();
+	let api = Api::<(), _, PlainTipExtrinsicParams<Runtime>, Runtime>::new(client).unwrap();
 
 	println!("Subscribe to events");
 	let mut subscription = api.subscribe_system_events().unwrap();

--- a/examples/examples/event_error_details.rs
+++ b/examples/examples/event_error_details.rs
@@ -14,12 +14,12 @@
 */
 
 use codec::Decode;
-use kitchensink_runtime::Runtime;
+use kitchensink_runtime::{Runtime, Signature};
 use sp_keyring::AccountKeyring;
 use sp_runtime::{AccountId32 as AccountId, MultiAddress};
 use substrate_api_client::{
-	rpc::JsonrpseeClient, Api, AssetTipExtrinsicParams, GetAccountInformation, StaticEvent,
-	SubmitAndWatchUntilSuccess,
+	rpc::JsonrpseeClient, Api, AssetTipExtrinsicParams, ExtrinsicSigner, GetAccountInformation,
+	Result, StaticEvent, SubmitAndWatch, SubscribeEvents, SubscribeFrameSystem, XtStatus,
 };
 
 #[derive(Decode)]
@@ -44,7 +44,7 @@ async fn main() {
 	// ! Careful: AssetTipExtrinsicParams is used here, because the substrate kitchensink runtime uses assets as tips. But for most
 	// runtimes, the PlainTipExtrinsicParams needs to be used.
 	let mut api = Api::<_, _, AssetTipExtrinsicParams<Runtime>, Runtime>::new(client).unwrap();
-	api.set_signer(alice_signer);
+	api.set_signer(ExtrinsicSigner::<_, Signature, Runtime>::new(alice_signer));
 
 	let alice = AccountKeyring::Alice.to_account_id();
 	let balance_of_alice = api.get_account_data(&alice).unwrap().unwrap().free;

--- a/examples/examples/event_error_details.rs
+++ b/examples/examples/event_error_details.rs
@@ -19,7 +19,8 @@ use sp_keyring::AccountKeyring;
 use sp_runtime::{AccountId32 as AccountId, MultiAddress};
 use substrate_api_client::{
 	rpc::JsonrpseeClient, Api, AssetTipExtrinsicParams, ExtrinsicSigner, GetAccountInformation,
-	Result, StaticEvent, SubmitAndWatch, SubscribeEvents, SubscribeFrameSystem, XtStatus,
+	Result, StaticEvent, SubmitAndWatch, SubmitAndWatchUntilSuccess, SubscribeEvents,
+	SubscribeFrameSystem, XtStatus,
 };
 
 #[derive(Decode)]

--- a/examples/examples/get_account_identity.rs
+++ b/examples/examples/get_account_identity.rs
@@ -16,13 +16,13 @@
 //! Example to show how to get the account identity display name from the identity pallet.
 
 use frame_support::traits::Currency;
-use kitchensink_runtime::Runtime as KitchensinkRuntime;
+use kitchensink_runtime::{Runtime as KitchensinkRuntime, Signature};
 use pallet_identity::{Data, IdentityInfo, Registration};
 use sp_core::{crypto::Pair, H256};
 use sp_keyring::AccountKeyring;
 use substrate_api_client::{
-	compose_extrinsic, rpc::JsonrpseeClient, Api, AssetTipExtrinsicParams, GetStorage,
-	SubmitAndWatch, UncheckedExtrinsicV4, XtStatus,
+	compose_extrinsic, rpc::JsonrpseeClient, Api, AssetTipExtrinsicParams, ExtrinsicSigner,
+	GetStorage, SubmitAndWatch, UncheckedExtrinsicV4, XtStatus,
 };
 
 type BalanceOf<T> = <<T as pallet_identity::Config>::Currency as Currency<
@@ -43,7 +43,7 @@ async fn main() {
 	let mut api =
 		Api::<_, _, AssetTipExtrinsicParams<KitchensinkRuntime>, KitchensinkRuntime>::new(client)
 			.unwrap();
-	api.set_signer(signer.clone());
+	api.set_signer(ExtrinsicSigner::<_, Signature, KitchensinkRuntime>::new(signer.clone()));
 
 	// Fill Identity storage.
 	let info = IdentityInfo::<MaxAdditionalFieldsOf<KitchensinkRuntime>> {
@@ -58,7 +58,7 @@ async fn main() {
 		twitter: Data::None,
 	};
 
-	let xt: UncheckedExtrinsicV4<_, _> =
+	let xt: UncheckedExtrinsicV4<_, _, _, _> =
 		compose_extrinsic!(&api, "Identity", "set_identity", Box::new(info.clone()));
 	println!("[+] Composed Extrinsic:\n {:?}\n", xt);
 

--- a/examples/examples/get_storage.rs
+++ b/examples/examples/get_storage.rs
@@ -16,9 +16,11 @@
 //! Very simple example that shows how to get some simple storage values.
 
 use frame_system::AccountInfo as GenericAccountInfo;
-use kitchensink_runtime::Runtime;
+use kitchensink_runtime::{Runtime, Signature};
 use sp_keyring::AccountKeyring;
-use substrate_api_client::{rpc::JsonrpseeClient, Api, GetStorage, PlainTipExtrinsicParams};
+use substrate_api_client::{
+	rpc::JsonrpseeClient, Api, ExtrinsicSigner, GetStorage, PlainTipExtrinsicParams,
+};
 
 type IndexFor<T> = <T as frame_system::Config>::Index;
 type AccountDataFor<T> = <T as frame_system::Config>::AccountData;
@@ -54,7 +56,7 @@ async fn main() {
 
 	// get Alice's AccountNonce with api.get_nonce()
 	let signer = AccountKeyring::Alice.pair();
-	api.set_signer(signer);
+	api.set_signer(ExtrinsicSigner::<_, Signature, Runtime>::new(signer));
 	println!("[+] Alice's Account Nonce is {}", api.get_nonce().unwrap());
 
 	// Get an vector of storage keys, numbering up to the given max keys and that start with the (optionally) given storage key prefix.

--- a/examples/examples/sudo.rs
+++ b/examples/examples/sudo.rs
@@ -27,12 +27,12 @@ use substrate_api_client::{
 };
 
 // Define an extrinsic signer type which sets the generic types of the `GenericExtrinsicSigner`.
-// This way, the types don't have to be reassigned with every usage of this type and make
+// This way, the types don't have to be reassigned with every usage of this type and makes
 // the code better readable.
 type ExtrinsicSigner = GenericExtrinsicSigner<Pair, Signature, Runtime>;
 
-// To access the ExtrinsicAddress type of the ExtrinsicSigner, we need to access the trait `SignExtrinsic`.
-// As this is very verbose, we define a simple type here and, at the same time, assign the
+// To access the ExtrinsicAddress type of the Signer, we need to do this via the trait `SignExtrinsic`.
+// For better code readability, we define a simple type here and, at the same time, assign the
 // AccountId type of the `SignExtrinsic` trait.
 type ExtrinsicAddressOf<Signer> = <Signer as SignExtrinsic<AccountId>>::ExtrinsicAddress;
 

--- a/examples/examples/sudo.rs
+++ b/examples/examples/sudo.rs
@@ -22,11 +22,19 @@ use sp_core::sr25519::Pair;
 use sp_keyring::AccountKeyring;
 use substrate_api_client::{
 	compose_call, compose_extrinsic, rpc::JsonrpseeClient, Api, AssetTipExtrinsicParams,
-	ExtrinsicSigner, GetAccountInformation, SignExtrinsic, SubmitAndWatch, UncheckedExtrinsicV4,
-	XtStatus,
+	ExtrinsicSigner as GenericExtrinsicSigner, GetAccountInformation, SignExtrinsic,
+	SubmitAndWatch, UncheckedExtrinsicV4, XtStatus,
 };
 
-type MyExtrinsicSigner = ExtrinsicSigner<Pair, Signature, Runtime>;
+// Define an extrinsic signer type which sets the generic types of the `GenericExtrinsicSigner`.
+// This way, the types don't have to be reassigned with every usage of this type and make
+// the code better readable.
+type ExtrinsicSigner = GenericExtrinsicSigner<Pair, Signature, Runtime>;
+
+// To access the ExtrinsicAddress type of the ExtrinsicSigner, we need to access the trait `SignExtrinsic`.
+// As this is very verbose, we define a simple type here and, at the same time, assign the
+// AccountId type of the `SignExtrinsic` trait.
+type ExtrinsicAddressOf<Signer> = <Signer as SignExtrinsic<AccountId>>::ExtrinsicAddress;
 
 #[tokio::main]
 async fn main() {
@@ -36,7 +44,7 @@ async fn main() {
 	let sudoer = AccountKeyring::Alice.pair();
 	let client = JsonrpseeClient::with_default_url().unwrap();
 	let mut api = Api::<_, _, AssetTipExtrinsicParams<Runtime>, Runtime>::new(client).unwrap();
-	api.set_signer(MyExtrinsicSigner::new(sudoer));
+	api.set_signer(ExtrinsicSigner::new(sudoer));
 
 	// Set the recipient of newly issued funds.
 	let recipient = AccountKeyring::Bob.to_account_id();
@@ -46,7 +54,8 @@ async fn main() {
 	println!("[+] Recipients's Free Balance is now {}\n", recipient_balance);
 
 	// Compose a call that should only be executable via Sudo.
-	let recipients_extrinsic_address: <MyExtrinsicSigner as SignExtrinsic<AccountId>>::ExtrinsicAddress = recipient.clone().into();
+	let recipients_extrinsic_address: ExtrinsicAddressOf<ExtrinsicSigner> =
+		recipient.clone().into();
 	let new_balance = recipient_balance + 100;
 	let call = compose_call!(
 		api.metadata(),

--- a/examples/examples/transfer_with_tungstenite_client.rs
+++ b/examples/examples/transfer_with_tungstenite_client.rs
@@ -15,15 +15,15 @@
 
 //! Very simple example that shows how to use a predefined extrinsic from the extrinsic module.
 
-use kitchensink_runtime::Runtime;
+use kitchensink_runtime::{Runtime, Signature};
 use sp_core::{
 	crypto::{Pair, Ss58Codec},
 	sr25519,
 };
 use sp_runtime::MultiAddress;
 use substrate_api_client::{
-	rpc::TungsteniteRpcClient, Api, AssetTipExtrinsicParams, GetAccountInformation, SubmitAndWatch,
-	XtStatus,
+	rpc::TungsteniteRpcClient, Api, AssetTipExtrinsicParams, ExtrinsicSigner,
+	GetAccountInformation, SubmitAndWatch, XtStatus,
 };
 
 fn main() {
@@ -40,7 +40,7 @@ fn main() {
 	// Initialize api and set the signer (sender) that is used to sign the extrinsics.
 	let client = TungsteniteRpcClient::with_default_url(100);
 	let mut api = Api::<_, _, AssetTipExtrinsicParams<Runtime>, Runtime>::new(client).unwrap();
-	api.set_signer(alice.clone());
+	api.set_signer(ExtrinsicSigner::<_, Signature, Runtime>::new(alice.clone()));
 
 	// Retrieve bobs current balance.
 	let bob = sr25519::Public::from_ss58check("5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty")

--- a/examples/examples/transfer_with_ws_client.rs
+++ b/examples/examples/transfer_with_ws_client.rs
@@ -15,14 +15,15 @@
 
 //! Very simple example that shows how to use a predefined extrinsic from the extrinsic module.
 
-use kitchensink_runtime::Runtime;
+use kitchensink_runtime::{Runtime, Signature};
 use sp_core::{
 	crypto::{Pair, Ss58Codec},
 	sr25519,
 };
 use sp_runtime::MultiAddress;
 use substrate_api_client::{
-	rpc::WsRpcClient, Api, AssetTipExtrinsicParams, GetAccountInformation, SubmitAndWatch, XtStatus,
+	rpc::WsRpcClient, Api, AssetTipExtrinsicParams, ExtrinsicSigner, GetAccountInformation,
+	SubmitAndWatch, XtStatus,
 };
 
 fn main() {
@@ -39,7 +40,7 @@ fn main() {
 	// Initialize api and set the signer (sender) that is used to sign the extrinsics.
 	let client = WsRpcClient::with_default_url();
 	let mut api = Api::<_, _, AssetTipExtrinsicParams<Runtime>, Runtime>::new(client).unwrap();
-	api.set_signer(alice.clone());
+	api.set_signer(ExtrinsicSigner::<_, Signature, Runtime>::new(alice.clone()));
 
 	// Retrieve bobs current balance.
 	let bob = sr25519::Public::from_ss58check("5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty")

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -25,6 +25,7 @@ pub use pallet_traits::*;
 pub use rpc_numbers::*;
 pub use rpc_params::RpcParams;
 pub use serde_impls::*;
+pub use signer::*;
 pub use types::*;
 
 pub mod extrinsic_params;
@@ -33,4 +34,5 @@ pub mod pallet_traits;
 pub mod rpc_numbers;
 pub mod rpc_params;
 pub mod serde_impls;
+pub mod signer;
 pub mod types;

--- a/primitives/src/signer.rs
+++ b/primitives/src/signer.rs
@@ -1,0 +1,92 @@
+/*
+   Copyright 2019 Supercomputing Systems AG
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+	   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+*/
+
+//! Signer used to sign extrinsic.
+
+use crate::FrameSystemConfig;
+use codec::{Decode, Encode};
+use core::marker::PhantomData;
+use sp_core::Pair;
+use sp_runtime::traits::StaticLookup;
+
+pub trait SignExtrinsic<AccountId: Clone + Encode> {
+	type Signature;
+	type ExtrinsicAddress: Clone + Encode;
+
+	/// Sign a given payload and return the resulting Signature.
+	fn sign(&self, payload: &[u8]) -> Self::Signature;
+
+	/// Return the public account id of the key pair.
+	fn public_account_id(&self) -> &AccountId;
+
+	/// Return the public address of the key pair. This is needed for the
+	/// extrinsic creation, as substrate requires a Lookup transformation
+	/// from Address to AccoundId.
+	fn extrinsic_address(&self) -> Self::ExtrinsicAddress;
+}
+
+#[derive(Encode, Decode, Clone, PartialEq)]
+pub struct ExtrinsicSigner<Signer, Signature, Runtime>
+where
+	Signer: Pair,
+	Runtime: FrameSystemConfig,
+{
+	signer: Signer,
+	account_id: Runtime::AccountId,
+	extrinsic_address: <Runtime::Lookup as StaticLookup>::Source,
+	_phantom: PhantomData<Signature>,
+}
+
+impl<Signer, Signature, Runtime> ExtrinsicSigner<Signer, Signature, Runtime>
+where
+	Signer: Pair,
+	Runtime: FrameSystemConfig,
+	Runtime::AccountId: From<Signer::Public>,
+{
+	pub fn new(signer: Signer) -> Self {
+		let account_id: Runtime::AccountId = signer.public().into();
+		let extrinsic_address = Runtime::Lookup::unlookup(account_id.clone());
+		Self { signer, account_id, extrinsic_address, _phantom: Default::default() }
+	}
+
+	pub fn signer(&self) -> &Signer {
+		&self.signer
+	}
+}
+
+impl<Signer, Signature, Runtime> SignExtrinsic<Runtime::AccountId>
+	for ExtrinsicSigner<Signer, Signature, Runtime>
+where
+	Runtime: FrameSystemConfig,
+	Signer: Pair,
+	Signature: From<Signer::Signature>,
+{
+	type Signature = Signature;
+	type ExtrinsicAddress = <Runtime::Lookup as StaticLookup>::Source;
+
+	fn sign(&self, payload: &[u8]) -> Self::Signature {
+		self.signer.sign(payload).into()
+	}
+
+	fn public_account_id(&self) -> &Runtime::AccountId {
+		&self.account_id
+	}
+
+	fn extrinsic_address(&self) -> Self::ExtrinsicAddress {
+		self.extrinsic_address.clone()
+	}
+}

--- a/src/api/rpc_api/author.rs
+++ b/src/api/rpc_api/author.rs
@@ -37,12 +37,14 @@ pub trait SubmitExtrinsic {
 
 	/// Submit an encodable extrinsic to the substrate node.
 	/// Returns the extrinsic hash.
-	fn submit_extrinsic<Call, SignedExtra>(
+	fn submit_extrinsic<Address, Call, Signature, SignedExtra>(
 		&self,
-		extrinsic: UncheckedExtrinsicV4<Call, SignedExtra>,
+		extrinsic: UncheckedExtrinsicV4<Address, Call, Signature, SignedExtra>,
 	) -> Result<Self::Hash>
 	where
+		Address: Encode,
 		Call: Encode,
+		Signature: Encode,
 		SignedExtra: Encode;
 
 	/// Submit an encoded, opaque extrsinic to the substrate node.
@@ -58,12 +60,14 @@ where
 {
 	type Hash = Runtime::Hash;
 
-	fn submit_extrinsic<Call, SignedExtra>(
+	fn submit_extrinsic<Address, Call, Signature, SignedExtra>(
 		&self,
-		extrinsic: UncheckedExtrinsicV4<Call, SignedExtra>,
+		extrinsic: UncheckedExtrinsicV4<Address, Call, Signature, SignedExtra>,
 	) -> Result<Self::Hash>
 	where
+		Address: Encode,
 		Call: Encode,
+		Signature: Encode,
 		SignedExtra: Encode,
 	{
 		self.submit_opaque_extrinsic(extrinsic.encode().into())
@@ -84,12 +88,14 @@ where
 {
 	/// Submit an extrinsic an return a Subscription
 	/// to watch the extrinsic progress.
-	fn submit_and_watch_extrinsic<Call, SignedExtra>(
+	fn submit_and_watch_extrinsic<Address, Call, Signature, SignedExtra>(
 		&self,
-		extrinsic: UncheckedExtrinsicV4<Call, SignedExtra>,
+		extrinsic: UncheckedExtrinsicV4<Address, Call, Signature, SignedExtra>,
 	) -> Result<TransactionSubscriptionFor<Client, Hash>>
 	where
+		Address: Encode,
 		Call: Encode,
+		Signature: Encode,
 		SignedExtra: Encode;
 
 	/// Submit an encoded, opaque extrinsic an return a Subscription to
@@ -107,13 +113,15 @@ where
 	///   hash of the block the extrinsic was included in
 	/// - last known extrinsic (transaction) status
 	/// This method is blocking.
-	fn submit_and_watch_extrinsic_until<Call, SignedExtra>(
+	fn submit_and_watch_extrinsic_until<Address, Call, Signature, SignedExtra>(
 		&self,
-		extrinsic: UncheckedExtrinsicV4<Call, SignedExtra>,
+		extrinsic: UncheckedExtrinsicV4<Address, Call, Signature, SignedExtra>,
 		watch_until: XtStatus,
 	) -> Result<ExtrinsicReport<Hash>>
 	where
+		Address: Encode,
 		Call: Encode,
+		Signature: Encode,
 		SignedExtra: Encode;
 
 	/// Submit an encoded, opaque extrinsic and watch it until the desired status
@@ -146,13 +154,15 @@ where
 	/// - last known extrinsic (transaction) status
 	/// - associated events of the extrinsic
 	/// This method is blocking.
-	fn submit_and_watch_extrinsic_until_success<Call, SignedExtra>(
+	fn submit_and_watch_extrinsic_until_success<Address, Call, Signature, SignedExtra>(
 		&self,
-		extrinsic: UncheckedExtrinsicV4<Call, SignedExtra>,
+		extrinsic: UncheckedExtrinsicV4<Address, Call, Signature, SignedExtra>,
 		wait_for_finalized: bool,
 	) -> Result<ExtrinsicReport<Hash>>
 	where
+		Address: Encode,
 		Call: Encode,
+		Signature: Encode,
 		SignedExtra: Encode;
 
 	/// Submit an encoded, opaque extrinsic and watch it until
@@ -180,12 +190,14 @@ where
 	Runtime: FrameSystemConfig,
 	Runtime::Hashing: HashTrait<Output = Runtime::Hash>,
 {
-	fn submit_and_watch_extrinsic<Call, SignedExtra>(
+	fn submit_and_watch_extrinsic<Address, Call, Signature, SignedExtra>(
 		&self,
-		extrinsic: UncheckedExtrinsicV4<Call, SignedExtra>,
+		extrinsic: UncheckedExtrinsicV4<Address, Call, Signature, SignedExtra>,
 	) -> Result<TransactionSubscriptionFor<Client, Runtime::Hash>>
 	where
+		Address: Encode,
 		Call: Encode,
+		Signature: Encode,
 		SignedExtra: Encode,
 	{
 		self.submit_and_watch_opaque_extrinsic(extrinsic.encode().into())
@@ -203,13 +215,15 @@ where
 			.map_err(|e| e.into())
 	}
 
-	fn submit_and_watch_extrinsic_until<Call, SignedExtra>(
+	fn submit_and_watch_extrinsic_until<Address, Call, Signature, SignedExtra>(
 		&self,
-		extrinsic: UncheckedExtrinsicV4<Call, SignedExtra>,
+		extrinsic: UncheckedExtrinsicV4<Address, Call, Signature, SignedExtra>,
 		watch_until: XtStatus,
 	) -> Result<ExtrinsicReport<Runtime::Hash>>
 	where
+		Address: Encode,
 		Call: Encode,
+		Signature: Encode,
 		SignedExtra: Encode,
 	{
 		self.submit_and_watch_opaque_extrinsic_until(extrinsic.encode().into(), watch_until)
@@ -257,13 +271,15 @@ where
 	Runtime::RuntimeBlock: BlockTrait + DeserializeOwned,
 	Runtime::Hashing: HashTrait<Output = Runtime::Hash>,
 {
-	fn submit_and_watch_extrinsic_until_success<Call, SignedExtra>(
+	fn submit_and_watch_extrinsic_until_success<Address, Call, Signature, SignedExtra>(
 		&self,
-		extrinsic: UncheckedExtrinsicV4<Call, SignedExtra>,
+		extrinsic: UncheckedExtrinsicV4<Address, Call, Signature, SignedExtra>,
 		wait_for_finalized: bool,
 	) -> Result<ExtrinsicReport<Runtime::Hash>>
 	where
+		Address: Encode,
 		Call: Encode,
+		Signature: Encode,
 		SignedExtra: Encode,
 	{
 		self.submit_and_watch_opaque_extrinsic_until_success(

--- a/src/api/rpc_api/frame_system.rs
+++ b/src/api/rpc_api/frame_system.rs
@@ -19,13 +19,11 @@ use crate::{
 };
 use ac_compose_macros::rpc_params;
 use ac_primitives::{
-	AccountInfo, ExtrinsicParams, FrameSystemConfig, StorageChangeSet, StorageKey,
+	AccountInfo, ExtrinsicParams, FrameSystemConfig, SignExtrinsic, StorageChangeSet, StorageKey,
 };
 use alloc::{string::String, vec, vec::Vec};
 use log::*;
 use serde::de::DeserializeOwned;
-use sp_core::Pair;
-use sp_runtime::MultiSignature;
 
 pub trait GetAccountInformation<AccountId> {
 	type Index;
@@ -42,8 +40,7 @@ pub trait GetAccountInformation<AccountId> {
 impl<Signer, Client, Params, Runtime> GetAccountInformation<Runtime::AccountId>
 	for Api<Signer, Client, Params, Runtime>
 where
-	Signer: Pair,
-	MultiSignature: From<Signer::Signature>,
+	Signer: SignExtrinsic<Runtime::AccountId>,
 	Client: Request,
 	Runtime: FrameSystemConfig,
 	Params: ExtrinsicParams<Runtime::Index, Runtime::Hash>,

--- a/src/extrinsic/common.rs
+++ b/src/extrinsic/common.rs
@@ -19,11 +19,10 @@
 
 use alloc::vec::Vec;
 use codec::{Decode, Encode};
-use sp_runtime::AccountId32;
 
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, Debug)]
-pub struct PayoutStakers {
-	pub validator_stash: AccountId32,
+pub struct PayoutStakers<AccountId> {
+	pub validator_stash: AccountId,
 	pub era: u32,
 }
 #[derive(Clone, Eq, PartialEq, Encode, Decode, Debug)]

--- a/src/extrinsic/offline_extrinsic.rs
+++ b/src/extrinsic/offline_extrinsic.rs
@@ -19,26 +19,22 @@
 
 use crate::Api;
 use ac_compose_macros::compose_extrinsic_offline;
-use ac_primitives::{ExtrinsicParams, FrameSystemConfig, UncheckedExtrinsicV4};
+use ac_primitives::{ExtrinsicParams, FrameSystemConfig, SignExtrinsic, UncheckedExtrinsicV4};
 use codec::Encode;
-use sp_core::Pair;
-use sp_runtime::{MultiSignature, MultiSigner};
 
 impl<Signer, Client, Params, Runtime> Api<Signer, Client, Params, Runtime>
 where
-	Signer: Pair,
-	MultiSignature: From<Signer::Signature>,
-	MultiSigner: From<Signer::Public>,
+	Signer: SignExtrinsic<Runtime::AccountId>,
 	Params: ExtrinsicParams<Runtime::Index, Runtime::Hash>,
 	Runtime: FrameSystemConfig,
-	Runtime::AccountId: From<Signer::Public>,
 {
 	/// Wrapper around the `compose_extrinsic_offline!` macro to be less verbose.
 	pub fn compose_extrinsic_offline<Call: Encode + Clone>(
 		&self,
 		call: Call,
 		nonce: Runtime::Index,
-	) -> UncheckedExtrinsicV4<Call, Params::SignedExtra> {
+	) -> UncheckedExtrinsicV4<Signer::ExtrinsicAddress, Call, Signer::Signature, Params::SignedExtra>
+	{
 		match self.signer() {
 			Some(signer) => compose_extrinsic_offline!(signer, call, self.extrinsic_params(nonce)),
 			None => UncheckedExtrinsicV4 { signature: None, function: call },

--- a/src/extrinsic/staking.rs
+++ b/src/extrinsic/staking.rs
@@ -21,13 +21,12 @@ use super::common::*;
 use crate::{rpc::Request, Api};
 use ac_compose_macros::compose_extrinsic;
 use ac_primitives::{
-	BalancesConfig, CallIndex, ExtrinsicParams, GenericAddress, RewardDestination, StakingConfig,
+	BalancesConfig, CallIndex, ExtrinsicParams, RewardDestination, SignExtrinsic, StakingConfig,
 	UncheckedExtrinsicV4,
 };
 use codec::{Compact, Encode};
 use serde::de::DeserializeOwned;
-use sp_core::Pair;
-use sp_runtime::{traits::GetRuntimeBlockType, AccountId32, MultiSignature, MultiSigner};
+use sp_runtime::traits::GetRuntimeBlockType;
 
 const STAKING_MODULE: &str = "Staking";
 const STAKING_BOND: &str = "bond";
@@ -45,57 +44,58 @@ const FORCE_NO_ERA: &str = "force_no_era";
 const STAKING_SET_PAYEE: &str = "set_payee";
 const SET_VALIDATOR_COUNT: &str = "set_validator_count";
 
-pub type StakingBondFn<Balance> =
-	(CallIndex, GenericAddress, Compact<Balance>, RewardDestination<GenericAddress>);
+pub type StakingBondFn<Address, Balance> =
+	(CallIndex, Address, Compact<Balance>, RewardDestination<Address>);
 pub type StakingBondExtraFn<Balance> = (CallIndex, Compact<Balance>);
 pub type StakingUnbondFn<Balance> = (CallIndex, Compact<Balance>);
 pub type StakingRebondFn<Balance> = (CallIndex, Compact<Balance>);
 pub type StakingWithdrawUnbondedFn = (CallIndex, u32);
-pub type StakingNominateFn = (CallIndex, Vec<GenericAddress>);
+pub type StakingNominateFn<Address> = (CallIndex, Vec<Address>);
 pub type StakingChillFn = CallIndex;
-pub type StakingSetControllerFn = (CallIndex, GenericAddress);
-pub type StakingPayoutStakersFn = (CallIndex, PayoutStakers);
+pub type StakingSetControllerFn<Address> = (CallIndex, Address);
+pub type StakingPayoutStakersFn<AccountId> = (CallIndex, PayoutStakers<AccountId>);
 pub type StakingForceNewEraFn = (CallIndex, ForceEra);
 pub type StakingForceNewEraAlwaysFn = (CallIndex, ForceEra);
 pub type StakingForceNoEraFn = (CallIndex, ForceEra);
-pub type StakingSetPayeeFn = (CallIndex, GenericAddress);
+pub type StakingSetPayeeFn<Address> = (CallIndex, Address);
 pub type StakingSetValidatorCountFn = (CallIndex, u32);
 
-pub type StakingBondXt<SignedExtra, Balance> =
-	UncheckedExtrinsicV4<StakingBondFn<Balance>, SignedExtra>;
-pub type StakingBondExtraXt<SignedExtra, Balance> =
-	UncheckedExtrinsicV4<StakingBondExtraFn<Balance>, SignedExtra>;
-pub type StakingUnbondXt<SignedExtra, Balance> =
-	UncheckedExtrinsicV4<StakingUnbondFn<Balance>, SignedExtra>;
-pub type StakingRebondXt<SignedExtra, Balance> =
-	UncheckedExtrinsicV4<StakingRebondFn<Balance>, SignedExtra>;
-pub type StakingWithdrawUnbondedXt<SignedExtra> =
-	UncheckedExtrinsicV4<StakingWithdrawUnbondedFn, SignedExtra>;
-pub type StakingNominateXt<SignedExtra> = UncheckedExtrinsicV4<StakingNominateFn, SignedExtra>;
-pub type StakingChillXt<SignedExtra> = UncheckedExtrinsicV4<StakingChillFn, SignedExtra>;
-pub type StakingSetControllerXt<SignedExtra> =
-	UncheckedExtrinsicV4<StakingSetControllerFn, SignedExtra>;
-pub type StakingPayoutStakersXt<SignedExtra> =
-	UncheckedExtrinsicV4<StakingPayoutStakersFn, SignedExtra>;
-pub type StakingForceNewEraXt<SignedExtra> =
-	UncheckedExtrinsicV4<StakingForceNewEraFn, SignedExtra>;
-pub type StakingForceNewEraAlwaysXt<SignedExtra> =
-	UncheckedExtrinsicV4<StakingForceNewEraAlwaysFn, SignedExtra>;
-pub type StakingForceNoEraXt<SignedExtra> = UncheckedExtrinsicV4<StakingForceNoEraFn, SignedExtra>;
-pub type StakingSetPayeeXt<SignedExtra> = UncheckedExtrinsicV4<StakingSetPayeeFn, SignedExtra>;
-pub type StakingSetValidatorCountXt<SignedExtra> =
-	UncheckedExtrinsicV4<StakingSetValidatorCountFn, SignedExtra>;
+pub type StakingBondXt<Address, Signature, SignedExtra, Balance> =
+	UncheckedExtrinsicV4<Address, StakingBondFn<Address, Balance>, Signature, SignedExtra>;
+pub type StakingBondExtraXt<Address, Signature, SignedExtra, Balance> =
+	UncheckedExtrinsicV4<Address, StakingBondExtraFn<Balance>, Signature, SignedExtra>;
+pub type StakingUnbondXt<Address, Signature, SignedExtra, Balance> =
+	UncheckedExtrinsicV4<Address, StakingUnbondFn<Balance>, Signature, SignedExtra>;
+pub type StakingRebondXt<Address, Signature, SignedExtra, Balance> =
+	UncheckedExtrinsicV4<Address, StakingRebondFn<Balance>, Signature, SignedExtra>;
+pub type StakingWithdrawUnbondedXt<Address, Signature, SignedExtra> =
+	UncheckedExtrinsicV4<Address, StakingWithdrawUnbondedFn, Signature, SignedExtra>;
+pub type StakingNominateXt<Address, Signature, SignedExtra> =
+	UncheckedExtrinsicV4<Address, StakingNominateFn<Address>, Signature, SignedExtra>;
+pub type StakingChillXt<Address, Signature, SignedExtra> =
+	UncheckedExtrinsicV4<Address, StakingChillFn, Signature, SignedExtra>;
+pub type StakingSetControllerXt<Address, Signature, SignedExtra> =
+	UncheckedExtrinsicV4<Address, StakingSetControllerFn<Address>, Signature, SignedExtra>;
+pub type StakingPayoutStakersXt<Address, Signature, SignedExtra, AccountId> =
+	UncheckedExtrinsicV4<Address, StakingPayoutStakersFn<AccountId>, Signature, SignedExtra>;
+pub type StakingForceNewEraXt<Address, Signature, SignedExtra> =
+	UncheckedExtrinsicV4<Address, StakingForceNewEraFn, Signature, SignedExtra>;
+pub type StakingForceNewEraAlwaysXt<Address, Signature, SignedExtra> =
+	UncheckedExtrinsicV4<Address, StakingForceNewEraAlwaysFn, Signature, SignedExtra>;
+pub type StakingForceNoEraXt<Address, Signature, SignedExtra> =
+	UncheckedExtrinsicV4<Address, StakingForceNoEraFn, Signature, SignedExtra>;
+pub type StakingSetPayeeXt<Address, Signature, SignedExtra> =
+	UncheckedExtrinsicV4<Address, StakingSetPayeeFn<Address>, Signature, SignedExtra>;
+pub type StakingSetValidatorCountXt<Address, Signature, SignedExtra> =
+	UncheckedExtrinsicV4<Address, StakingSetValidatorCountFn, Signature, SignedExtra>;
 
 // https://polkadot.js.org/docs/substrate/extrinsics#staking
 impl<Signer, Client, Params, Runtime> Api<Signer, Client, Params, Runtime>
 where
-	Signer: Pair,
-	MultiSignature: From<Signer::Signature>,
-	MultiSigner: From<Signer::Public>,
+	Signer: SignExtrinsic<Runtime::AccountId>,
 	Client: Request,
 	Params: ExtrinsicParams<Runtime::Index, Runtime::Hash>,
 	Runtime: GetRuntimeBlockType + BalancesConfig + StakingConfig,
-	Runtime::AccountId: From<Signer::Public>,
 	Compact<Runtime::CurrencyBalance>: Encode,
 	Runtime::Header: DeserializeOwned,
 	Runtime::RuntimeBlock: DeserializeOwned,
@@ -103,10 +103,15 @@ where
 	/// Bond `value` amount to `controller`
 	pub fn staking_bond(
 		&self,
-		controller: GenericAddress,
+		controller: Signer::ExtrinsicAddress,
 		value: Runtime::CurrencyBalance,
-		payee: RewardDestination<GenericAddress>,
-	) -> StakingBondXt<Params::SignedExtra, Runtime::CurrencyBalance> {
+		payee: RewardDestination<Signer::ExtrinsicAddress>,
+	) -> StakingBondXt<
+		Signer::ExtrinsicAddress,
+		Signer::Signature,
+		Params::SignedExtra,
+		Runtime::CurrencyBalance,
+	> {
 		compose_extrinsic!(self, STAKING_MODULE, STAKING_BOND, controller, Compact(value), payee)
 	}
 
@@ -114,7 +119,12 @@ where
 	pub fn staking_bond_extra(
 		&self,
 		value: Runtime::CurrencyBalance,
-	) -> StakingBondExtraXt<Params::SignedExtra, Runtime::CurrencyBalance> {
+	) -> StakingBondExtraXt<
+		Signer::ExtrinsicAddress,
+		Signer::Signature,
+		Params::SignedExtra,
+		Runtime::CurrencyBalance,
+	> {
 		compose_extrinsic!(self, STAKING_MODULE, STAKING_BOND_EXTRA, Compact(value))
 	}
 
@@ -124,7 +134,12 @@ where
 	pub fn staking_unbond(
 		&self,
 		value: Runtime::CurrencyBalance,
-	) -> StakingUnbondXt<Params::SignedExtra, Runtime::CurrencyBalance> {
+	) -> StakingUnbondXt<
+		Signer::ExtrinsicAddress,
+		Signer::Signature,
+		Params::SignedExtra,
+		Runtime::CurrencyBalance,
+	> {
 		compose_extrinsic!(self, STAKING_MODULE, STAKING_UNBOND, Compact(value))
 	}
 
@@ -132,7 +147,12 @@ where
 	pub fn staking_rebond(
 		&self,
 		value: Runtime::CurrencyBalance,
-	) -> StakingRebondXt<Params::SignedExtra, Runtime::CurrencyBalance> {
+	) -> StakingRebondXt<
+		Signer::ExtrinsicAddress,
+		Signer::Signature,
+		Params::SignedExtra,
+		Runtime::CurrencyBalance,
+	> {
 		compose_extrinsic!(self, STAKING_MODULE, STAKING_REBOND, Compact(value))
 	}
 
@@ -142,7 +162,8 @@ where
 	pub fn staking_withdraw_unbonded(
 		&self,
 		num_slashing_spans: u32,
-	) -> StakingWithdrawUnbondedXt<Params::SignedExtra> {
+	) -> StakingWithdrawUnbondedXt<Signer::ExtrinsicAddress, Signer::Signature, Params::SignedExtra>
+	{
 		compose_extrinsic!(self, STAKING_MODULE, STAKING_WITHDRAW_UNBONDED, num_slashing_spans)
 	}
 
@@ -150,13 +171,15 @@ where
 	/// Must be signed by the controller of the stash and called when EraElectionStatus is Closed.
 	pub fn staking_nominate(
 		&self,
-		targets: Vec<GenericAddress>,
-	) -> StakingNominateXt<Params::SignedExtra> {
+		targets: Vec<Signer::ExtrinsicAddress>,
+	) -> StakingNominateXt<Signer::ExtrinsicAddress, Signer::Signature, Params::SignedExtra> {
 		compose_extrinsic!(self, STAKING_MODULE, STAKING_NOMINATE, targets)
 	}
 
 	/// Stop nominating por validating. Effects take place in the next era
-	pub fn staking_chill(&self) -> StakingChillXt<Params::SignedExtra> {
+	pub fn staking_chill(
+		&self,
+	) -> StakingChillXt<Signer::ExtrinsicAddress, Signer::Signature, Params::SignedExtra> {
 		compose_extrinsic!(self, STAKING_MODULE, STAKING_CHILL)
 	}
 
@@ -165,37 +188,54 @@ where
 	/// Must be Signed by the stash, not the controller.
 	pub fn staking_set_controller(
 		&self,
-		controller: GenericAddress,
-	) -> StakingSetControllerXt<Params::SignedExtra> {
+		controller: Signer::ExtrinsicAddress,
+	) -> StakingSetControllerXt<Signer::ExtrinsicAddress, Signer::Signature, Params::SignedExtra> {
 		compose_extrinsic!(self, STAKING_MODULE, STAKING_SET_CONTROLLER, controller)
 	}
+
 	/// Return the payout call for the given era
 	pub fn payout_stakers(
 		&self,
 		era: u32,
-		account: AccountId32,
-	) -> StakingPayoutStakersXt<Params::SignedExtra> {
+		account: Runtime::AccountId,
+	) -> StakingPayoutStakersXt<
+		Signer::ExtrinsicAddress,
+		Signer::Signature,
+		Params::SignedExtra,
+		Runtime::AccountId,
+	> {
 		let value = PayoutStakers { validator_stash: account, era };
 		compose_extrinsic!(self, STAKING_MODULE, PAYOUT_STAKERS, value)
 	}
 
 	/// For New Era at the end of Next Session.
-	pub fn force_new_era(&self) -> StakingForceNewEraXt<Params::SignedExtra> {
+	pub fn force_new_era(
+		&self,
+	) -> StakingForceNewEraXt<Signer::ExtrinsicAddress, Signer::Signature, Params::SignedExtra> {
 		compose_extrinsic!(self, STAKING_MODULE, FORCE_NEW_ERA, ForceEra {})
 	}
 
 	/// Force there to be a new era at the end of sessions indefinitely.
-	pub fn force_new_era_always(&self) -> StakingForceNewEraAlwaysXt<Params::SignedExtra> {
+	pub fn force_new_era_always(
+		&self,
+	) -> StakingForceNewEraAlwaysXt<Signer::ExtrinsicAddress, Signer::Signature, Params::SignedExtra>
+	{
 		compose_extrinsic!(self, STAKING_MODULE, FORCE_NEW_ERA_ALWAYS, ForceEra {})
 	}
 
 	/// Force there to be no new eras indefinitely.
-	pub fn force_no_era(&self) -> StakingForceNewEraAlwaysXt<Params::SignedExtra> {
+	pub fn force_no_era(
+		&self,
+	) -> StakingForceNewEraAlwaysXt<Signer::ExtrinsicAddress, Signer::Signature, Params::SignedExtra>
+	{
 		compose_extrinsic!(self, STAKING_MODULE, FORCE_NO_ERA, ForceEra {})
 	}
 
 	/// Re-set the payment target for a controller.
-	pub fn set_payee(&self, payee: GenericAddress) -> StakingSetControllerXt<Params::SignedExtra> {
+	pub fn set_payee(
+		&self,
+		payee: Signer::ExtrinsicAddress,
+	) -> StakingSetControllerXt<Signer::ExtrinsicAddress, Signer::Signature, Params::SignedExtra> {
 		compose_extrinsic!(self, STAKING_MODULE, STAKING_SET_PAYEE, payee)
 	}
 
@@ -203,7 +243,8 @@ where
 	pub fn set_validator_count(
 		&self,
 		count: u32,
-	) -> StakingSetValidatorCountXt<Params::SignedExtra> {
+	) -> StakingSetValidatorCountXt<Signer::ExtrinsicAddress, Signer::Signature, Params::SignedExtra>
+	{
 		compose_extrinsic!(self, STAKING_MODULE, SET_VALIDATOR_COUNT, count)
 	}
 }

--- a/src/extrinsic/utility.rs
+++ b/src/extrinsic/utility.rs
@@ -20,34 +20,32 @@
 use super::common::Batch;
 use crate::{rpc::Request, Api};
 use ac_compose_macros::compose_extrinsic;
-use ac_primitives::{BalancesConfig, CallIndex, ExtrinsicParams, UncheckedExtrinsicV4};
+use ac_primitives::{
+	BalancesConfig, CallIndex, ExtrinsicParams, SignExtrinsic, UncheckedExtrinsicV4,
+};
 use alloc::{borrow::ToOwned, vec::Vec};
 use codec::Encode;
-use sp_core::Pair;
-use sp_runtime::{traits::GetRuntimeBlockType, MultiSignature, MultiSigner};
+use sp_runtime::traits::GetRuntimeBlockType;
 
 const UTILITY_MODULE: &str = "Utility";
 const UTILITY_BATCH: &str = "batch";
 const UTILITY_FORCE_BATCH: &str = "force_batch";
 
 pub type UtilityBatchFn<Call> = (CallIndex, Batch<Call>);
-pub type UtilityBatchXt<Call, SignedExtra> =
-	UncheckedExtrinsicV4<UtilityBatchFn<Call>, SignedExtra>;
+pub type UtilityBatchXt<Address, Call, Signature, SignedExtra> =
+	UncheckedExtrinsicV4<Address, UtilityBatchFn<Call>, Signature, SignedExtra>;
 
 impl<Signer, Client, Params, Runtime> Api<Signer, Client, Params, Runtime>
 where
-	Signer: Pair,
-	MultiSignature: From<Signer::Signature>,
-	MultiSigner: From<Signer::Public>,
+	Signer: SignExtrinsic<Runtime::AccountId>,
 	Client: Request,
 	Params: ExtrinsicParams<Runtime::Index, Runtime::Hash>,
 	Runtime: GetRuntimeBlockType + BalancesConfig,
-	Runtime::AccountId: From<Signer::Public>,
 {
 	pub fn batch<Call: Encode + Clone>(
 		&self,
 		calls: Vec<Call>,
-	) -> UtilityBatchXt<Call, Params::SignedExtra> {
+	) -> UtilityBatchXt<Signer::ExtrinsicAddress, Call, Signer::Signature, Params::SignedExtra> {
 		let calls = Batch { calls };
 		compose_extrinsic!(self, UTILITY_MODULE, UTILITY_BATCH, calls)
 	}
@@ -55,7 +53,7 @@ where
 	pub fn force_batch<Call: Encode + Clone>(
 		&self,
 		calls: Vec<Call>,
-	) -> UtilityBatchXt<Call, Params::SignedExtra> {
+	) -> UtilityBatchXt<Signer::ExtrinsicAddress, Call, Signer::Signature, Params::SignedExtra> {
 		let calls = Batch { calls };
 		compose_extrinsic!(self, UTILITY_MODULE, UTILITY_FORCE_BATCH, calls)
 	}

--- a/testing/examples/author_tests.rs
+++ b/testing/examples/author_tests.rs
@@ -26,14 +26,7 @@ use substrate_api_client::{
 	XtStatus,
 };
 
-// Define an extrinsic signer type which sets the generic types of the `GenericExtrinsicSigner`.
-// This way, the types don't have to be reassigned with every usage of this type and make
-// the code better readable.
 type ExtrinsicSigner = GenericExtrinsicSigner<Pair, Signature, Runtime>;
-
-// To access the ExtrinsicAddress type of the ExtrinsicSigner, we need to access the trait `SignExtrinsic`.
-// As this is very verbose, we define a simple type here and, at the same time, assign the
-// AccountId type of the `SignExtrinsic` trait.
 type ExtrinsicAddressOf<Signer> = <Signer as SignExtrinsic<AccountId>>::ExtrinsicAddress;
 
 #[tokio::main]
@@ -47,7 +40,7 @@ async fn main() {
 	let bob: ExtrinsicAddressOf<ExtrinsicSigner> = AccountKeyring::Bob.to_account_id().into();
 
 	// Submit extrinisc.
-	let xt0 = api.balance_transfer(bob.clone().into(), 1000);
+	let xt0 = api.balance_transfer(bob.clone(), 1000);
 	let _tx_hash = api.submit_extrinsic(xt0).unwrap();
 
 	// Submit and watch.

--- a/testing/examples/author_tests.rs
+++ b/testing/examples/author_tests.rs
@@ -15,14 +15,17 @@
 
 //! Tests for the author rpc interface functions.
 
-use kitchensink_runtime::Runtime;
+use kitchensink_runtime::{AccountId, Runtime, Signature};
+use sp_core::sr25519::Pair;
 use sp_keyring::AccountKeyring;
 use std::{thread, time::Duration};
 use substrate_api_client::{
 	rpc::{HandleSubscription, JsonrpseeClient},
-	Api, AssetTipExtrinsicParams, EventDetails, MultiAddress, SubmitAndWatch,
+	Api, AssetTipExtrinsicParams, EventDetails, ExtrinsicSigner, SignExtrinsic, SubmitAndWatch,
 	SubmitAndWatchUntilSuccess, SubmitExtrinsic, TransactionStatus, XtStatus,
 };
+
+type MyExtrinsicSigner = ExtrinsicSigner<Pair, Signature, Runtime>;
 
 #[tokio::main]
 async fn main() {
@@ -30,12 +33,13 @@ async fn main() {
 	let client = JsonrpseeClient::with_default_url().unwrap();
 	let alice_pair = AccountKeyring::Alice.pair();
 	let mut api = Api::<_, _, AssetTipExtrinsicParams<Runtime>, Runtime>::new(client).unwrap();
-	api.set_signer(alice_pair);
+	api.set_signer(MyExtrinsicSigner::new(alice_pair));
 
-	let bob = MultiAddress::Id(AccountKeyring::Bob.to_account_id());
+	let bob: <MyExtrinsicSigner as SignExtrinsic<AccountId>>::ExtrinsicAddress =
+		AccountKeyring::Bob.to_account_id().into();
 
 	// Submit extrinisc.
-	let xt0 = api.balance_transfer(bob.clone(), 1000);
+	let xt0 = api.balance_transfer(bob.clone().into(), 1000);
 	let _tx_hash = api.submit_extrinsic(xt0).unwrap();
 
 	// Submit and watch.

--- a/testing/examples/frame_system_tests.rs
+++ b/testing/examples/frame_system_tests.rs
@@ -17,11 +17,11 @@
 
 use codec::Decode;
 use frame_support::dispatch::DispatchInfo;
-use kitchensink_runtime::Runtime;
+use kitchensink_runtime::{Runtime, Signature};
 use sp_keyring::AccountKeyring;
 use substrate_api_client::{
-	rpc::JsonrpseeClient, Api, AssetTipExtrinsicParams, GetAccountInformation, StaticEvent,
-	SubscribeEvents, SubscribeFrameSystem, SystemApi,
+	rpc::JsonrpseeClient, Api, AssetTipExtrinsicParams, ExtrinsicSigner, GetAccountInformation,
+	StaticEvent, SubscribeEvents, SubscribeFrameSystem, SystemApi,
 };
 
 /// Check out frame_system::Event::ExtrinsicSuccess:
@@ -41,7 +41,7 @@ async fn main() {
 	let client = JsonrpseeClient::with_default_url().unwrap();
 	let alice_pair = AccountKeyring::Alice.pair();
 	let mut api = Api::<_, _, AssetTipExtrinsicParams<Runtime>, Runtime>::new(client).unwrap();
-	api.set_signer(alice_pair);
+	api.set_signer(ExtrinsicSigner::<_, Signature, Runtime>::new(alice_pair));
 
 	let alice = AccountKeyring::Alice.to_account_id();
 

--- a/testing/examples/pallet_transaction_payment_tests.rs
+++ b/testing/examples/pallet_transaction_payment_tests.rs
@@ -16,10 +16,10 @@
 //! Tests for the pallet transaction payment interface functions.
 
 use codec::Encode;
-use kitchensink_runtime::Runtime;
+use kitchensink_runtime::{Runtime, Signature};
 use sp_keyring::AccountKeyring;
 use substrate_api_client::{
-	rpc::JsonrpseeClient, Api, AssetTipExtrinsicParams, GenericAddress, GetBlock,
+	rpc::JsonrpseeClient, Api, AssetTipExtrinsicParams, ExtrinsicSigner, GetBlock,
 	GetTransactionPayment,
 };
 
@@ -29,12 +29,12 @@ async fn main() {
 	let client = JsonrpseeClient::with_default_url().unwrap();
 	let alice_pair = AccountKeyring::Alice.pair();
 	let mut api = Api::<_, _, AssetTipExtrinsicParams<Runtime>, Runtime>::new(client).unwrap();
-	api.set_signer(alice_pair);
+	api.set_signer(ExtrinsicSigner::<_, Signature, Runtime>::new(alice_pair));
 
 	let bob = AccountKeyring::Bob.to_account_id();
 
 	let block_hash = api.get_block_hash(None).unwrap().unwrap();
-	let encoded_xt = api.balance_transfer(GenericAddress::Id(bob), 1000000000000).encode();
+	let encoded_xt = api.balance_transfer(bob.into(), 1000000000000).encode();
 
 	// Tests
 	let _fee_details = api


### PR DESCRIPTION
`UncheckedExtrinsic` is now generic over the AccountId, Signer and Address type. All types of substrate nodes should now be supported, no matter which Account types are used.
- introduced `SignExtrinsic` trait to simplify the `Address`, `AccountId` and `Signature` allocation as much as possible.
- The default implementation `ExtrinsicSigner` should be usable for most use cases, except for when no `Runtime` is used. In that case one still has to option to implement the trait oneselves.
- `UncheckedExtrinsic` now implements a `new_unsigned` function.

Drawback: `Signature` type needs to be defined explicitly. However, https://github.com/scs/substrate-api-client/issues/406 may help with that.


closes #360 