### PR TITLE
Clarify distinction of `Metadata` struct and internal `metadata` field

### DIFF
--- a/examples/examples/print_metadata.rs
+++ b/examples/examples/print_metadata.rs
@@ -18,9 +18,7 @@
 
 use kitchensink_runtime::Runtime;
 use sp_core::sr25519;
-use substrate_api_client::{
-	ac_node_api::Metadata, ac_primitives::PlainTipExtrinsicParams, rpc::JsonrpseeClient, Api,
-};
+use substrate_api_client::{ac_primitives::PlainTipExtrinsicParams, rpc::JsonrpseeClient, Api};
 
 #[tokio::main]
 async fn main() {
@@ -44,5 +42,5 @@ async fn main() {
 	api.update_runtime().unwrap();
 
 	// Print full substrate metadata json formatted.
-	println!("{}", Metadata::pretty_format(&api.metadata().metadata).unwrap())
+	println!("{}", (&api.metadata().pretty_format().unwrap()))
 }


### PR DESCRIPTION
To make it more obvious to the user what's the difference between `Metadata` and `metadata` the following is updated:
- renamed `metadata` to `runtime_metadata`
- Added explanatory comment to `Metadata`struct
- `pretty_format` now takes self as argument and returns an error instead of an Option (which resulted in information loss in case of an error)

closes #493