### PR TITLE
Prepare for tag v0.13.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,7 +100,7 @@ dependencies = [
 
 [[package]]
 name = "ac-testing"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "frame-support",
  "frame-system",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,7 @@ dependencies = [
 
 [[package]]
 name = "ac-compose-macros"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "ac-primitives",
  "log",
@@ -23,7 +23,7 @@ dependencies = [
 
 [[package]]
 name = "ac-examples"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "env_logger",
  "frame-support",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "ac-node-api"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "ac-primitives",
  "bitvec",
@@ -73,7 +73,7 @@ dependencies = [
 
 [[package]]
 name = "ac-primitives"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "frame-system",
  "impl-serde",
@@ -5660,7 +5660,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-api-client"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "ac-compose-macros",
  "ac-node-api",
@@ -5705,7 +5705,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-client-keystore"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "array-bytes",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-api-client"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["Supercomputing Systems AG <info@scs.ch>"]
 license = "Apache-2.0"
 edition = "2021"

--- a/client-keystore/Cargo.toml
+++ b/client-keystore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-client-keystore"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Supercomputing Systems AG <info@scs.ch>"]
 license = "Apache-2.0"
 edition = "2021"

--- a/compose-macros/Cargo.toml
+++ b/compose-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ac-compose-macros"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Supercomputing Systems AG <info@scs.ch>"]
 license = "Apache-2.0"
 edition = "2021"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ac-examples"
-version = "0.4.0"
+version = "0.4.1"
 license = "Apache-2.0"
 edition = "2021"
 

--- a/node-api/Cargo.toml
+++ b/node-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ac-node-api"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Supercomputing Systems AG <info@scs.ch>"]
 license = "Apache-2.0"
 edition = "2021"

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ac-primitives"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Supercomputing Systems AG <info@scs.ch>"]
 license = "Apache-2.0"
 edition = "2021"

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ac-testing"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Supercomputing Systems AG <info@scs.ch>"]
 license = "Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
Changes can be looked up here: https://github.com/scs/substrate-api-client/compare/v0.12.0...master

Summary:
- `api-client`: ⚡  Contains breaking changes due to node-api update.
- `client-keystore`:  no breaking changes, new functionality only
- `compose-macros`:  no breaking changes. Updates are internal only due to node-api update
- `examples`:  no breaking changes
- `node-api`:  ⚡   lots of breaking changes: see https://github.com/scs/substrate-api-client/pull/597
- `primitives`: ⚡  breaking changes due to removal of duplicate types: https://github.com/scs/substrate-api-client/pull/580
- `testing`: no breaking changes


closes #595 