### PR TITLE
Remove thiserror

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5163,6 +5163,7 @@ dependencies = [
  "ac-compose-macros",
  "ac-node-api",
  "ac-primitives",
+ "derive_more",
  "frame-metadata 15.0.0 (git+https://github.com/paritytech/frame-metadata)",
  "frame-support",
  "futures",
@@ -5177,7 +5178,6 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "sp-runtime-interface",
- "thiserror-core",
  "tungstenite",
  "url",
  "ws",
@@ -5311,26 +5311,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
 dependencies = [
  "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-core"
-version = "1.0.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808e769db82353a456db04af0e76a4e211c5428516cead2b420dfa3d82cb83d3"
-dependencies = [
- "thiserror-core-impl",
-]
-
-[[package]]
-name = "thiserror-core-impl"
-version = "1.0.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7905b4dad6617f9e81544469da6bb1c658c02c6c7e420ee953d03687db1e1cfe"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,13 +20,11 @@ members = [
 [dependencies]
 # crates.io no_std
 codec = { package = "parity-scale-codec", version = "3.2.1", default-features = false, features = ['derive'] }
+derive_more = { version = "0.99.5" }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 log = { version = "0.4.14", default-features = false }
 serde = { version = "1.0.136", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.79", default-features = false }
-
-#FIXME: convert back to thiserror once possible #317
-thiserror = { version = "1.0", package = "thiserror-core", default-features = false }
 
 # crates.io std only
 url = { version = "2.0.0", optional = true }
@@ -69,7 +67,6 @@ std = [
     "log/std",
     "serde/std",
     "serde_json/std",
-    "thiserror/std",
     # crates.io std only
     "url",
     # substrate no_std

--- a/src/api/api_client.rs
+++ b/src/api/api_client.rs
@@ -243,7 +243,7 @@ where
 	fn get_genesis_hash(client: &Client) -> Result<Runtime::Hash> {
 		let genesis: Option<Runtime::Hash> =
 			client.request("chain_getBlockHash", rpc_params![Some(0)])?;
-		genesis.ok_or(Error::Genesis)
+		genesis.ok_or(Error::FetchGenesisHash)
 	}
 
 	/// Get runtime version from node via websocket query.

--- a/src/api/error.rs
+++ b/src/api/error.rs
@@ -24,70 +24,23 @@ use alloc::{boxed::Box, string::String};
 
 pub type Result<T> = core::result::Result<T, Error>;
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, derive_more::From)]
 pub enum Error {
-	#[error("Fetching genesis hash failed. Are you connected to the correct endpoint?")]
-	Genesis,
-	#[error("Fetching runtime version failed. Are you connected to the correct endpoint?")]
-	RuntimeVersion,
-	#[error("Fetching Metadata failed. Are you connected to the correct endpoint?")]
-	MetadataFetch,
-	#[error("Operation needs a signer to be set in the api")]
+	FetchGenesisHash,
+	FetchRuntimeVersion,
+	FetchMetadata,
 	NoSigner,
-	#[error("RpcClient error: {0:?}")]
-	RpcClient(#[from] RpcClientError),
-	#[error("Metadata Error: {0:?}")]
+	RpcClient(RpcClientError),
 	Metadata(MetadataError),
-	#[error("InvalidMetadata: {0:?}")]
 	InvalidMetadata(InvalidMetadataError),
-	#[error("Events Error: {0:?}")]
 	NodeApi(ac_node_api::error::Error),
-	#[error("Error decoding storage value: {0}")]
 	StorageValueDecode(codec::Error),
-	#[error("UnsupportedXtStatus Error: Can only wait for finalized, in block, broadcast and ready. Waited for: {0:?}")]
 	UnsupportedXtStatus(XtStatus),
-	#[error("Error converting NumberOrHex to Balance")]
 	TryFromIntError,
-	#[error("The node runtime could not dispatch an extrinsic")]
 	Dispatch(DispatchError),
-	#[error("Extrinsic Error: {0}")]
 	Extrinsic(String),
-	#[error("Stream ended unexpectedly")]
 	NoStream,
-	#[error("Expected a block hash")]
 	NoBlockHash,
-	#[error("Did not find any block")]
 	NoBlock,
-	#[error(transparent)]
-	Other(#[from] Box<dyn core::error::Error + Send + Sync + 'static>),
-}
-
-impl From<codec::Error> for Error {
-	fn from(error: codec::Error) -> Self {
-		Error::StorageValueDecode(error)
-	}
-}
-
-impl From<InvalidMetadataError> for Error {
-	fn from(error: InvalidMetadataError) -> Self {
-		Error::InvalidMetadata(error)
-	}
-}
-
-impl From<MetadataError> for Error {
-	fn from(error: MetadataError) -> Self {
-		Error::Metadata(error)
-	}
-}
-
-impl From<ac_node_api::error::Error> for Error {
-	fn from(error: ac_node_api::error::Error) -> Self {
-		Error::NodeApi(error)
-	}
-}
-
-impl From<ac_node_api::error::DispatchError> for Error {
-	fn from(error: ac_node_api::error::DispatchError) -> Self {
-		Error::Dispatch(error)
-	}
+	Other(Box<dyn core::error::Error + Send + Sync + 'static>),
 }

--- a/src/api/error.rs
+++ b/src/api/error.rs
@@ -27,8 +27,6 @@ pub type Result<T> = core::result::Result<T, Error>;
 #[derive(Debug, derive_more::From)]
 pub enum Error {
 	FetchGenesisHash,
-	FetchRuntimeVersion,
-	FetchMetadata,
 	NoSigner,
 	RpcClient(RpcClientError),
 	Metadata(MetadataError),

--- a/src/rpc/tungstenite_client/client.rs
+++ b/src/rpc/tungstenite_client/client.rs
@@ -141,7 +141,7 @@ fn subscribe_to_server(
 pub fn do_reconnect(error: &RpcClientError) -> bool {
 	matches!(
 		error,
-		RpcClientError::Serde(_) | RpcClientError::ConnectionClosed | RpcClientError::Client(_)
+		RpcClientError::SerdeJson(_) | RpcClientError::ConnectionClosed | RpcClientError::Client(_)
 	)
 }
 
@@ -173,7 +173,7 @@ fn attempt_connection_until(url: &Url, max_attempts: u8) -> Result<(MySocket, Re
 		current_attempt += 1;
 	}
 
-	Err(RpcClientError::ConnectionAttemptsExceeded)
+	Err(RpcClientError::MaxConnectionAttemptsExceeded)
 }
 
 fn read_until_text_message(socket: &mut MySocket) -> Result<String> {

--- a/src/rpc/ws_client/client.rs
+++ b/src/rpc/ws_client/client.rs
@@ -85,7 +85,6 @@ impl WsRpcClient {
 	where
 		MessageHandler: HandleMessage + Clone + Send + 'static,
 		MessageHandler::ThreadMessage: Send + Sync + Debug,
-		MessageHandler::Error: Into<ws::Error>,
 		MessageHandler::Context: From<MessageContext<MessageHandler::ThreadMessage>>,
 	{
 		let mut socket = ws::Builder::new().build(move |out| RpcClient {
@@ -116,7 +115,6 @@ impl WsRpcClient {
 	where
 		MessageHandler: HandleMessage + Clone + Send + 'static,
 		MessageHandler::ThreadMessage: Send + Sync + Debug,
-		MessageHandler::Error: Into<ws::Error>,
 		MessageHandler::Context: From<MessageContext<MessageHandler::ThreadMessage>>,
 	{
 		let (result_in, result_out) = channel();


### PR DESCRIPTION
- remove this error and replace with `derive_more` where possible. This should declutter some overly verbose error messages. Better for `no_std` environments.
- clean up some unused error values
- remove generic Result in ws client - not used anyway and makes it more complex than necessary
 
closes #317