### PR TITLE
Add `next_events_from_metadata` and rename `next_event`

### DIFF
--- a/examples/examples/event_callback.rs
+++ b/examples/examples/event_callback.rs
@@ -39,7 +39,7 @@ async fn main() {
 
 	// Wait for event callbacks from the node, which are received via subscription.
 	for _ in 0..5 {
-		let event_records = subscription.next_event::<RuntimeEvent, Hash>().unwrap().unwrap();
+		let event_records = subscription.next_events::<RuntimeEvent, Hash>().unwrap().unwrap();
 		for event_record in &event_records {
 			println!("decoded: {:?} {:?}", event_record.phase, event_record.event);
 			match &event_record.event {

--- a/node-api/src/events.rs
+++ b/node-api/src/events.rs
@@ -24,9 +24,6 @@ use sp_core::H256;
 
 /// A collection of events obtained from a block, bundled with the necessary
 /// information needed to decode and iterate over them.
-//
-// In subxt, this was generic over a `Config` type, but it's sole usage was to derive the
-// hash type. We omitted this here and use the `ac_primitives::Hash` instead.
 #[derive(Clone, Debug)]
 pub struct Events<Hash> {
 	metadata: Metadata,

--- a/testing/examples/events_tests.rs
+++ b/testing/examples/events_tests.rs
@@ -70,7 +70,7 @@ async fn main() {
 	// Wait for event callbacks from the node, which are received via subscription.
 	for _ in 0..5 {
 		let event_records = event_subscription
-			.next_event::<RuntimeEvent, <Runtime as FrameSystemConfig>::Hash>()
+			.next_events::<RuntimeEvent, <Runtime as FrameSystemConfig>::Hash>()
 			.unwrap()
 			.unwrap();
 		for event_record in &event_records {
@@ -78,6 +78,20 @@ async fn main() {
 			match &event_record.event {
 				RuntimeEvent::System(_) => println!("Got System event, all good"),
 				_ => panic!("Unexpected event"),
+			}
+		}
+	}
+
+	// Wait for event callbacks from the node, which are received via subscription, in case no RuntimeEvents are accessible.
+	for _ in 0..5 {
+		let events = event_subscription.next_events_from_metadata().unwrap().unwrap();
+		for event in events.iter() {
+			let event = event.unwrap();
+			println!("got event: {:?} {:?}", event.pallet_name(), event.variant_name());
+			if let Ok(Some(_extrinisic_success)) = event.as_event::<ExtrinsicSuccess>() {
+				println!("Got System event, all good");
+			} else {
+				panic!("Unexpected event");
 			}
 		}
 	}


### PR DESCRIPTION
Updated the `EventSubscription` Wrapper to support decoding events from the metadata:
- added new functionality `next_events_from_metadata` to derive events from metadata instead of `RuntimeEvents` generated by the `construct_runtime` macro of Substrate
- renamed `next_event` to more appropriate `next_events`.
- introduced a `metadata` field for event derivation from metadata (needed by `next_events_from_metadata`). Therefore, the `From` derivation from `Subscription`is not possible any more (needs metadata) and was removed.

closes https://github.com/scs/substrate-api-client/issues/440