### PR TITLE
Remove `wait_for_event` and simplify event access in `subscribe_events`

### DIFF
--- a/examples/examples/event_callback.rs
+++ b/examples/examples/event_callback.rs
@@ -13,22 +13,16 @@
 	limitations under the License.
 */
 
-//! Very simple example that shows how to subscribe to events.
+//! Example that shows how to subscribe to events and do some action
+//! upon encounterign them.
 
-use codec::Decode;
-use frame_support::dispatch::DispatchInfo;
-use kitchensink_runtime::Runtime;
 use log::debug;
 use sp_core::H256 as Hash;
-use substrate_api_client::{
-	rpc::{HandleSubscription, JsonrpseeClient},
-	Api, PlainTipExtrinsicParams, SubscribeFrameSystem,
-};
+use substrate_api_client::{rpc::JsonrpseeClient, Api, PlainTipExtrinsicParams, SubscribeEvents};
 
-// This module depends on node_runtime.
-// To avoid dependency collisions, node_runtime has been removed from the substrate-api-client library.
+// This module depends on the specific node runtime.
 // Replace this crate by your own if you run a custom substrate node to get your custom events.
-use kitchensink_runtime::RuntimeEvent;
+use kitchensink_runtime::{Runtime, RuntimeEvent};
 
 #[tokio::main]
 async fn main() {
@@ -38,26 +32,15 @@ async fn main() {
 	let client = JsonrpseeClient::with_default_url().unwrap();
 	let api = Api::<(), _, PlainTipExtrinsicParams<Runtime>, Runtime>::new(client).unwrap();
 
-	println!("Subscribe to a single event type");
-	let (sender, receiver) = channel();
-	let api2 = api.clone();
-	thread::spawn(move || {
-		api2.subscribe_for_event_type::<ExtrinsicSuccess>(sender).unwrap();
-	});
-
 	println!("Subscribe to events");
-	let mut subscription = api.subscribe_system_events().unwrap();
+	let mut subscription = api.subscribe_events().unwrap();
 
 	// Wait for event callbacks from the node, which are received via subscription.
 	for _ in 0..5 {
-		let event_bytes = subscription.next().unwrap().unwrap().changes[0].1.clone().unwrap().0;
-		let events = Vec::<frame_system::EventRecord<RuntimeEvent, Hash>>::decode(
-			&mut event_bytes.as_slice(),
-		)
-		.unwrap();
-		for evr in &events {
-			println!("decoded: {:?} {:?}", evr.phase, evr.event);
-			match &evr.event {
+		let event_records = subscription.next_event::<RuntimeEvent, Hash>().unwrap().unwrap();
+		for event_record in &event_records {
+			println!("decoded: {:?} {:?}", event_record.phase, event_record.event);
+			match &event_record.event {
 				RuntimeEvent::Balances(balances_event) => {
 					println!(">>>>>>>>>> balances event: {:?}", balances_event);
 					match &balances_event {
@@ -75,7 +58,7 @@ async fn main() {
 				RuntimeEvent::System(system_event) => {
 					println!(">>>>>>>>>> system event: {:?}", system_event);
 					match &system_event {
-						frame_system::Event::ExtrinsicSuccess { dispatch_info: DispatchInfo } => {
+						frame_system::Event::ExtrinsicSuccess { dispatch_info } => {
 							println!("DispatchInfo: {:?}", dispatch_info);
 							return
 						},
@@ -84,11 +67,14 @@ async fn main() {
 						},
 					}
 				},
-				_ => debug!("ignoring unsupported module event: {:?}", evr.event),
+				_ => debug!("ignoring unsupported module event: {:?}", event_record.event),
 			}
 		}
 	}
 
-	// After we finished whatever we wanted, unusubscribe from the subscription:
-	subscription.unsubscribe();
+	// After we finished whatever we wanted, unusubscribe from the subscription,
+	// to ensure, that the node does not keep sending us events.
+	// This is not mandatory. If the subscription goes out of scope, it should
+	// automatically unsubscribe from  the node.
+	subscription.unsubscribe().unwrap();
 }

--- a/examples/examples/event_callback.rs
+++ b/examples/examples/event_callback.rs
@@ -74,7 +74,5 @@ async fn main() {
 
 	// After we finished whatever we wanted, unusubscribe from the subscription,
 	// to ensure, that the node does not keep sending us events.
-	// This is not mandatory. If the subscription goes out of scope, it should
-	// automatically unsubscribe from  the node.
 	subscription.unsubscribe().unwrap();
 }

--- a/node-api/src/lib.rs
+++ b/node-api/src/lib.rs
@@ -70,6 +70,7 @@ pub trait StaticEvent: Decode {
 }
 
 /// A phase of a block's execution.
+// https://github.com/paritytech/substrate/blob/2bfc1dd66ef32cf8beb90007dfb544a9d28f1b2f/frame/system/src/lib.rs#L698-L708
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Encode, Decode)]
 pub enum Phase {
 	/// Applying an extrinsic.
@@ -78,4 +79,16 @@ pub enum Phase {
 	Finalization,
 	/// Initializing the block.
 	Initialization,
+}
+
+/// Record of an event happening.
+// https://github.com/paritytech/substrate/blob/2bfc1dd66ef32cf8beb90007dfb544a9d28f1b2f/frame/system/src/lib.rs#L716-L726
+#[derive(Encode, Decode, PartialEq, Eq, Clone)]
+pub struct EventRecord<E, T> {
+	/// The phase of the block it happened in.
+	pub phase: Phase,
+	/// The event itself.
+	pub event: E,
+	/// The list of the topics this event has.
+	pub topics: Vec<T>,
 }

--- a/src/api/rpc_api/events.rs
+++ b/src/api/rpc_api/events.rs
@@ -103,7 +103,6 @@ where
 		// changes in the set. Also, we don't care about the key but only the data, so take
 		// the second value in the tuple of two.
 		let storage_data = change_set.changes[0].1.as_ref()?;
-		// Decode to the expected EventRecord type.
 		let events = Decode::decode(&mut storage_data.0.as_slice()).map_err(Error::Codec);
 		Some(events)
 	}

--- a/src/api/rpc_api/events.rs
+++ b/src/api/rpc_api/events.rs
@@ -103,7 +103,7 @@ where
 		// changes in the set. Also, we don't care about the key but only the data, so take
 		// the second value in the tuple of two.
 		let storage_data = change_set.changes[0].1.as_ref()?;
-		// Decode to the expected EventRecord type:
+		// Decode to the expected EventRecord type.
 		let events = Decode::decode(&mut storage_data.0.as_slice()).map_err(Error::Codec);
 		Some(events)
 	}

--- a/src/api/rpc_api/events.rs
+++ b/src/api/rpc_api/events.rs
@@ -97,7 +97,7 @@ where
 	) -> Option<Result<Vec<EventRecord<RuntimeEvent, Topic>>>> {
 		let change_set = match self.subscription.next()? {
 			Ok(set) => set,
-			Err(e) => return Some(Err(e).map_err(Error::RpcClient)),
+			Err(e) => return Some(Err(Error::RpcClient(e))),
 		};
 		// Since we subscribed to only the events key, we can simply take the first value of the
 		// changes in the set. Also, we don't care about the key but only the data, so take

--- a/src/api/rpc_api/events.rs
+++ b/src/api/rpc_api/events.rs
@@ -14,10 +14,10 @@
 use crate::{
 	api::{Api, Error, Result},
 	rpc::{HandleSubscription, Request, Subscribe},
-	GetBlock, GetStorage, Phase,
+	GetBlock, GetStorage, Phase, SubscribeFrameSystem,
 };
 use ac_node_api::{EventDetails, Events, StaticEvent};
-use ac_primitives::{ExtrinsicParams, FrameSystemConfig, StorageChangeSet};
+use ac_primitives::{ExtrinsicParams, FrameSystemConfig};
 use alloc::vec::Vec;
 use codec::Encode;
 use log::*;
@@ -70,76 +70,69 @@ where
 	}
 }
 
-// FIXME: This should rather be implemented directly on the
-// Subscription return value, rather than the api. Or directly
-// subcribe. Should be looked at in #288
-// https://github.com/scs/substrate-api-client/issues/288#issuecomment-1346221653
-pub trait SubscribeEvents<Client, Hash>
-where
-	Client: Subscribe,
-	Hash: DeserializeOwned,
-{
-	fn wait_for_event<Ev: StaticEvent>(
-		&self,
-		subscription: &mut Client::Subscription<StorageChangeSet<Hash>>,
-	) -> Result<Ev>;
-
-	fn wait_for_event_details<Ev: StaticEvent>(
-		&self,
-		subscription: &mut Client::Subscription<StorageChangeSet<Hash>>,
-	) -> Result<EventDetails>;
-}
-
-impl<Signer, Client, Params, Runtime> SubscribeEvents<Client, Runtime::Hash>
-	for Api<Signer, Client, Params, Runtime>
-where
-	Client: Subscribe,
-	Params: ExtrinsicParams<Runtime::Index, Runtime::Hash>,
-	Runtime: FrameSystemConfig,
-{
-	fn wait_for_event<Ev: StaticEvent>(
-		&self,
-		subscription: &mut Client::Subscription<StorageChangeSet<Runtime::Hash>>,
-	) -> Result<Ev> {
-		let maybe_event_details = self.wait_for_event_details::<Ev>(subscription)?;
-		maybe_event_details
-			.as_event()?
-			.ok_or(Error::Other("Could not find the specific event".into()))
+#[cfg(feature = "std")]
+pub use std_only::*;
+#[cfg(feature = "std")]
+mod std_only {
+	use super::*;
+	use std::{marker::Sync, sync::mpsc::Sender};
+	pub trait SubscribeEvents<Client, Hash>
+	where
+		Client: Subscribe,
+		Hash: DeserializeOwned,
+	{
+		/// Listens for a specific event type and notifies updates via channel.
+		/// This function is an endless loop and only returns if the subscription has failed or
+		/// no new notifications are received. Which may happen if the node connection is down.
+		fn subscribe_for_event_type<Ev: StaticEvent + Sync + Send + 'static>(
+			&self,
+			sender: Sender<Ev>,
+		) -> Result<()>;
 	}
 
-	fn wait_for_event_details<Ev: StaticEvent>(
-		&self,
-		subscription: &mut Client::Subscription<StorageChangeSet<Runtime::Hash>>,
-	) -> Result<EventDetails> {
-		while let Some(change_set) = subscription.next() {
-			let event_bytes = change_set?.changes[0].1.as_ref().unwrap().0.clone();
-			let events = Events::<Runtime::Hash>::new(
-				self.metadata().clone(),
-				Default::default(),
-				event_bytes,
-			);
-			for maybe_event_details in events.iter() {
-				let event_details = maybe_event_details?;
+	#[cfg(feature = "std")]
+	impl<Signer, Client, Params, Runtime> SubscribeEvents<Client, Runtime::Hash>
+		for Api<Signer, Client, Params, Runtime>
+	where
+		Client: Subscribe,
+		Params: ExtrinsicParams<Runtime::Index, Runtime::Hash>,
+		Runtime: FrameSystemConfig,
+	{
+		fn subscribe_for_event_type<Ev: StaticEvent + Sync + Send + 'static>(
+			&self,
+			sender: Sender<Ev>,
+		) -> Result<()> {
+			let mut subscription = self.subscribe_system_events()?;
 
-				// Check for failed xt and return as Dispatch Error in case we find one.
-				// Careful - this reports the first one encountered. This event may belong to another extrinsic
-				// than the one that is being waited for.
-				event_details.check_if_failed()?;
-
-				let event_metadata = event_details.event_metadata();
-				trace!(
-					"Found extrinsic: {:?}, {:?}",
-					event_metadata.pallet(),
-					event_metadata.event()
-				);
-				if event_metadata.pallet() == Ev::PALLET && event_metadata.event() == Ev::EVENT {
-					return Ok(event_details)
-				} else {
-					trace!("Not the event we are looking for, skipping.")
+			while let Some(Ok(change_set)) = subscription.next() {
+				// We only subscribed to one key, so always take the first value of the change set.
+				if let Some(storage_data) = &change_set.changes[0].1 {
+					let events = Events::<Runtime::Hash>::new(
+						self.metadata().clone(),
+						Default::default(),
+						storage_data.0.clone(),
+					);
+					for event_details in events.iter().flatten() {
+						match event_details.as_event::<Ev>() {
+							Ok(Some(event)) => {
+								sender.send(event).map_err(|e| Error::Other(Box::new(e)))?;
+							},
+							Ok(None) => {
+								trace!(
+									"Found extrinsic: {:?}, {:?}",
+									event_details.event_metadata().pallet(),
+									event_details.event_metadata().event()
+								);
+								trace!("Not the event we are looking for, skipping.");
+							},
+							Err(_) => error!("Could not decode event details."),
+						}
+					}
 				}
 			}
+
+			Ok(())
 		}
-		Err(Error::NoStream)
 	}
 }
 

--- a/src/api/rpc_api/events.rs
+++ b/src/api/rpc_api/events.rs
@@ -11,8 +11,6 @@
    limitations under the License.
 */
 
-use core::marker::PhantomData;
-
 use crate::{
 	api::{Api, Error, Result},
 	rpc::{HandleSubscription, Request, Subscribe},
@@ -23,6 +21,7 @@ use ac_node_api::{EventDetails, EventRecord, Events};
 use ac_primitives::{ExtrinsicParams, FrameSystemConfig, StorageChangeSet};
 use alloc::{vec, vec::Vec};
 use codec::{Decode, Encode};
+use core::marker::PhantomData;
 use log::*;
 use serde::de::DeserializeOwned;
 use sp_runtime::traits::{Block as BlockTrait, GetRuntimeBlockType, Hash as HashTrait};

--- a/src/api/rpc_api/events.rs
+++ b/src/api/rpc_api/events.rs
@@ -83,7 +83,7 @@ mod std_only {
 	{
 		/// Listens for a specific event type and notifies updates via channel.
 		/// This function is an endless loop and only returns if the subscription has failed or
-		/// no new notifications are received. Which may happen if the node connection is down.
+		/// no new notifications are received. This may happen if the node connection is down.
 		fn subscribe_for_event_type<Ev: StaticEvent + Sync + Send + 'static>(
 			&self,
 			sender: Sender<Ev>,

--- a/src/api/rpc_api/events.rs
+++ b/src/api/rpc_api/events.rs
@@ -21,7 +21,7 @@ use crate::{
 use ac_compose_macros::rpc_params;
 use ac_node_api::{EventDetails, EventRecord, Events};
 use ac_primitives::{ExtrinsicParams, FrameSystemConfig, StorageChangeSet};
-use alloc::vec::Vec;
+use alloc::{vec, vec::Vec};
 use codec::{Decode, Encode};
 use log::*;
 use serde::de::DeserializeOwned;

--- a/src/api/rpc_api/events.rs
+++ b/src/api/rpc_api/events.rs
@@ -110,8 +110,7 @@ where
 
 	/// Unsubscribe from the internal subscription.
 	pub fn unsubscribe(self) -> Result<()> {
-		self.subscription.unsubscribe()?;
-		Ok(())
+		self.subscription.unsubscribe().map_err(|e| e.into())
 	}
 }
 

--- a/src/api/rpc_api/events.rs
+++ b/src/api/rpc_api/events.rs
@@ -147,7 +147,6 @@ where
 	) -> Result<
 		EventSubscription<Client::Subscription<StorageChangeSet<Runtime::Hash>>, Runtime::Hash>,
 	> {
-		debug!("subscribing to events");
 		let key = crate::storage_key("System", "Events");
 		let subscription = self
 			.client()

--- a/src/api/rpc_api/events.rs
+++ b/src/api/rpc_api/events.rs
@@ -75,12 +75,12 @@ where
 
 /// Wrapper around a Event `StorageChangeSet` subscription.
 /// Simplifies the event retrieval from the subscription.
-pub struct EventSubcription<Subscription, Hash> {
+pub struct EventSubscription<Subscription, Hash> {
 	pub subscription: Subscription,
 	_phantom: PhantomData<Hash>,
 }
 
-impl<Subscription, Hash> EventSubcription<Subscription, Hash>
+impl<Subscription, Hash> EventSubscription<Subscription, Hash>
 where
 	Hash: DeserializeOwned,
 	Subscription: HandleSubscription<StorageChangeSet<Hash>>,
@@ -114,13 +114,13 @@ where
 	}
 }
 
-impl<Subscription, Hash> From<Subscription> for EventSubcription<Subscription, Hash>
+impl<Subscription, Hash> From<Subscription> for EventSubscription<Subscription, Hash>
 where
 	Hash: DeserializeOwned,
 	Subscription: HandleSubscription<StorageChangeSet<Hash>>,
 {
 	fn from(subscription: Subscription) -> Self {
-		EventSubcription::new(subscription)
+		EventSubscription::new(subscription)
 	}
 }
 
@@ -132,7 +132,7 @@ where
 	/// Subscribe to events.
 	fn subscribe_events(
 		&self,
-	) -> Result<EventSubcription<Client::Subscription<StorageChangeSet<Hash>>, Hash>>;
+	) -> Result<EventSubscription<Client::Subscription<StorageChangeSet<Hash>>, Hash>>;
 }
 
 impl<Signer, Client, Params, Runtime> SubscribeEvents<Client, Runtime::Hash>
@@ -145,7 +145,7 @@ where
 	fn subscribe_events(
 		&self,
 	) -> Result<
-		EventSubcription<Client::Subscription<StorageChangeSet<Runtime::Hash>>, Runtime::Hash>,
+		EventSubscription<Client::Subscription<StorageChangeSet<Runtime::Hash>>, Runtime::Hash>,
 	> {
 		debug!("subscribing to events");
 		let key = crate::storage_key("System", "Events");

--- a/src/api/rpc_api/frame_system.rs
+++ b/src/api/rpc_api/frame_system.rs
@@ -15,15 +15,12 @@
 
 use crate::{
 	api::{Api, GetStorage, Result},
-	rpc::{Request, Subscribe},
+	rpc::Request,
 };
 use ac_compose_macros::rpc_params;
-use ac_primitives::{
-	AccountInfo, ExtrinsicParams, FrameSystemConfig, SignExtrinsic, StorageChangeSet, StorageKey,
-};
-use alloc::{string::String, vec, vec::Vec};
+use ac_primitives::{AccountInfo, ExtrinsicParams, FrameSystemConfig, SignExtrinsic, StorageKey};
+use alloc::{string::String, vec::Vec};
 use log::*;
-use serde::de::DeserializeOwned;
 
 pub trait GetAccountInformation<AccountId> {
 	type Index;
@@ -156,31 +153,5 @@ where
 	fn get_system_local_listen_addresses(&self) -> Result<Vec<String>> {
 		let res = self.client().request("system_localListenAddresses", rpc_params![])?;
 		Ok(res)
-	}
-}
-
-pub trait SubscribeFrameSystem<Client, Hash>
-where
-	Client: Subscribe,
-	Hash: DeserializeOwned,
-{
-	fn subscribe_system_events(&self) -> Result<Client::Subscription<StorageChangeSet<Hash>>>;
-}
-
-impl<Signer, Client, Params, Runtime> SubscribeFrameSystem<Client, Runtime::Hash>
-	for Api<Signer, Client, Params, Runtime>
-where
-	Client: Subscribe,
-	Params: ExtrinsicParams<Runtime::Index, Runtime::Hash>,
-	Runtime: FrameSystemConfig,
-{
-	fn subscribe_system_events(
-		&self,
-	) -> Result<Client::Subscription<StorageChangeSet<Runtime::Hash>>> {
-		debug!("subscribing to events");
-		let key = crate::storage_key("System", "Events");
-		self.client()
-			.subscribe("state_subscribeStorage", rpc_params![vec![key]], "state_unsubscribeStorage")
-			.map_err(|e| e.into())
 	}
 }

--- a/testing/examples/events_tests.rs
+++ b/testing/examples/events_tests.rs
@@ -78,43 +78,6 @@ async fn main() {
 				_ => panic!("Unexpected event"),
 			}
 		}
-
-		// let events = Vec::<frame_system::EventRecord<RuntimeEvent, Hash>>::decode(
-		// 	&mut event_bytes.as_slice(),
-		// )
-		// .unwrap();
-		// for evr in &events {
-		// 	println!("decoded: {:?} {:?}", evr.phase, evr.event);
-		// 	match &evr.event {
-		// 		RuntimeEvent::Balances(balances_event) => {
-		// 			println!(">>>>>>>>>> balances event: {:?}", balances_event);
-		// 			match &balances_event {
-		// 				pallet_balances::Event::Transfer { from, to, amount } => {
-		// 					println!("Transactor: {:?}", from);
-		// 					println!("Destination: {:?}", to);
-		// 					println!("Value: {:?}", amount);
-		// 					return
-		// 				},
-		// 				_ => {
-		// 					debug!("ignoring unsupported balances event");
-		// 				},
-		// 			}
-		// 		},
-		// 		RuntimeEvent::System(system_event) => {
-		// 			println!(">>>>>>>>>> system event: {:?}", system_event);
-		// 			match &system_event {
-		// 				frame_system::Event::ExtrinsicSuccess { dispatch_info: DispatchInfo } => {
-		// 					println!("DispatchInfo: {:?}", dispatch_info);
-		// 					return
-		// 				},
-		// 				_ => {
-		// 					debug!("ignoring unsupported system event");
-		// 				},
-		// 			}
-		// 		},
-		// 		_ => debug!("ignoring unsupported module event: {:?}", evr.event),
-		// 	}
-		// }
 	}
 }
 

--- a/testing/examples/events_tests.rs
+++ b/testing/examples/events_tests.rs
@@ -17,11 +17,12 @@
 
 use codec::Decode;
 use frame_support::dispatch::DispatchInfo;
-use kitchensink_runtime::{Runtime, Signature};
+use kitchensink_runtime::{Runtime, RuntimeEvent, Signature};
 use sp_keyring::AccountKeyring;
 use substrate_api_client::{
 	extrinsic::BalancesExtrinsics, rpc::JsonrpseeClient, Api, AssetTipExtrinsicParams,
-	EventDetails, ExtrinsicSigner, FetchEvents, GetBlock, StaticEvent, SubmitAndWatch, XtStatus,
+	EventDetails, ExtrinsicSigner, FetchEvents, FrameSystemConfig, GetBlock, StaticEvent,
+	SubmitAndWatch, SubscribeEvents, XtStatus,
 };
 
 /// Check out frame_system::Event::ExtrinsicSuccess:
@@ -60,6 +61,61 @@ async fn main() {
 		.fetch_events_for_extrinsic(report.extrinsic_hash, report.block_hash.unwrap())
 		.unwrap();
 	assert_assosciated_events_match_expected(extrinisc_events);
+
+	// Subscribe to system events.
+	let mut event_subscription = api.subscribe_events().unwrap();
+
+	// Wait for event callbacks from the node, which are received via subscription.
+	for _ in 0..5 {
+		let event_records = event_subscription
+			.next_event::<RuntimeEvent, <Runtime as FrameSystemConfig>::Hash>()
+			.unwrap()
+			.unwrap();
+		for event_record in &event_records {
+			println!("got event: {:?} {:?}", event_record.phase, event_record.event);
+			match &event_record.event {
+				RuntimeEvent::System(_) => println!("Got System event, all good"),
+				_ => panic!("Unexpected event"),
+			}
+		}
+
+		// let events = Vec::<frame_system::EventRecord<RuntimeEvent, Hash>>::decode(
+		// 	&mut event_bytes.as_slice(),
+		// )
+		// .unwrap();
+		// for evr in &events {
+		// 	println!("decoded: {:?} {:?}", evr.phase, evr.event);
+		// 	match &evr.event {
+		// 		RuntimeEvent::Balances(balances_event) => {
+		// 			println!(">>>>>>>>>> balances event: {:?}", balances_event);
+		// 			match &balances_event {
+		// 				pallet_balances::Event::Transfer { from, to, amount } => {
+		// 					println!("Transactor: {:?}", from);
+		// 					println!("Destination: {:?}", to);
+		// 					println!("Value: {:?}", amount);
+		// 					return
+		// 				},
+		// 				_ => {
+		// 					debug!("ignoring unsupported balances event");
+		// 				},
+		// 			}
+		// 		},
+		// 		RuntimeEvent::System(system_event) => {
+		// 			println!(">>>>>>>>>> system event: {:?}", system_event);
+		// 			match &system_event {
+		// 				frame_system::Event::ExtrinsicSuccess { dispatch_info: DispatchInfo } => {
+		// 					println!("DispatchInfo: {:?}", dispatch_info);
+		// 					return
+		// 				},
+		// 				_ => {
+		// 					debug!("ignoring unsupported system event");
+		// 				},
+		// 			}
+		// 		},
+		// 		_ => debug!("ignoring unsupported module event: {:?}", evr.event),
+		// 	}
+		// }
+	}
 }
 
 fn assert_assosciated_events_match_expected(events: Vec<EventDetails>) {

--- a/testing/examples/frame_system_tests.rs
+++ b/testing/examples/frame_system_tests.rs
@@ -51,26 +51,26 @@ async fn main() {
 
 	// System Api
 	let system_name = api.get_system_name().unwrap();
-	println!("System name: {}", system_name);
+	println!("System name: {system_name}");
 
 	let system_version = api.get_system_version().unwrap();
-	println!("System version: {}", system_version);
+	println!("System version: {system_version}");
 
 	let system_chain = api.get_system_chain().unwrap();
-	println!("System chain: {}", system_chain);
+	println!("System chain: {system_chain}");
 
 	let system_chain_type = api.get_system_chain_type().unwrap();
-	println!("System chain type: {:?}", system_chain_type);
+	println!("System chain type: {system_chain_type:?}");
 
 	let system_properties = api.get_system_properties().unwrap();
-	println!("System properties: {:?}", system_properties);
+	println!("System properties: {system_properties:?}");
 
 	let system_health = api.get_system_health().unwrap();
-	println!("System health: {}", system_health);
+	println!("System health: {system_health}");
 
 	let system_local_peer_id = api.get_system_local_peer_id().unwrap();
-	println!("System local peer id: {:?}", system_local_peer_id);
+	println!("System local peer id: {system_local_peer_id:?}");
 
 	let system_local_listen_addresses = api.get_system_local_listen_addresses().unwrap();
-	println!("System local listen addresses: {:?}", system_local_listen_addresses);
+	println!("System local listen addresses: {system_local_listen_addresses:?}");
 }

--- a/testing/examples/frame_system_tests.rs
+++ b/testing/examples/frame_system_tests.rs
@@ -19,13 +19,14 @@ use codec::Decode;
 use frame_support::dispatch::DispatchInfo;
 use kitchensink_runtime::{Runtime, Signature};
 use sp_keyring::AccountKeyring;
+use std::{sync::mpsc::channel, thread};
 use substrate_api_client::{
 	rpc::JsonrpseeClient, Api, AssetTipExtrinsicParams, ExtrinsicSigner, GetAccountInformation,
 	StaticEvent, SubscribeEvents, SubscribeFrameSystem, SystemApi,
 };
 
 /// Check out frame_system::Event::ExtrinsicSuccess:
-#[derive(Decode)]
+#[derive(Decode, Debug)]
 struct ExtrinsicSuccess {
 	_dispatch_info: DispatchInfo,
 }
@@ -74,10 +75,18 @@ async fn main() {
 	let system_local_listen_addresses = api.get_system_local_listen_addresses().unwrap();
 	println!("System local listen addresses: {:?}", system_local_listen_addresses);
 
-	// Subscribe
-	let mut event_subscription = api.subscribe_system_events().unwrap();
-	let _event: ExtrinsicSuccess = api.wait_for_event(&mut event_subscription).unwrap();
-	let _event_details =
-		api.wait_for_event_details::<ExtrinsicSuccess>(&mut event_subscription).unwrap();
-	println!("Success: Wait for event Details");
+	// Subscribe to system events.
+	let _event_subscription = api.subscribe_system_events().unwrap();
+
+	// Subscribe to system events in a never ending loop. Could be useful wherever a specific event should trigger something.
+	let (sender, receiver) = channel();
+	let api2 = api.clone();
+	thread::spawn(move || {
+		api2.subscribe_for_event_type::<ExtrinsicSuccess>(sender).unwrap();
+	});
+	// Wait for event callbacks from the node, which are received via subscription.
+	for _ in 0..5 {
+		let event_update = receiver.recv();
+		println!("Received event update: {event_update:?}");
+	}
 }

--- a/testing/examples/frame_system_tests.rs
+++ b/testing/examples/frame_system_tests.rs
@@ -19,10 +19,9 @@ use codec::Decode;
 use frame_support::dispatch::DispatchInfo;
 use kitchensink_runtime::{Runtime, Signature};
 use sp_keyring::AccountKeyring;
-use std::{sync::mpsc::channel, thread};
 use substrate_api_client::{
 	rpc::JsonrpseeClient, Api, AssetTipExtrinsicParams, ExtrinsicSigner, GetAccountInformation,
-	StaticEvent, SubscribeEvents, SubscribeFrameSystem, SystemApi,
+	StaticEvent, SystemApi,
 };
 
 /// Check out frame_system::Event::ExtrinsicSuccess:
@@ -74,19 +73,4 @@ async fn main() {
 
 	let system_local_listen_addresses = api.get_system_local_listen_addresses().unwrap();
 	println!("System local listen addresses: {:?}", system_local_listen_addresses);
-
-	// Subscribe to system events.
-	let _event_subscription = api.subscribe_system_events().unwrap();
-
-	// Subscribe to system events in a never ending loop. Could be useful wherever a specific event should trigger something.
-	let (sender, receiver) = channel();
-	let api2 = api.clone();
-	thread::spawn(move || {
-		api2.subscribe_for_event_type::<ExtrinsicSuccess>(sender).unwrap();
-	});
-	// Wait for event callbacks from the node, which are received via subscription.
-	for _ in 0..5 {
-		let event_update = receiver.recv();
-		println!("Received event update: {event_update:?}");
-	}
 }


### PR DESCRIPTION
Removes the obsolete `wait_for_event` functions. I don't see the use case of these functions any more.

In addition, the event subscription has been updated:
- Renames `subscribe_frame_events` to `subscribe_events` and moved to more fitting `event.rs` instead of the frame_system file.
- Instead of returning the `StorageChangeSet`, which required quite some type insight to retrieve the events from it, a struct `EventSubscription` is returned. Upon `next_event` it directly tries to retrieve the events.

closes #413