### PR TITLE
Fix CI to run with latest node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
 
       - name: Run latest node
         run: |
-          docker run -p 9944:9944 -p 9933:9933 -p 30333:30333 parity/substrate:latest --dev --ws-external --rpc-external &
+          docker run -p 9944:9944 -p 9933:9933 -p 30333:30333 parity/substrate:latest --dev --rpc-external &
 
       - name: Wait until node has started
         run: sleep 20s


### PR DESCRIPTION
no more --ws-external CMD since Substrate commit [71d749](https://github.com/paritytech/substrate/commit/71d749c74e43c7a840c94fcbbdd2b0172a21d473#diff-9290817490e013034857f5b228f357bb0e93d7e33e028cdeea17d20fa1d21b35L86)