### PR TITLE
Add a new function storage_double_map_key_prefix to meta to implement…

### DIFF
--- a/node-api/src/metadata.rs
+++ b/node-api/src/metadata.rs
@@ -480,6 +480,17 @@ impl Metadata {
 		self.pallet(pallet)?.storage(storage_item)?.get_map_prefix(pallet)
 	}
 
+	pub fn storage_double_map_key_prefix<K: Encode>(
+		&self,
+		storage_prefix: &'static str,
+		storage_key_name: &'static str,
+		first: K,
+	) -> Result<StorageKey, MetadataError> {
+		self.pallet(storage_prefix)?
+			.storage(storage_key_name)?
+			.get_double_map_prefix::<K>(storage_prefix, first)
+	}
+
 	pub fn storage_double_map_key<K: Encode, Q: Encode>(
 		&self,
 		pallet: &'static str,

--- a/node-api/src/storage.rs
+++ b/node-api/src/storage.rs
@@ -81,6 +81,11 @@ pub trait GetStorageTypes {
 	fn get_map<K: Encode>(&self, pallet_prefix: &str) -> Result<StorageMap<K>, MetadataError>;
 	fn get_map_prefix(&self, pallet_prefix: &str) -> Result<StorageKey, MetadataError>;
 	fn get_value(&self, pallet_prefix: &str) -> Result<StorageValue, MetadataError>;
+	fn get_double_map_prefix<K: Encode>(
+		&self,
+		pallet_prefix: &str,
+		key1: K,
+	) -> Result<StorageKey, MetadataError>;
 }
 
 impl GetStorageTypes for StorageEntryMetadata<PortableForm> {
@@ -139,6 +144,28 @@ impl GetStorageTypes for StorageEntryMetadata<PortableForm> {
 			StorageEntryType::Map { .. } => {
 				let mut bytes = sp_core::twox_128(pallet_prefix.as_bytes()).to_vec();
 				bytes.extend(&sp_core::twox_128(self.name.as_bytes())[..]);
+				Ok(StorageKey(bytes))
+			},
+			_ => Err(MetadataError::StorageTypeError),
+		}
+	}
+
+	fn get_double_map_prefix<K: Encode>(
+		&self,
+		pallet_prefix: &str,
+		key1: K,
+	) -> Result<StorageKey, MetadataError> {
+		match &self.ty {
+			StorageEntryType::Map { hashers, .. } => {
+				let module_prefix = pallet_prefix.as_bytes();
+				let storage_prefix = self.name.as_bytes();
+
+				let hasher1 = hashers.get(0).ok_or(MetadataError::StorageTypeError)?;
+
+				let mut bytes = sp_core::twox_128(module_prefix).to_vec();
+				bytes.extend(&sp_core::twox_128(storage_prefix)[..]);
+				bytes.extend(key_hash(&key1, &hasher1));
+
 				Ok(StorageKey(bytes))
 			},
 			_ => Err(MetadataError::StorageTypeError),

--- a/src/api/rpc_api/state.rs
+++ b/src/api/rpc_api/state.rs
@@ -59,6 +59,13 @@ pub trait GetStorage {
 		storage_item: &'static str,
 	) -> Result<StorageKey>;
 
+	fn get_storage_double_map_key_prefix<K: Encode>(
+		&self,
+		storage_prefix: &'static str,
+		storage_key_name: &'static str,
+		first: K,
+	) -> Result<StorageKey>;
+
 	/// Retrieve the storage value from a double map for the given keys: `first_double_map_key` and `second_double_map_key`.
 	///
 	/// `at_block`: the state is queried at this block, set to `None` to get the state from the latest known block.
@@ -210,6 +217,17 @@ where
 		)?;
 		info!("storage key is: 0x{}", hex::encode(&storagekey));
 		self.get_storage_by_key(storagekey, at_block)
+	}
+
+	fn get_storage_double_map_key_prefix<K: Encode>(
+		&self,
+		storage_prefix: &'static str,
+		storage_key_name: &'static str,
+		first: K,
+	) -> Result<StorageKey> {
+		self.metadata()
+			.storage_double_map_key_prefix(storage_prefix, storage_key_name, first)
+			.map_err(|e| e.into())
 	}
 
 	fn get_storage_by_key<V: Decode>(


### PR DESCRIPTION
use as this
```
let key = api
    .get_storage_double_map_key_prefix("WeteeGov", "ReferendumInfoOf", 5000)
    .unwrap();

let storage_keys = api
    .get_storage_keys_paged(Some(key), 10, None, None)
    .unwrap();

for storage_key in storage_keys.iter() {
    println!("Retrieving value for key {:?}", storage_key);
    let storage_data: ReferendumInfo<BlockNumber, RuntimeCall, Balance> = api
        .get_storage_by_key_hash(storage_key.clone(), None)
        .unwrap()
        .unwrap();
    println!("Retrieved data {:?}", storage_data);
}
```