### PR TITLE
Expand chain api

### DIFF
--- a/examples/examples/compose_extrinsic_offline.rs
+++ b/examples/examples/compose_extrinsic_offline.rs
@@ -22,7 +22,7 @@ use sp_runtime::{generic::Era, MultiAddress};
 use substrate_api_client::{
 	ac_primitives::{AssetTipExtrinsicParams, ExtrinsicSigner, GenericAdditionalParams},
 	rpc::JsonrpseeClient,
-	Api, GetHeader, SubmitAndWatch, XtStatus,
+	Api, GetChainInfo, SubmitAndWatch, XtStatus,
 };
 
 #[tokio::main]

--- a/examples/examples/custom_nonce.rs
+++ b/examples/examples/custom_nonce.rs
@@ -22,7 +22,7 @@ use sp_runtime::{generic::Era, MultiAddress};
 use substrate_api_client::{
 	ac_primitives::{AssetTipExtrinsicParams, ExtrinsicSigner, GenericAdditionalParams},
 	rpc::JsonrpseeClient,
-	Api, Error, GetHeader, SubmitAndWatch, UnexpectedTxStatus, XtStatus,
+	Api, Error, GetChainInfo, SubmitAndWatch, UnexpectedTxStatus, XtStatus,
 };
 
 #[tokio::main]

--- a/examples/examples/get_blocks.rs
+++ b/examples/examples/get_blocks.rs
@@ -21,7 +21,7 @@ use sp_core::sr25519;
 use substrate_api_client::{
 	ac_primitives::PlainTipExtrinsicParams,
 	rpc::{HandleSubscription, JsonrpseeClient},
-	Api, GetBlock, GetHeader, SubscribeChain,
+	Api, GetChainInfo, SubscribeChain,
 };
 
 #[tokio::main]

--- a/examples/examples/get_blocks.rs
+++ b/examples/examples/get_blocks.rs
@@ -38,15 +38,17 @@ async fn main() {
 	let header_hash = api.get_finalized_head().unwrap().unwrap();
 	println!("Latest Finalized Header Hash:\n {} \n", header_hash);
 
-	let h = api.get_header(Some(header_hash)).unwrap().unwrap();
-	println!("Finalized header:\n {:?} \n", h);
+	let header = api.get_header(Some(header_hash)).unwrap().unwrap();
+	println!("Finalized header:\n {:?} \n", header);
 
-	let b = api.get_finalized_block().unwrap().unwrap();
-	println!("Finalized block:\n {:?} \n", b);
-	let last_block_number = b.block.header.number;
-	let block_numbers = std::cmp::max(0, last_block_number - 3)..last_block_number;
-	let block_numbers = block_numbers.collect::<Vec<_>>();
-	let blocks = api.get_signed_blocks(&block_numbers).unwrap();
+	let signed_block = api.get_finalized_block().unwrap().unwrap();
+	println!("Finalized block:\n {:?} \n", signed_block);
+
+	let last_block_number = signed_block.block.header.number;
+	// Get the previous three blocks of the last_block_number
+	let number_of_last_three_blocks: Vec<_> =
+		(last_block_number.saturating_sub(3)..last_block_number).collect();
+	let blocks = api.get_signed_blocks(&number_of_last_three_blocks).unwrap();
 	for (i, b) in blocks.iter().enumerate() {
 		println!("Block {} has number: {}", i, b.block.header.number);
 	}

--- a/examples/examples/get_blocks.rs
+++ b/examples/examples/get_blocks.rs
@@ -43,6 +43,13 @@ async fn main() {
 
 	let b = api.get_finalized_block().unwrap().unwrap();
 	println!("Finalized block:\n {:?} \n", b);
+	let last_block_number = b.block.header.number;
+	let block_numbers = std::cmp::max(0, last_block_number - 3)..last_block_number;
+	let block_numbers = block_numbers.collect::<Vec<_>>();
+	let blocks = api.get_signed_blocks(&block_numbers).unwrap();
+	for (i, b) in blocks.iter().enumerate() {
+		println!("Block {} has number: {}", i, b.block.header.number);
+	}
 
 	println!("Latest Header: \n {:?} \n", api.get_header(None).unwrap());
 

--- a/examples/examples/get_blocks.rs
+++ b/examples/examples/get_blocks.rs
@@ -49,8 +49,9 @@ async fn main() {
 	let number_of_last_three_blocks: Vec<_> =
 		(last_block_number.saturating_sub(3)..last_block_number).collect();
 	let blocks = api.get_signed_blocks(&number_of_last_three_blocks).unwrap();
+	println!("Block numbers of the previous three blocks: ");
 	for (i, b) in blocks.iter().enumerate() {
-		println!("Block {} has number: {}", i, b.block.header.number);
+		println!("  Block {} has block number {}", i, b.block.header.number);
 	}
 
 	println!("Latest Header: \n {:?} \n", api.get_header(None).unwrap());

--- a/examples/examples/get_blocks.rs
+++ b/examples/examples/get_blocks.rs
@@ -33,7 +33,7 @@ async fn main() {
 	let api =
 		Api::<sr25519::Pair, _, PlainTipExtrinsicParams<Runtime>, Runtime>::new(client).unwrap();
 
-	println!("Genesis block: \n {:?} \n", api.get_block_by_num(Some(0)).unwrap());
+	println!("Genesis block: \n {:?} \n", api.get_genesis_block().unwrap());
 
 	let header_hash = api.get_finalized_head().unwrap().unwrap();
 	println!("Latest Finalized Header Hash:\n {} \n", header_hash);
@@ -41,8 +41,8 @@ async fn main() {
 	let h = api.get_header(Some(header_hash)).unwrap().unwrap();
 	println!("Finalized header:\n {:?} \n", h);
 
-	let b = api.get_signed_block(Some(header_hash)).unwrap().unwrap();
-	println!("Finalized signed block:\n {:?} \n", b);
+	let b = api.get_finalized_block().unwrap().unwrap();
+	println!("Finalized block:\n {:?} \n", b);
 
 	println!("Latest Header: \n {:?} \n", api.get_header(None).unwrap());
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -23,7 +23,7 @@ use serde::{Deserialize, Serialize};
 pub use api_client::Api;
 pub use error::{Error, Result};
 pub use rpc_api::{
-	FetchEvents, GetAccountInformation, GetBalance, GetBlock, GetHeader, GetStorage,
+	FetchEvents, GetAccountInformation, GetBalance, GetChainInfo, GetStorage,
 	GetTransactionPayment, SubmitAndWatch, SubmitAndWatchUntilSuccess, SubmitExtrinsic,
 	SubscribeChain, SubscribeEvents, SystemApi,
 };

--- a/src/api/rpc_api/author.rs
+++ b/src/api/rpc_api/author.rs
@@ -267,6 +267,7 @@ where
 	Runtime: FrameSystemConfig + GetRuntimeBlockType,
 	Runtime::RuntimeBlock: BlockTrait + DeserializeOwned,
 	Runtime::Hashing: HashTrait<Output = Runtime::Hash>,
+	Runtime::Header: DeserializeOwned,
 {
 	type Client = Client;
 	type Hash = Runtime::Hash;

--- a/src/api/rpc_api/chain.rs
+++ b/src/api/rpc_api/chain.rs
@@ -18,6 +18,7 @@ use crate::{
 };
 use ac_compose_macros::rpc_params;
 use ac_primitives::{ExtrinsicParams, FrameSystemConfig, SignedBlock};
+use alloc::vec::Vec;
 use log::*;
 use serde::de::DeserializeOwned;
 use sp_runtime::traits::GetRuntimeBlockType;
@@ -145,7 +146,7 @@ where
 
 		for n in block_numbers {
 			if let Some(block) = self.get_signed_block_by_num(Some(*n))? {
-				blocks.push(block.into());
+				blocks.push(block);
 			}
 		}
 		Ok(blocks)

--- a/src/api/rpc_api/chain.rs
+++ b/src/api/rpc_api/chain.rs
@@ -81,6 +81,11 @@ pub trait GetBlock {
 	) -> Result<Option<SignedBlock<Self::Block>>>;
 
 	fn get_finalized_block(&self) -> Result<Option<SignedBlock<Self::Block>>>;
+
+	fn get_signed_blocks(
+		&self,
+		block_numbers: &[Self::BlockNumber],
+	) -> Result<Vec<SignedBlock<Self::Block>>>;
 }
 
 impl<Signer, Client, Params, Runtime> GetBlock for Api<Signer, Client, Params, Runtime>
@@ -130,6 +135,20 @@ where
 	fn get_finalized_block(&self) -> Result<Option<SignedBlock<Self::Block>>> {
 		self.get_finalized_head()?
 			.map_or_else(|| Ok(None), |hash| self.get_signed_block(Some(hash)))
+	}
+
+	fn get_signed_blocks(
+		&self,
+		block_numbers: &[Self::BlockNumber],
+	) -> Result<Vec<SignedBlock<Self::Block>>> {
+		let mut blocks = Vec::<SignedBlock<Self::Block>>::new();
+
+		for n in block_numbers {
+			if let Some(block) = self.get_signed_block_by_num(Some(*n))? {
+				blocks.push(block.into());
+			}
+		}
+		Ok(blocks)
 	}
 }
 pub trait SubscribeChain {

--- a/src/api/rpc_api/chain.rs
+++ b/src/api/rpc_api/chain.rs
@@ -61,6 +61,7 @@ pub trait GetBlock {
 
 	fn get_block_hash(&self, number: Option<Self::BlockNumber>) -> Result<Option<Self::Hash>>;
 
+	/// Returns the genesis block
 	fn get_genesis_block(&self) -> Result<Self::Block>;
 
 	fn get_block(&self, hash: Option<Self::Hash>) -> Result<Option<Self::Block>>;
@@ -81,8 +82,11 @@ pub trait GetBlock {
 		number: Option<Self::BlockNumber>,
 	) -> Result<Option<SignedBlock<Self::Block>>>;
 
+	/// Get the last finalized signed block.
 	fn get_finalized_block(&self) -> Result<Option<SignedBlock<Self::Block>>>;
 
+	/// Returns a vector containing the blocks with the block numbers given in the input parameter.
+	/// If fetching any of the block fails then a `Result::Err` will be returned.
 	fn get_signed_blocks(
 		&self,
 		block_numbers: &[Self::BlockNumber],

--- a/src/api/rpc_api/events.rs
+++ b/src/api/rpc_api/events.rs
@@ -50,6 +50,7 @@ where
 	Runtime: FrameSystemConfig + GetRuntimeBlockType,
 	Runtime::RuntimeBlock: BlockTrait + DeserializeOwned,
 	Runtime::Hashing: HashTrait<Output = Runtime::Hash>,
+	Runtime::Header: DeserializeOwned,
 {
 	type Hash = Runtime::Hash;
 
@@ -159,6 +160,7 @@ where
 	Runtime: FrameSystemConfig + GetRuntimeBlockType,
 	Runtime::RuntimeBlock: BlockTrait + DeserializeOwned,
 	Runtime::Hashing: HashTrait<Output = Runtime::Hash>,
+	Runtime::Header: DeserializeOwned,
 {
 	/// Retrieve block details from node and search for the position of the given extrinsic.
 	fn retrieve_extrinsic_index_from_block(

--- a/src/api/rpc_api/events.rs
+++ b/src/api/rpc_api/events.rs
@@ -14,7 +14,7 @@
 use crate::{
 	api::{Api, Error, Result},
 	rpc::{HandleSubscription, Request, Subscribe},
-	GetBlock, GetStorage,
+	GetChainInfo, GetStorage,
 };
 use ac_compose_macros::rpc_params;
 use ac_node_api::{EventDetails, EventRecord, Events, Phase};

--- a/testing/examples/chain_tests.rs
+++ b/testing/examples/chain_tests.rs
@@ -20,7 +20,7 @@ use sp_keyring::AccountKeyring;
 use substrate_api_client::{
 	ac_primitives::AssetTipExtrinsicParams,
 	rpc::{HandleSubscription, JsonrpseeClient},
-	Api, GetBlock, GetHeader, SubscribeChain,
+	Api, GetChainInfo, SubscribeChain,
 };
 
 #[tokio::main]
@@ -31,12 +31,10 @@ async fn main() {
 	let mut api = Api::<_, _, AssetTipExtrinsicParams<Runtime>, Runtime>::new(client).unwrap();
 	api.set_signer(alice_pair);
 
-	// GetHeader
+	// GetChainInfo
 	let finalized_header_hash = api.get_finalized_head().unwrap().unwrap();
 	let _latest_header = api.get_header(None).unwrap().unwrap();
 	let _some_header = api.get_header(Some(finalized_header_hash)).unwrap().unwrap();
-
-	// GetBlock
 	let _block_hash = api.get_block_hash(None).unwrap().unwrap();
 	let block_hash = api.get_block_hash(Some(1)).unwrap().unwrap();
 	let _block = api.get_block(None).unwrap().unwrap();

--- a/testing/examples/events_tests.rs
+++ b/testing/examples/events_tests.rs
@@ -24,7 +24,7 @@ use substrate_api_client::{
 	ac_primitives::{AssetTipExtrinsicParams, ExtrinsicSigner, FrameSystemConfig},
 	extrinsic::BalancesExtrinsics,
 	rpc::JsonrpseeClient,
-	Api, FetchEvents, GetBlock, SubmitAndWatch, SubscribeEvents, XtStatus,
+	Api, FetchEvents, GetChainInfo, SubmitAndWatch, SubscribeEvents, XtStatus,
 };
 
 /// Check out frame_system::Event::ExtrinsicSuccess:

--- a/testing/examples/pallet_transaction_payment_tests.rs
+++ b/testing/examples/pallet_transaction_payment_tests.rs
@@ -22,7 +22,7 @@ use substrate_api_client::{
 	ac_primitives::{AssetTipExtrinsicParams, ExtrinsicSigner},
 	extrinsic::BalancesExtrinsics,
 	rpc::JsonrpseeClient,
-	Api, GetBlock, GetTransactionPayment,
+	Api, GetChainInfo, GetTransactionPayment,
 };
 
 #[tokio::main]

--- a/testing/examples/state_tests.rs
+++ b/testing/examples/state_tests.rs
@@ -23,7 +23,7 @@ use sp_core::{crypto::Ss58Codec, sr25519};
 use sp_keyring::AccountKeyring;
 use sp_staking::EraIndex;
 use substrate_api_client::{
-	ac_primitives::AssetTipExtrinsicParams, rpc::JsonrpseeClient, Api, GetBlock, GetStorage,
+	ac_primitives::AssetTipExtrinsicParams, rpc::JsonrpseeClient, Api, GetChainInfo, GetStorage,
 };
 
 type Balance = <Runtime as pallet_balances::Config>::Balance;


### PR DESCRIPTION
- In order to use `get_finalized_head()` inside of `get_finalized_block()` I had to add a trait bound for `Runtime::Header` but I think it is not too limiting.
- There is already a `genesis_hash()` in `API`. I implemented `get_genesis_block()` instead.
- Merged the `GetBlock` and `GetHeader` traits into a single `GetChainInfo` trait