### PR TITLE
Explicitly state edition in rustfmt.toml

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,4 +1,5 @@
 # Basic
+edition = "2021"
 hard_tabs = true
 max_width = 100
 use_small_heuristics = "Max"


### PR DESCRIPTION
Explicitly state the edition as CLion is somehow not able to correctly pick up the edition when using rustfmt. 
I guess rustfmt is not being executed with `cargo` and then it defaults to `2015`:
https://rust-lang.github.io/rustfmt/?version=v1.5.1&search=#edition
Then CLion constantly complains when using newer features such as `async`...
