### PR TITLE
Udpate toml versions for tag v0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,7 @@ dependencies = [
 
 [[package]]
 name = "ac-compose-macros"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "ac-primitives",
  "log",
@@ -26,7 +26,7 @@ dependencies = [
 
 [[package]]
 name = "ac-examples"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "env_logger",
  "frame-support",
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "ac-node-api"
-version = "0.2.3"
+version = "0.3.0"
 dependencies = [
  "ac-primitives",
  "bitvec",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "ac-primitives"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "frame-system",
  "hex",
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "ac-testing"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5294,7 +5294,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-api-client"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "ac-compose-macros",
  "ac-node-api",
@@ -5334,7 +5334,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-client-keystore"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,7 @@ dependencies = [
 
 [[package]]
 name = "ac-compose-macros"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "ac-primitives",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-api-client"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Supercomputing Systems AG <info@scs.ch>"]
 license = "Apache-2.0"
 edition = "2021"

--- a/client-keystore/Cargo.toml
+++ b/client-keystore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-client-keystore"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Supercomputing Systems AG <info@scs.ch>"]
 license = "Apache-2.0"
 edition = "2021"

--- a/compose-macros/Cargo.toml
+++ b/compose-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ac-compose-macros"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["Supercomputing Systems AG <info@scs.ch>"]
 license = "Apache-2.0"
 edition = "2021"

--- a/compose-macros/Cargo.toml
+++ b/compose-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ac-compose-macros"
-version = "0.2.4"
+version = "0.3.0"
 authors = ["Supercomputing Systems AG <info@scs.ch>"]
 license = "Apache-2.0"
 edition = "2021"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ac-examples"
-version = "0.2.0"
+version = "0.3.0"
 license = "Apache-2.0"
 edition = "2021"
 

--- a/node-api/Cargo.toml
+++ b/node-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ac-node-api"
-version = "0.2.3"
+version = "0.3.0"
 license = "Apache-2.0"
 edition = "2021"
 

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ac-primitives"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Supercomputing Systems AG <info@scs.ch>"]
 license = "Apache-2.0"
 edition = "2021"

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ac-testing"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Supercomputing Systems AG <info@scs.ch>"]
 license = "Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
Changes can be looked up here: https://github.com/scs/substrate-api-client/compare/v0.10.0...v0.11.0

Summary:
- `api-client`: ⚡  Contains breaking changes due to function renaming and pub re-exports removals.
- `client-keystore`:  ⚡  Breaking changes due to substrate update
- `compose-macros`:  ⚡  Breaking changes due to `pub use rpc::*` removal
- `examples`:  ⚡  follow the breaking changes of substrate
- `node-api`:  ⚡  breaking changes due to more restrictive public re-export
- `primitives`: ⚡  breaking changes due to more restrictive public re-export and file moving
- `testing`: ⚡  follow the breaking changes of substrate