### PR TITLE
fetch more storage keys than the maximum limit set by substrate

### DIFF
--- a/examples/examples/get_storage.rs
+++ b/examples/examples/get_storage.rs
@@ -76,7 +76,7 @@ async fn main() {
 	let storage_key_prefix = api.get_storage_map_key_prefix("System", "Account").unwrap();
 	let max_keys = 3;
 	let storage_keys = api
-		.get_storage_keys_paged(Some(storage_key_prefix), max_keys, None, None)
+		.get_storage_keys_paged_limited(Some(storage_key_prefix), max_keys, None, None)
 		.unwrap();
 	assert_eq!(storage_keys.len() as u32, max_keys);
 	// Get the storage values that belong to the retrieved storage keys.
@@ -91,7 +91,7 @@ async fn main() {
 	let storage_double_map_key_prefix =
 		api.get_storage_double_map_key_prefix("Staking", "ErasStakers", 0).unwrap();
 	let double_map_storage_keys = api
-		.get_storage_keys_paged(Some(storage_double_map_key_prefix), max_keys, None, None)
+		.get_storage_keys_paged_limited(Some(storage_double_map_key_prefix), max_keys, None, None)
 		.unwrap();
 
 	// Get the storage values that belong to the retrieved storage keys.

--- a/examples/examples/get_storage.rs
+++ b/examples/examples/get_storage.rs
@@ -76,7 +76,7 @@ async fn main() {
 	let storage_key_prefix = api.get_storage_map_key_prefix("System", "Account").unwrap();
 	let max_keys = 3;
 	let storage_keys = api
-		.get_storage_keys_paged_limited(Some(storage_key_prefix), max_keys, None, None)
+		.get_storage_keys_paged(Some(storage_key_prefix), max_keys, None, None)
 		.unwrap();
 	assert_eq!(storage_keys.len() as u32, max_keys);
 	// Get the storage values that belong to the retrieved storage keys.
@@ -91,7 +91,7 @@ async fn main() {
 	let storage_double_map_key_prefix =
 		api.get_storage_double_map_key_prefix("Staking", "ErasStakers", 0).unwrap();
 	let double_map_storage_keys = api
-		.get_storage_keys_paged_limited(Some(storage_double_map_key_prefix), max_keys, None, None)
+		.get_storage_keys_paged(Some(storage_double_map_key_prefix), max_keys, None, None)
 		.unwrap();
 
 	// Get the storage values that belong to the retrieved storage keys.

--- a/src/api/rpc_api/state.rs
+++ b/src/api/rpc_api/state.rs
@@ -297,7 +297,7 @@ where
 
 		while still_todo > 0 {
 			let new_count = if still_todo < STORAGE_KEYS_PAGED_MAX_COUNT {
-				still_todo.clone()
+				still_todo
 			} else {
 				STORAGE_KEYS_PAGED_MAX_COUNT
 			};
@@ -309,7 +309,7 @@ where
 			if keys.len() < STORAGE_KEYS_PAGED_MAX_COUNT as usize {
 				break
 			}
-			still_todo = still_todo - new_count.clone();
+			still_todo -= new_count;
 			new_key = keys.last().map(|x| x.to_owned());
 		}
 

--- a/src/api/rpc_api/state.rs
+++ b/src/api/rpc_api/state.rs
@@ -94,12 +94,12 @@ pub trait GetStorage {
 
 	/// Retrieve the keys with prefix with pagination support.
 	/// Call the RPC substrate storage_keys_paged, which limits the number of returned keys.
-	/// See https://github.com/paritytech/substrate/blob/9f6fecfeea15345c983629af275b1f1702a50004/client/rpc/src/state/mod.rs#L54
 	///
 	/// Up to `count` keys will be returned. If `count` is too big, an error will be returned
 	/// If `start_key` is passed, return next keys in storage in lexicographic order.
 	///
 	/// `at_block`: the state is queried at this block, set to `None` to get the state from the latest known block.
+	// See https://github.com/paritytech/substrate/blob/9f6fecfeea15345c983629af275b1f1702a50004/client/rpc/src/state/mod.rs#L54
 	async fn get_storage_keys_paged_limited(
 		&self,
 		prefix: Option<StorageKey>,

--- a/src/api/rpc_api/state.rs
+++ b/src/api/rpc_api/state.rs
@@ -306,9 +306,6 @@ where
 				.get_storage_keys_paged(storage_key_prefix.clone(), new_count, new_key, at_block)
 				.await?;
 			storage_keys.append(&mut keys);
-			if keys.len() < STORAGE_KEYS_PAGED_MAX_COUNT as usize {
-				break
-			}
 			still_todo -= new_count;
 			new_key = keys.last().map(|x| x.to_owned());
 		}

--- a/src/api/rpc_api/state.rs
+++ b/src/api/rpc_api/state.rs
@@ -26,7 +26,7 @@ use serde::de::DeserializeOwned;
 use sp_storage::{StorageChangeSet, StorageData, StorageKey};
 
 /// Default substrate value of maximum number of keys returned.
-/// See https://github.com/paritytech/substrate/blob/9f6fecfeea15345c983629af275b1f1702a50004/client/rpc/src/state/mod.rs#L54
+// See https://github.com/paritytech/substrate/blob/9f6fecfeea15345c983629af275b1f1702a50004/client/rpc/src/state/mod.rs#L54
 const STORAGE_KEYS_PAGED_MAX_COUNT: u32 = 1000;
 
 pub type StorageChangeSetSubscriptionFor<Client, Hash> =

--- a/testing/examples/state_tests.rs
+++ b/testing/examples/state_tests.rs
@@ -98,8 +98,7 @@ async fn main() {
 	let storage_keys = api
 		.get_all_storage_keys_paged_up_to_count(Some(storage_key_prefix), max_keys, None, None)
 		.unwrap();
-	assert!(storage_keys.len() as u32 > 3);
-	assert!(storage_keys.len() as u32 <= max_keys);
+	assert!(storage_keys.len() as u32 = 8);
 
 	let max_keys = 20;
 	let storage_keys = api.get_storage_keys_paged(None, max_keys.clone(), None, None).unwrap();

--- a/testing/examples/state_tests.rs
+++ b/testing/examples/state_tests.rs
@@ -98,7 +98,8 @@ async fn main() {
 	let storage_keys = api
 		.get_all_storage_keys_paged_up_to_count(Some(storage_key_prefix), max_keys, None, None)
 		.unwrap();
-	assert_eq!(storage_keys.len() as u32, 8);
+	assert!(storage_keys.len() as u32 > 3);
+	assert!(storage_keys.len() as u32 <= max_keys);
 
 	let max_keys = 20;
 	let storage_keys = api.get_storage_keys_paged(None, max_keys.clone(), None, None).unwrap();

--- a/testing/examples/state_tests.rs
+++ b/testing/examples/state_tests.rs
@@ -98,7 +98,7 @@ async fn main() {
 	let storage_keys = api
 		.get_all_storage_keys_paged_up_to_count(Some(storage_key_prefix), max_keys, None, None)
 		.unwrap();
-	assert!(storage_keys.len() as u32 = 8);
+	assert_eq!(storage_keys.len() as u32, 8);
 
 	let max_keys = 20;
 	let storage_keys = api.get_storage_keys_paged(None, max_keys.clone(), None, None).unwrap();

--- a/testing/examples/state_tests.rs
+++ b/testing/examples/state_tests.rs
@@ -90,22 +90,25 @@ async fn main() {
 	let _constants: Balance = api.get_constant("Balances", "ExistentialDeposit").unwrap();
 
 	let max_keys = 2003;
-	let result =
-		api.get_storage_keys_paged(Some(storage_key_prefix.clone()), max_keys.clone(), None, None);
+	let result = api.get_storage_keys_paged_limited(
+		Some(storage_key_prefix.clone()),
+		max_keys.clone(),
+		None,
+		None,
+	);
 	assert!(result.is_err());
 	assert!(format!("{result:?}").contains("count exceeds maximum value"));
 
 	let storage_keys = api
-		.get_all_storage_keys_paged_up_to_count(Some(storage_key_prefix), max_keys, None, None)
+		.get_storage_keys_paged(Some(storage_key_prefix), max_keys, None, None)
 		.unwrap();
-	assert!(storage_keys.len() as u32 > 3);
-	assert!(storage_keys.len() as u32 <= max_keys);
+	assert_eq!(storage_keys.len() as u32, 13);
 
 	let max_keys = 20;
-	let storage_keys = api.get_storage_keys_paged(None, max_keys.clone(), None, None).unwrap();
+	let storage_keys =
+		api.get_storage_keys_paged_limited(None, max_keys.clone(), None, None).unwrap();
 	assert_eq!(storage_keys.len() as u32, max_keys);
 
-	let storage_keys =
-		api.get_all_storage_keys_paged_up_to_count(None, max_keys, None, None).unwrap();
+	let storage_keys = api.get_storage_keys_paged(None, max_keys, None, None).unwrap();
 	assert_eq!(storage_keys.len() as u32, max_keys);
 }

--- a/testing/examples/state_tests.rs
+++ b/testing/examples/state_tests.rs
@@ -89,13 +89,23 @@ async fn main() {
 	let _keys = api.get_keys(storage_key, None).unwrap().unwrap();
 	let _constants: Balance = api.get_constant("Balances", "ExistentialDeposit").unwrap();
 
-	let max_keys = 3;
+	let max_keys = 2003;
+	let result =
+		api.get_storage_keys_paged(Some(storage_key_prefix.clone()), max_keys.clone(), None, None);
+	assert!(result.is_err());
+	assert!(format!("{result:?}").contains("count exceeds maximum value"));
+
 	let storage_keys = api
-		.get_storage_keys_paged(Some(storage_key_prefix), max_keys, None, None)
+		.get_all_storage_keys_paged_up_to_count(Some(storage_key_prefix), max_keys, None, None)
 		.unwrap();
-	assert_eq!(storage_keys.len() as u32, max_keys);
+	assert!(storage_keys.len() as u32 > 3);
+	assert!(storage_keys.len() as u32 <= max_keys);
 
 	let max_keys = 20;
-	let storage_keys = api.get_storage_keys_paged(None, max_keys, None, None).unwrap();
+	let storage_keys = api.get_storage_keys_paged(None, max_keys.clone(), None, None).unwrap();
+	assert_eq!(storage_keys.len() as u32, max_keys);
+
+	let storage_keys =
+		api.get_all_storage_keys_paged_up_to_count(None, max_keys, None, None).unwrap();
 	assert_eq!(storage_keys.len() as u32, max_keys);
 }


### PR DESCRIPTION
Add **get_all_storage_keys_paged_up_to_count** to fetch required number of keys, independantly of substrate limit:
- call several times the substrate RPC call with the max limited number (1000), if required

The default call, **get_storage_keys_paged** performs according to substrate: if required number of keys> 1000, an error is thrown. The documentation warns the user.

This does not completely fix #588. To fetch all pages, you need to know how many keys are stored. Currently,  `count `is mandatory in [`state_getKeysPaged`](https://github.com/paritytech/substrate/blob/fe2d51377fe1a8fbbb0599523f4fdc1422c82f81/client/rpc/src/state/mod.rs#L374) and substrate doesn't support the feature for obtaining all keys. 