### PR TITLE
Bump cargo-install to remove Node.js warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install cargo-about
-        uses: baptiste0928/cargo-install@v1
+        uses: baptiste0928/cargo-install@v2
         with:
           crate: cargo-about
           version: "0.5"


### PR DESCRIPTION
Fixes the Node.js warnings (see Annotations here: https://github.com/scs/substrate-api-client/actions/runs/4806291597?pr=541)