### PR TITLE
Update toml versions for tag v0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,7 @@ dependencies = [
 
 [[package]]
 name = "ac-compose-macros"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "ac-primitives",
  "log",
@@ -23,7 +23,7 @@ dependencies = [
 
 [[package]]
 name = "ac-examples"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "env_logger",
  "frame-support",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "ac-node-api"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "ac-primitives",
  "bitvec",
@@ -68,7 +68,7 @@ dependencies = [
 
 [[package]]
 name = "ac-primitives"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "frame-system",
  "impl-serde",
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "ac-testing"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5361,7 +5361,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-api-client"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "ac-compose-macros",
  "ac-node-api",
@@ -5403,7 +5403,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-client-keystore"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -5498,7 +5498,7 @@ dependencies = [
 
 [[package]]
 name = "test-no-std"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "ac-compose-macros",
  "ac-node-api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-api-client"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Supercomputing Systems AG <info@scs.ch>"]
 license = "Apache-2.0"
 edition = "2021"

--- a/client-keystore/Cargo.toml
+++ b/client-keystore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-client-keystore"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Supercomputing Systems AG <info@scs.ch>"]
 license = "Apache-2.0"
 edition = "2021"

--- a/compose-macros/Cargo.toml
+++ b/compose-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ac-compose-macros"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Supercomputing Systems AG <info@scs.ch>"]
 license = "Apache-2.0"
 edition = "2021"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ac-examples"
-version = "0.3.0"
+version = "0.4.0"
 license = "Apache-2.0"
 edition = "2021"
 

--- a/node-api/Cargo.toml
+++ b/node-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ac-node-api"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Supercomputing Systems AG <info@scs.ch>"]
 license = "Apache-2.0"
 edition = "2021"

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ac-primitives"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Supercomputing Systems AG <info@scs.ch>"]
 license = "Apache-2.0"
 edition = "2021"

--- a/test-no-std/Cargo.toml
+++ b/test-no-std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test-no-std"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Supercomputing Systems AG <info@scs.ch>"]
 license = "Apache-2.0"
 edition = "2021"

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ac-testing"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Supercomputing Systems AG <info@scs.ch>"]
 license = "Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
Changes can be looked up here: https://github.com/scs/substrate-api-client/compare/v0.11.0...master

Summary:
- `api-client`: ⚡  Contains breaking changes due to clean trait bounds and new functionalities
- `client-keystore`: ⚡  breaking changes due to to substrate update 
- `compose-macros`:  ⚡  breaking changes due to async support
- `examples`:  ⚡  breaking changes due to clean trait bounds and new functionalies
- `node-api`:  ⚡  breaking changes due to improve of metadata and dispatch errors
- `primitives`: ⚡  breaking changes due to clean trait bounds
- `testing`: ⚡  breaking changes due to async support
