### PR TITLE
Update dependencies and rust toolchain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,7 +251,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -510,9 +510,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-expr"
-version = "0.10.3"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aacacf4d96c24b2ad6eb8ee6df040e4f27b0d0b39a5710c30091baa830485db"
+checksum = "c8790cf1286da485c72cf5fc7aeba308438800036ec67d89425924c4807268c9"
 dependencies = [
  "smallvec",
 ]
@@ -737,7 +737,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -754,7 +754,7 @@ checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -944,7 +944,7 @@ checksum = "5e9a1f9f7d83e59740248a6e14ecf93929ade55027844dfcea78beafccc15745"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -1110,7 +1110,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -1135,7 +1135,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-pallet-pov"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -1150,18 +1150,18 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
 name = "frame-election-provider-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -1178,7 +1178,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1206,7 +1206,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "bitflags",
  "environmental",
@@ -1225,6 +1225,7 @@ dependencies = [
  "sp-arithmetic",
  "sp-core",
  "sp-core-hashing-proc-macro",
+ "sp-debug-derive",
  "sp-inherents",
  "sp-io",
  "sp-runtime",
@@ -1239,7 +1240,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -1249,36 +1250,37 @@ dependencies = [
  "proc-macro-warning",
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
 name = "frame-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
+ "cfg-if 1.0.0",
  "frame-support",
  "log",
  "parity-scale-codec",
@@ -1295,7 +1297,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -1310,7 +1312,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -1319,7 +1321,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -1413,7 +1415,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -1916,7 +1918,7 @@ dependencies = [
 [[package]]
 name = "kitchensink-runtime"
 version = "3.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-benchmarking",
  "frame-benchmarking-pallet-pov",
@@ -1930,6 +1932,7 @@ dependencies = [
  "log",
  "node-primitives",
  "pallet-alliance",
+ "pallet-asset-rate",
  "pallet-asset-tx-payment",
  "pallet-assets",
  "pallet-authority-discovery",
@@ -1960,6 +1963,7 @@ dependencies = [
  "pallet-message-queue",
  "pallet-mmr",
  "pallet-multisig",
+ "pallet-nft-fractionalization",
  "pallet-nfts",
  "pallet-nfts-runtime-api",
  "pallet-nis",
@@ -1984,6 +1988,7 @@ dependencies = [
  "pallet-staking-reward-curve",
  "pallet-staking-runtime-api",
  "pallet-state-trie-migration",
+ "pallet-statement",
  "pallet-sudo",
  "pallet-timestamp",
  "pallet-tips",
@@ -2009,6 +2014,7 @@ dependencies = [
  "sp-runtime",
  "sp-session",
  "sp-staking",
+ "sp-statement-store",
  "sp-std",
  "sp-transaction-pool",
  "sp-version",
@@ -2349,7 +2355,7 @@ dependencies = [
 [[package]]
 name = "node-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-system",
  "parity-scale-codec",
@@ -2362,7 +2368,7 @@ dependencies = [
 [[package]]
 name = "node-template-runtime"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",
@@ -2535,7 +2541,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -2559,7 +2565,7 @@ dependencies = [
 [[package]]
 name = "pallet-alliance"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2577,9 +2583,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-asset-rate"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "pallet-asset-tx-payment"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2597,7 +2617,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2612,7 +2632,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2628,7 +2648,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2644,7 +2664,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2658,7 +2678,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2671,7 +2691,7 @@ dependencies = [
  "scale-info",
  "sp-application-crypto",
  "sp-consensus-babe",
- "sp-consensus-vrf",
+ "sp-core",
  "sp-io",
  "sp-runtime",
  "sp-session",
@@ -2682,7 +2702,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -2702,7 +2722,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2717,7 +2737,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2735,7 +2755,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2754,7 +2774,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2771,7 +2791,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "bitflags",
  "environmental",
@@ -2800,7 +2820,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-primitives"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "bitflags",
  "parity-scale-codec",
@@ -2813,17 +2833,17 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
 name = "pallet-conviction-voting"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -2840,7 +2860,7 @@ dependencies = [
 [[package]]
 name = "pallet-core-fellowship"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2858,7 +2878,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2876,7 +2896,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -2899,7 +2919,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -2912,7 +2932,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "5.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2930,7 +2950,7 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -2948,7 +2968,7 @@ dependencies = [
 [[package]]
 name = "pallet-glutton"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "blake2",
  "frame-benchmarking",
@@ -2966,7 +2986,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2989,7 +3009,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -3005,7 +3025,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3025,7 +3045,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3042,7 +3062,7 @@ dependencies = [
 [[package]]
 name = "pallet-insecure-randomness-collective-flip"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3056,7 +3076,7 @@ dependencies = [
 [[package]]
 name = "pallet-lottery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3070,7 +3090,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3087,7 +3107,7 @@ dependencies = [
 [[package]]
 name = "pallet-message-queue"
 version = "7.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3106,7 +3126,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3123,7 +3143,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3137,9 +3157,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-nft-fractionalization"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "log",
+ "pallet-assets",
+ "pallet-nfts",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "pallet-nfts"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -3157,7 +3194,7 @@ dependencies = [
 [[package]]
 name = "pallet-nfts-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-support",
  "pallet-nfts",
@@ -3168,7 +3205,7 @@ dependencies = [
 [[package]]
 name = "pallet-nis"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3184,7 +3221,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3201,7 +3238,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -3221,7 +3258,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
 version = "1.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
@@ -3232,7 +3269,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3249,7 +3286,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -3273,7 +3310,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3290,7 +3327,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3305,7 +3342,7 @@ dependencies = [
 [[package]]
 name = "pallet-ranked-collective"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3323,7 +3360,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3338,7 +3375,7 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3356,7 +3393,7 @@ dependencies = [
 [[package]]
 name = "pallet-remark"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3373,7 +3410,7 @@ dependencies = [
 [[package]]
 name = "pallet-root-testing"
 version = "1.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3388,7 +3425,7 @@ dependencies = [
 [[package]]
 name = "pallet-salary"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3406,7 +3443,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3423,7 +3460,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3444,7 +3481,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3460,7 +3497,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3474,7 +3511,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -3496,18 +3533,18 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
 name = "pallet-staking-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -3516,7 +3553,7 @@ dependencies = [
 [[package]]
 name = "pallet-state-trie-migration"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3531,10 +3568,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-statement"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-api",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-statement-store",
+ "sp-std",
+]
+
+[[package]]
 name = "pallet-sudo"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
+ "frame-benchmarking",
  "frame-support",
  "frame-system",
  "parity-scale-codec",
@@ -3547,7 +3603,7 @@ dependencies = [
 [[package]]
 name = "pallet-template"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3559,7 +3615,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3577,7 +3633,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3596,7 +3652,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3612,7 +3668,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -3624,7 +3680,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-storage"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3644,7 +3700,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3661,7 +3717,7 @@ dependencies = [
 [[package]]
 name = "pallet-uniques"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3676,7 +3732,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3692,7 +3748,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3707,7 +3763,7 @@ dependencies = [
 [[package]]
 name = "pallet-whitelist"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3890,7 +3946,7 @@ checksum = "0e99670bafb56b9a106419397343bdbc8b8742c3cc449fec6345f86173f47cd4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -4038,7 +4094,7 @@ checksum = "8d2275aab483050ab2a7364c1a46604865ee7d6906684e08db0f090acf74f9e7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -4231,10 +4287,9 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "array-bytes",
- "async-trait",
  "parking_lot",
  "serde_json",
  "sp-application-crypto",
@@ -4443,7 +4498,7 @@ checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -4629,7 +4684,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "hash-db",
  "log",
@@ -4649,7 +4704,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "Inflector",
  "blake2",
@@ -4657,13 +4712,13 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
 name = "sp-application-crypto"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -4676,7 +4731,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -4690,7 +4745,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -4703,7 +4758,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -4715,7 +4770,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "async-trait",
  "futures",
@@ -4730,7 +4785,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -4748,10 +4803,9 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "async-trait",
- "merlin",
  "parity-scale-codec",
  "scale-info",
  "serde",
@@ -4759,7 +4813,6 @@ dependencies = [
  "sp-application-crypto",
  "sp-consensus",
  "sp-consensus-slots",
- "sp-consensus-vrf",
  "sp-core",
  "sp-inherents",
  "sp-keystore",
@@ -4771,7 +4824,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -4789,7 +4842,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -4799,22 +4852,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-consensus-vrf"
-version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
-dependencies = [
- "parity-scale-codec",
- "scale-info",
- "schnorrkel",
- "sp-core",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
 name = "sp-core"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "array-bytes",
  "bitflags",
@@ -4833,6 +4873,7 @@ dependencies = [
  "merlin",
  "parity-scale-codec",
  "parking_lot",
+ "paste",
  "primitive-types",
  "rand 0.8.5",
  "regex",
@@ -4857,7 +4898,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -4871,28 +4912,28 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "proc-macro2",
  "quote",
  "sp-core-hashing",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
 name = "sp-debug-derive"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
 name = "sp-externalities"
 version = "0.13.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -4903,7 +4944,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -4918,7 +4959,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "bytes 1.4.0",
  "ed25519",
@@ -4944,7 +4985,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -4955,13 +4996,11 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.13.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "futures",
- "merlin",
  "parity-scale-codec",
  "parking_lot",
- "schnorrkel",
  "serde",
  "sp-core",
  "sp-externalities",
@@ -4971,7 +5010,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "4.1.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "thiserror",
  "zstd",
@@ -4980,7 +5019,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",
@@ -4991,7 +5030,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "ckb-merkle-mountain-range",
  "log",
@@ -5009,7 +5048,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -5023,7 +5062,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -5033,7 +5072,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -5043,7 +5082,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -5065,7 +5104,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "bytes 1.4.0",
  "impl-trait-for-tuples",
@@ -5083,19 +5122,19 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
 name = "sp-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -5109,10 +5148,11 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
+ "serde",
  "sp-core",
  "sp-runtime",
  "sp-std",
@@ -5121,7 +5161,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.13.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "hash-db",
  "log",
@@ -5139,14 +5179,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-statement-store"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
+dependencies = [
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-core",
+ "sp-externalities",
+ "sp-runtime",
+ "sp-runtime-interface",
+ "sp-std",
+ "thiserror",
+]
+
+[[package]]
 name = "sp-std"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 
 [[package]]
 name = "sp-storage"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -5159,7 +5217,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "async-trait",
  "futures-timer",
@@ -5174,7 +5232,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "parity-scale-codec",
  "sp-std",
@@ -5186,7 +5244,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -5195,7 +5253,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "async-trait",
  "log",
@@ -5211,7 +5269,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "ahash 0.8.3",
  "hash-db",
@@ -5234,7 +5292,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -5251,18 +5309,18 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
 name = "sp-wasm-interface"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -5276,7 +5334,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -5420,7 +5478,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "5.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#4e93782c16f741cde18a8b98bd791838e03788fb"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80fbd3f02078dfb370883e446ee27a7850"
 dependencies = [
  "ansi_term",
  "build-helper",
@@ -5453,9 +5511,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.15"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
+checksum = "a6f671d4b5ffdb8eadec19c0ae67fe2639df8684bd7bc4b83d986b8db549cf01"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5525,7 +5583,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -5596,7 +5654,7 @@ checksum = "61a573bdc87985e9d6ddeed1b3d864e8a302c847e40d647746df2f1de209d1ce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -5788,9 +5846,9 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "digest 0.10.6",
- "rand 0.7.3",
+ "rand 0.8.5",
  "static_assertions",
 ]
 
@@ -5996,9 +6054,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-opt"
-version = "0.111.0"
+version = "0.112.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84a303793cbc01fb96551badfc7367db6007396bba6bac97936b3c8b6f7fdb41"
+checksum = "87fef6d0d508f08334e0ab0e6877feb4c0ecb3956bcf2cb950699b22fedf3e9c"
 dependencies = [
  "anyhow",
  "libc",
@@ -6012,9 +6070,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-opt-cxx-sys"
-version = "0.111.0"
+version = "0.112.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c9deb56f8a9f2ec177b3bd642a8205621835944ed5da55f2388ef216aca5a4"
+checksum = "bc816bbc1596c8f2e8127e137a760c798023ef3d378f2ae51f0f1840e2dfa445"
 dependencies = [
  "anyhow",
  "cxx",
@@ -6024,15 +6082,14 @@ dependencies = [
 
 [[package]]
 name = "wasm-opt-sys"
-version = "0.111.0"
+version = "0.112.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4432e28b542738a9776cedf92e8a99d8991c7b4667ee2c7ccddfb479dd2856a7"
+checksum = "40199e4f68ef1071b3c6d0bd8026a12b481865d4b9e49c156932ea9a6234dd14"
 dependencies = [
  "anyhow",
  "cc",
  "cxx",
  "cxx-build",
- "regex",
 ]
 
 [[package]]
@@ -6551,7 +6608,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,9 +164,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.20"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
 dependencies = [
  "memchr",
 ]
@@ -191,9 +191,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.70"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
+checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
 name = "approx"
@@ -289,9 +289,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+checksum = "3f1e31e207a6b8fb791a38ea3105e6cb541f55e4d029902d3039a4ad07cc4105"
 
 [[package]]
 name = "base64ct"
@@ -341,7 +341,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest 0.10.6",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -396,9 +396,9 @@ dependencies = [
 
 [[package]]
 name = "bounded-collections"
-version = "0.1.5"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a071c348a5ef6da1d3a87166b408170b46002382b1dda83992b5c2208cefb370"
+checksum = "07fbd1d11282a1eb134d3c3b7cf8ce213b5161c6e5f73fb1b98618482c606b64"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -423,9 +423,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.12.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
 name = "byte-slice-cast"
@@ -614,9 +614,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "280a9f2d8b3a38871a3c8a46fb80db65e5e5ed97da80c4d08bf27fb63e35e181"
+checksum = "3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58"
 dependencies = [
  "libc",
 ]
@@ -647,9 +647,9 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2538c4e68e52548bacb3e83ac549f903d44f011ac9d5abb5e132e67d0808f7"
+checksum = "cf4c2f4e1afd912bc40bfd6fed5d9dc1f288e0ba01bfcc835cc5bc3eb13efe15"
 dependencies = [
  "generic-array 0.14.7",
  "rand_core 0.6.4",
@@ -759,9 +759,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.3"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b10af9f9f9f2134a42d3f8aa74658660f2e0234b0eb81bd171df8aa32779ed"
+checksum = "56acb310e15652100da43d130af8d97b509e95af61aab1c5a7939ef24337ee17"
 dependencies = [
  "const-oid",
  "zeroize",
@@ -811,9 +811,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "const-oid",
@@ -856,15 +856,16 @@ checksum = "68b0cf012f1230e43cd00ebb729c6bb58707ecfa8ad08b52ef3a4ccd2697fc30"
 
 [[package]]
 name = "ecdsa"
-version = "0.16.6"
+version = "0.16.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a48e5d537b8a30c0b023116d981b16334be1485af7ca68db3a2b7024cbc957fd"
+checksum = "0997c976637b606099b9985693efa3581e84e41f5c11ba5255f88711058ad428"
 dependencies = [
  "der",
- "digest 0.10.6",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature 2.1.0",
+ "spki",
 ]
 
 [[package]]
@@ -910,13 +911,13 @@ checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75c71eaa367f2e5d556414a8eea812bc62985c879748d6403edabd9cb03f16e7"
+checksum = "968405c8fdc9b3bf4df0a6638858cc0b52462836ab6b1c87377785dd09cf1c0b"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest 0.10.6",
+ "digest 0.10.7",
  "ff",
  "generic-array 0.14.7",
  "group",
@@ -1615,7 +1616,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.6",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1668,12 +1669,11 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone-haiku"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
- "cxx",
- "cxx-build",
+ "cc",
 ]
 
 [[package]]
@@ -1778,7 +1778,7 @@ checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
 dependencies = [
  "hermit-abi 0.3.1",
  "io-lifetimes",
- "rustix 0.37.11",
+ "rustix 0.37.19",
  "windows-sys 0.48.0",
 ]
 
@@ -1808,9 +1808,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.61"
+version = "0.3.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
+checksum = "2f37a4a5928311ac501dee68b3c7613a1037d0edb30c8e5427bd832d55d1b790"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1898,9 +1898,9 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3afef3b6eff9ce9d8ff9b3601125eec7f0c8cbac7abd14f355d053fa56c98768"
+checksum = "8f6d5ed8676d904364de097082f4e7d240b571b67989ced0240f08b7f966f940"
 dependencies = [
  "cpufeatures",
 ]
@@ -2036,15 +2036,15 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.141"
+version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
+checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
 
 [[package]]
 name = "libm"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
+checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
 
 [[package]]
 name = "libsecp256k1"
@@ -2120,9 +2120,9 @@ checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.1"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59d8c75012853d2e872fb56bc8a2e53718e2cafe1a4c823143141c6d90c322f"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "lock_api"
@@ -2163,10 +2163,11 @@ dependencies = [
 
 [[package]]
 name = "matrixmultiply"
-version = "0.3.2"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add85d4dd35074e6fedc608f8c8f513a3548619a9024b751949ef0e8e45a4d84"
+checksum = "090126dc04f95dc0d1c1c91f61bdd474b3930ca064c1edc8a849da2c6cbe1e77"
 dependencies = [
+ "autocfg",
  "rawpointer",
 ]
 
@@ -2193,7 +2194,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffc89ccdc6e10d6907450f753537ebc5c5d3460d2e4e62ea74bd571db62c0f9e"
 dependencies = [
- "rustix 0.37.11",
+ "rustix 0.37.19",
 ]
 
 [[package]]
@@ -2520,9 +2521,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.50"
+version = "0.10.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e30d8bc91859781f0a943411186324d580f2bbeb71b452fe91ae344806af3f1"
+checksum = "01b8574602df80f7b85fdfc5392fa884a4e3b3f4f35402c070ab34c3d3f78d56"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -2552,9 +2553,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.85"
+version = "0.9.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d3d193fb1488ad46ffe3aaabc912cc931d02ee8518fe2959aea8ef52718b0c0"
+checksum = "8e17f59264b2809d77ae94f0e1ebabc434773f370d6ca667bd223ea10e06cc7e"
 dependencies = [
  "cc",
  "libc",
@@ -3777,9 +3778,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "637935964ff85a605d114591d4d2c13c5d1ba2806dae97cea6bf180238a749ac"
+checksum = "5ddb756ca205bd108aee3c62c6d3c994e1df84a59b9d6d4a5ea42ee1fd5a9a28"
 dependencies = [
  "arrayvec 0.7.2",
  "bitvec",
@@ -3852,7 +3853,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
- "digest 0.10.6",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3863,22 +3864,22 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pin-project"
-version = "1.0.12"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
+checksum = "c95a7476719eab1e366eaf73d0260af3021184f18177925b07f54b30089ceead"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.12"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
+checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -3905,9 +3906,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "ppv-lite86"
@@ -3951,9 +3952,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "fa1fb82fc0c281dd9671101b66b771ebbe1eaf967b96ac8740dcba4b70005ca8"
 dependencies = [
  "unicode-ident",
 ]
@@ -3969,9 +3970,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
 dependencies = [
  "proc-macro2",
 ]
@@ -4099,13 +4100,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.3"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
+checksum = "d1a59b5d8e97dee33696bf13c5ba8ab85341c002922fba050069326b9c498974"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.7.2",
 ]
 
 [[package]]
@@ -4114,7 +4115,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 dependencies = [
- "regex-syntax",
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -4122,6 +4123,12 @@ name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
 name = "rfc6979"
@@ -4186,9 +4193,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.12"
+version = "0.36.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0af200a3324fa5bcd922e84e9b55a298ea9f431a489f01961acdebc6e908f25"
+checksum = "14e4d67015953998ad0eb82887a0eb0129e18a7e2f3b7b0f6c422fddcd503d62"
 dependencies = [
  "bitflags",
  "errno",
@@ -4200,15 +4207,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.11"
+version = "0.37.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85597d61f83914ddeba6a47b3b8ffe7365107221c2e557ed94426489fefb5f77"
+checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
 dependencies = [
  "bitflags",
  "errno",
  "io-lifetimes",
  "libc",
- "linux-raw-sys 0.3.1",
+ "linux-raw-sys 0.3.8",
  "windows-sys 0.48.0",
 ]
 
@@ -4242,7 +4249,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
- "base64 0.21.0",
+ "base64 0.21.1",
 ]
 
 [[package]]
@@ -4300,9 +4307,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info"
-version = "2.5.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cfdffd972d76b22f3d7f81c8be34b2296afd3a25e0a547bd9abe340a4dbbe97"
+checksum = "b569c32c806ec3abdf3b5869fb8bf1e0d275a7c1c9b0b05603d9464632649edf"
 dependencies = [
  "bitvec",
  "cfg-if 1.0.0",
@@ -4314,9 +4321,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info-derive"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61fa974aea2d63dd18a4ec3a49d59af9f34178c73a4f56d2f18205628d00681e"
+checksum = "53012eae69e5aa5c14671942a5dd47de59d4cdcff8532a6dd0e081faf1119482"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -4427,9 +4434,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.8.2"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
+checksum = "1fc758eb7bffce5b308734e9b0c1468893cae9ff70ebf13e7090be8dcbcc83a8"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -4440,9 +4447,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c9bb296072e961fcbd8853511dd39c2d8be2deb1e17c6860b1d30732b323b4"
+checksum = "f51d0c0d83bec45f16480d0ce0058397a69e48fcdc52d1dc8855fb68acbd31a7"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -4483,18 +4490,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.160"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
+checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.160"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
+checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4514,9 +4521,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0efd8caf556a6cebd3b285caf480045fcc1ac04f6bd786b09a6f11af30c4fcf4"
+checksum = "93107647184f6027e3b7dcb2e11034cf95ffa1e3a682c67951963ac69c1c007d"
 dependencies = [
  "serde",
 ]
@@ -4554,7 +4561,7 @@ checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest 0.10.6",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4590,16 +4597,16 @@ checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest 0.10.6",
+ "digest 0.10.7",
 ]
 
 [[package]]
 name = "sha3"
-version = "0.10.7"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54c2bb1a323307527314a36bfb73f24febb08ce2b8a554bf4ffd6f51ad15198c"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
- "digest 0.10.6",
+ "digest 0.10.7",
  "keccak",
 ]
 
@@ -4624,7 +4631,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
 dependencies = [
- "digest 0.10.6",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -4902,7 +4909,7 @@ source = "git+https://github.com/paritytech/substrate.git?branch=master#2e494e80
 dependencies = [
  "blake2b_simd",
  "byteorder",
- "digest 0.10.6",
+ "digest 0.10.7",
  "sha2 0.10.6",
  "sha3",
  "sp-std",
@@ -5360,9 +5367,9 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "spki"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37a5be806ab6f127c3da44b7378837ebf01dadca8510a0e572460216b228bd0e"
+checksum = "9d1e996ef02c474957d681f1b05213dfb0abab947b446a62d37770b23500184a"
 dependencies = [
  "base64ct",
  "der",
@@ -5370,9 +5377,9 @@ dependencies = [
 
 [[package]]
 name = "ss58-registry"
-version = "1.39.0"
+version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecf0bd63593ef78eca595a7fc25e9a443ca46fe69fd472f8f09f5245cdcd769d"
+checksum = "eb47a8ad42e5fc72d5b1eb104a5546937eaf39843499948bb666d6e93c62423b"
 dependencies = [
  "Inflector",
  "num-format",
@@ -5528,9 +5535,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.6"
+version = "0.12.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae9980cab1db3fceee2f6c6f643d5d8de2997c58ee8d25fb0cc8a9e9e7348e5"
+checksum = "fd1ba337640d60c3e96bc6f0638a939b9c9a7f2c316a1598c279828b3d1dc8c5"
 
 [[package]]
 name = "tempfile"
@@ -5541,7 +5548,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "fastrand",
  "redox_syscall 0.3.5",
- "rustix 0.37.11",
+ "rustix 0.37.19",
  "windows-sys 0.45.0",
 ]
 
@@ -5632,9 +5639,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.27.0"
+version = "1.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0de47a4eecbe11f498978a9b29d792f0d2692d1dd003650c24c76510e3bc001"
+checksum = "0aa32867d44e6f2ce3385e89dceb990188b8bb0fb25b0cf576647a6f98ac5105"
 dependencies = [
  "autocfg",
  "libc",
@@ -5643,14 +5650,14 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "tokio-macros",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a573bdc87985e9d6ddeed1b3d864e8a302c847e40d647746df2f1de209d1ce"
+checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5670,9 +5677,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
+checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
 dependencies = [
  "bytes 1.4.0",
  "futures-core",
@@ -5684,9 +5691,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b403acf6f2bb0859c93c7f0d967cb4a75a7ac552100f9322faf64dc047669b21"
+checksum = "d6135d499e69981f9ff0ef2167955a5333c35e36f6937d382974566b3d5b94ec"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -5696,18 +5703,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+checksum = "5a76a9312f5ba4c2dec6b9161fdf25d87ad8a09256ccea5a556fef03c706a10f"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.19.8"
+version = "0.19.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239410c8609e8125456927e6707163a3b1fdb40561e4b803bc041f466ccfdc13"
+checksum = "92d964908cec0d030b812013af25a0e57fddfadb1e066ecc6681d86253129d4f"
 dependencies = [
  "indexmap",
  "serde",
@@ -5730,20 +5737,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
+checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.16",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
+checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -5847,7 +5854,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if 1.0.0",
- "digest 0.10.6",
+ "digest 0.10.7",
  "rand 0.8.5",
  "static_assertions",
 ]
@@ -5991,9 +5998,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+checksum = "5bba0e8cb82ba49ff4e229459ff22a191bbe9a1cb3a341610c9c33efc27ddf73"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -6001,24 +6008,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
+checksum = "19b04bc93f9d6bdee709f6bd2118f57dd6679cf1176a1af464fca3ab0d66d8fb"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.16",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+checksum = "14d6b024f1a526bb0234f52840389927257beb670610081360e5a03c5df9c258"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6026,22 +6033,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.16",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+checksum = "ed9d5b4305409d1fc9482fee2d7f9bcbf24b3972bf59817ef757e23982242a93"
 
 [[package]]
 name = "wasm-instrument"
@@ -6287,7 +6294,7 @@ dependencies = [
  "memoffset",
  "paste",
  "rand 0.8.5",
- "rustix 0.36.12",
+ "rustix 0.36.14",
  "wasmtime-asm-macros",
  "wasmtime-environ",
  "wasmtime-jit-debug",
@@ -6308,9 +6315,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.61"
+version = "0.3.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
+checksum = "3bdd9ef4e984da1187bf8110c5cf5b845fbc87a23602cdf912386a76fcd3a7c2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6337,9 +6344,9 @@ dependencies = [
 
 [[package]]
 name = "wide"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b689b6c49d6549434bf944e6b0f39238cf63693cb7a147e9d887507fffa3b223"
+checksum = "5cd0496a71f3cc6bc4bf0ed91346426a5099e93d89807e663162dc5a1069ff65"
 dependencies = [
  "bytemuck",
  "safe_arch",
@@ -6546,9 +6553,9 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
-version = "0.4.1"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae8970b36c66498d8ff1d66685dc86b91b29db0c7739899012f63a63814b4b28"
+checksum = "61de7bac303dc551fe038e2b3cef0f571087a47571ea6e79a87692ac99b99699"
 dependencies = [
  "memchr",
 ]

--- a/client-keystore/src/lib.rs
+++ b/client-keystore/src/lib.rs
@@ -22,13 +22,10 @@
 use parking_lot::RwLock;
 use sp_application_crypto::{AppCrypto, AppPair, IsWrappedBy};
 use sp_core::{
-	crypto::{ByteArray, ExposeSecret, KeyTypeId, Pair as CorePair, SecretString},
+	crypto::{ByteArray, ExposeSecret, KeyTypeId, Pair as CorePair, SecretString, VrfSigner},
 	ecdsa, ed25519, sr25519,
 };
-use sp_keystore::{
-	vrf::{make_transcript, VRFSignature, VRFTranscriptData},
-	Error as TraitError, Keystore, KeystorePtr,
-};
+use sp_keystore::{Error as TraitError, Keystore, KeystorePtr};
 use std::{
 	collections::HashMap,
 	fs::{self, File},
@@ -102,6 +99,20 @@ impl LocalKeystore {
 			.map(|pair| pair.sign(msg));
 		Ok(signature)
 	}
+
+	fn vrf_sign<T: CorePair + VrfSigner>(
+		&self,
+		key_type: KeyTypeId,
+		public: &T::Public,
+		transcript: &T::VrfInput,
+	) -> std::result::Result<Option<T::VrfSignature>, TraitError> {
+		let sig = self
+			.0
+			.read()
+			.key_pair_by_type::<T>(public, key_type)?
+			.map(|pair| pair.vrf_sign(transcript));
+		Ok(sig)
+	}
 }
 
 impl Keystore for LocalKeystore {
@@ -133,14 +144,9 @@ impl Keystore for LocalKeystore {
 		&self,
 		key_type: KeyTypeId,
 		public: &sr25519::Public,
-		transcript_data: VRFTranscriptData,
-	) -> std::result::Result<Option<VRFSignature>, TraitError> {
-		let sig = self.0.read().key_pair_by_type::<sr25519::Pair>(public, key_type)?.map(|pair| {
-			let transcript = make_transcript(transcript_data);
-			let (inout, proof, _) = pair.as_ref().vrf_sign(transcript);
-			VRFSignature { output: inout.to_output(), proof }
-		});
-		Ok(sig)
+		transcript: &sr25519::vrf::VrfTranscript,
+	) -> std::result::Result<Option<sr25519::vrf::VrfSignature>, TraitError> {
+		self.vrf_sign::<sr25519::Pair>(key_type, public, transcript)
 	}
 
 	fn ed25519_public_keys(&self, key_type: KeyTypeId) -> Vec<ed25519::Public> {

--- a/client-keystore/src/lib.rs
+++ b/client-keystore/src/lib.rs
@@ -478,12 +478,11 @@ impl KeystoreInner {
 		let mut public_keys: Vec<Vec<u8>> = self
 			.additional
 			.keys()
-			.into_iter()
 			.filter_map(|k| if k.0 == key_type { Some(k.1.clone()) } else { None })
 			.collect();
 
 		if let Some(path) = &self.path {
-			for entry in fs::read_dir(&path)? {
+			for entry in fs::read_dir(path)? {
 				let entry = entry?;
 				let path = entry.path();
 

--- a/client-keystore/src/lib.rs
+++ b/client-keystore/src/lib.rs
@@ -22,7 +22,7 @@
 use parking_lot::RwLock;
 use sp_application_crypto::{AppCrypto, AppPair, IsWrappedBy};
 use sp_core::{
-	crypto::{ByteArray, ExposeSecret, KeyTypeId, Pair as CorePair, SecretString, VrfSigner},
+	crypto::{ByteArray, ExposeSecret, KeyTypeId, Pair as CorePair, SecretString, VrfSecret},
 	ecdsa, ed25519, sr25519,
 };
 use sp_keystore::{Error as TraitError, Keystore, KeystorePtr};
@@ -100,18 +100,32 @@ impl LocalKeystore {
 		Ok(signature)
 	}
 
-	fn vrf_sign<T: CorePair + VrfSigner>(
+	fn vrf_sign<T: CorePair + VrfSecret>(
 		&self,
 		key_type: KeyTypeId,
 		public: &T::Public,
-		transcript: &T::VrfInput,
+		data: &T::VrfSignData,
 	) -> std::result::Result<Option<T::VrfSignature>, TraitError> {
 		let sig = self
 			.0
 			.read()
 			.key_pair_by_type::<T>(public, key_type)?
-			.map(|pair| pair.vrf_sign(transcript));
+			.map(|pair| pair.vrf_sign(data));
 		Ok(sig)
+	}
+
+	fn vrf_output<T: CorePair + VrfSecret>(
+		&self,
+		key_type: KeyTypeId,
+		public: &T::Public,
+		input: &T::VrfInput,
+	) -> std::result::Result<Option<T::VrfOutput>, TraitError> {
+		let preout = self
+			.0
+			.read()
+			.key_pair_by_type::<T>(public, key_type)?
+			.map(|pair| pair.vrf_output(input));
+		Ok(preout)
 	}
 }
 
@@ -122,7 +136,7 @@ impl Keystore for LocalKeystore {
 
 	/// Generate a new pair compatible with the 'ed25519' signature scheme.
 	///
-	/// If the `[seed]` is `Some` then the key will be ephemeral and stored in memory.
+	/// If `[seed]` is `Some` then the key will be ephemeral and stored in memory.
 	fn sr25519_generate_new(
 		&self,
 		key_type: KeyTypeId,
@@ -144,9 +158,18 @@ impl Keystore for LocalKeystore {
 		&self,
 		key_type: KeyTypeId,
 		public: &sr25519::Public,
-		transcript: &sr25519::vrf::VrfTranscript,
+		data: &sr25519::vrf::VrfSignData,
 	) -> std::result::Result<Option<sr25519::vrf::VrfSignature>, TraitError> {
-		self.vrf_sign::<sr25519::Pair>(key_type, public, transcript)
+		self.vrf_sign::<sr25519::Pair>(key_type, public, data)
+	}
+
+	fn sr25519_vrf_output(
+		&self,
+		key_type: KeyTypeId,
+		public: &sr25519::Public,
+		input: &sr25519::vrf::VrfInput,
+	) -> std::result::Result<Option<sr25519::vrf::VrfOutput>, TraitError> {
+		self.vrf_output::<sr25519::Pair>(key_type, public, input)
 	}
 
 	fn ed25519_public_keys(&self, key_type: KeyTypeId) -> Vec<ed25519::Public> {
@@ -155,7 +178,7 @@ impl Keystore for LocalKeystore {
 
 	/// Generate a new pair compatible with the 'sr25519' signature scheme.
 	///
-	/// If the `[seed]` is `Some` then the key will be ephemeral and stored in memory.
+	/// If `[seed]` is `Some` then the key will be ephemeral and stored in memory.
 	fn ed25519_generate_new(
 		&self,
 		key_type: KeyTypeId,
@@ -179,7 +202,7 @@ impl Keystore for LocalKeystore {
 
 	/// Generate a new pair compatible with the 'ecdsa' signature scheme.
 	///
-	/// If the `[seed]` is `Some` then the key will be ephemeral and stored in memory.
+	/// If `[seed]` is `Some` then the key will be ephemeral and stored in memory.
 	fn ecdsa_generate_new(
 		&self,
 		key_type: KeyTypeId,
@@ -209,6 +232,60 @@ impl Keystore for LocalKeystore {
 			.key_pair_by_type::<ecdsa::Pair>(public, key_type)?
 			.map(|pair| pair.sign_prehashed(msg));
 		Ok(sig)
+	}
+
+	#[cfg(feature = "bls-experimental")]
+	fn bls381_public_keys(&self, key_type: KeyTypeId) -> Vec<bls381::Public> {
+		self.public_keys::<bls381::Pair>(key_type)
+	}
+
+	#[cfg(feature = "bls-experimental")]
+	/// Generate a new pair compatible with the 'bls381' signature scheme.
+	///
+	/// If `[seed]` is `Some` then the key will be ephemeral and stored in memory.
+	fn bls381_generate_new(
+		&self,
+		key_type: KeyTypeId,
+		seed: Option<&str>,
+	) -> std::result::Result<bls381::Public, TraitError> {
+		self.generate_new::<bls381::Pair>(key_type, seed)
+	}
+
+	#[cfg(feature = "bls-experimental")]
+	fn bls381_sign(
+		&self,
+		key_type: KeyTypeId,
+		public: &bls381::Public,
+		msg: &[u8],
+	) -> std::result::Result<Option<bls381::Signature>, TraitError> {
+		self.sign::<bls381::Pair>(key_type, public, msg)
+	}
+
+	#[cfg(feature = "bls-experimental")]
+	fn bls377_public_keys(&self, key_type: KeyTypeId) -> Vec<bls377::Public> {
+		self.public_keys::<bls377::Pair>(key_type)
+	}
+
+	#[cfg(feature = "bls-experimental")]
+	/// Generate a new pair compatible with the 'bls377' signature scheme.
+	///
+	/// If `[seed]` is `Some` then the key will be ephemeral and stored in memory.
+	fn bls377_generate_new(
+		&self,
+		key_type: KeyTypeId,
+		seed: Option<&str>,
+	) -> std::result::Result<bls377::Public, TraitError> {
+		self.generate_new::<bls377::Pair>(key_type, seed)
+	}
+
+	#[cfg(feature = "bls-experimental")]
+	fn bls377_sign(
+		&self,
+		key_type: KeyTypeId,
+		public: &bls377::Public,
+		msg: &[u8],
+	) -> std::result::Result<Option<bls377::Signature>, TraitError> {
+		self.sign::<bls377::Pair>(key_type, public, msg)
 	}
 
 	fn insert(
@@ -401,11 +478,12 @@ impl KeystoreInner {
 		let mut public_keys: Vec<Vec<u8>> = self
 			.additional
 			.keys()
+			.into_iter()
 			.filter_map(|k| if k.0 == key_type { Some(k.1.clone()) } else { None })
 			.collect();
 
 		if let Some(path) = &self.path {
-			for entry in fs::read_dir(path)? {
+			for entry in fs::read_dir(&path)? {
 				let entry = entry?;
 				let path = entry.path();
 

--- a/examples/examples/get_blocks_async.rs
+++ b/examples/examples/get_blocks_async.rs
@@ -16,6 +16,7 @@
 //! Very simple example that shows how to fetch chain information with async.
 //! To compile this example for async you need to set the `--no-default-features` flag
 
+#[cfg(not(feature = "sync-examples"))]
 use substrate_api_client::{
 	ac_primitives::SubstrateKitchensinkConfig,
 	rpc::{HandleSubscription, JsonrpseeClient},

--- a/examples/examples/get_storage.rs
+++ b/examples/examples/get_storage.rs
@@ -33,6 +33,8 @@ type AccountInfo = GenericAccountInfo<
 	<SubstrateKitchensinkConfig as Config>::AccountData,
 >;
 
+type Balance = <SubstrateKitchensinkConfig as Config>::Balance;
+
 #[tokio::main]
 async fn main() {
 	env_logger::init();
@@ -42,7 +44,7 @@ async fn main() {
 	let mut api = Api::<SubstrateKitchensinkConfig, _>::new(client).unwrap();
 
 	// get some plain storage value
-	let result: u128 = api.get_storage("Balances", "TotalIssuance", None).unwrap().unwrap();
+	let result: Balance = api.get_storage("Balances", "TotalIssuance", None).unwrap().unwrap();
 	println!("[+] TotalIssuance is {}", result);
 
 	let proof = api.get_storage_value_proof("Balances", "TotalIssuance", None).unwrap();
@@ -80,7 +82,7 @@ async fn main() {
 	// Get the storage values that belong to the retrieved storage keys.
 	for storage_key in storage_keys.iter() {
 		println!("Retrieving value for key {:?}", storage_key);
-		// We're expecting account info as return value because we fetch added a prefix of "System" + "Account".
+		// We're expecting account info as return value because we fetch a storage value with prefix combination of "System" + "Account".
 		let storage_data: AccountInfo =
 			api.get_storage_by_key(storage_key.clone(), None).unwrap().unwrap();
 		println!("Retrieved data {:?}", storage_data);
@@ -95,8 +97,8 @@ async fn main() {
 	// Get the storage values that belong to the retrieved storage keys.
 	for storage_key in double_map_storage_keys.iter() {
 		println!("Retrieving value for key {:?}", storage_key);
-		// We're expecting account info as return value because we fetch added a prefix of "System" + "Account".
-		let storage_data: Exposure<AccountId, u128> =
+		// We're expecting Exposure as return value because we fetch a storage value with prefix combination of "Staking" + "EraStakers" + 0.
+		let storage_data: Exposure<AccountId, Balance> =
 			api.get_storage_by_key(storage_key.clone(), None).unwrap().unwrap();
 		println!("Retrieved data {:?}", storage_data);
 	}

--- a/examples/examples/get_storage.rs
+++ b/examples/examples/get_storage.rs
@@ -16,7 +16,7 @@
 //! Very simple example that shows how to get some simple storage values.
 
 use frame_system::AccountInfo as GenericAccountInfo;
-use kitchensink_runtime::{AccountId, Runtime, Signature};
+use kitchensink_runtime::AccountId;
 use pallet_staking::Exposure;
 use sp_keyring::AccountKeyring;
 use substrate_api_client::{

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2023-04-03"
+channel = "nightly-2023-05-22"
 targets = ["wasm32-unknown-unknown"]
 profile = "default" # include rustfmt, clippy


### PR DESCRIPTION
- run `cargo update`
- updated rust toolchain to `nightly-2023-05-22`
- updated keystore according to Substrate changes
- removed some clippy warnings due to unused dependencies
- fixed comment and added Balance type to example `get_storage`

closes #577 