### PR TITLE
Remove obsolete TransferEventArgs

### DIFF
--- a/examples/examples/event_error_details.rs
+++ b/examples/examples/event_error_details.rs
@@ -27,18 +27,6 @@ use substrate_api_client::{
 // To test this example in CI, we run it against the Substrate kitchensink node. Therefore, we use the SubstrateKitchensinkConfig
 // ! Careful: Most runtimes uses plain as tips, they need a polkadot config.
 
-#[derive(Decode)]
-struct TransferEventArgs {
-	_from: AccountId,
-	_to: AccountId,
-	_value: u128,
-}
-
-impl StaticEvent for TransferEventArgs {
-	const PALLET: &'static str = "Balances";
-	const EVENT: &'static str = "Transfer";
-}
-
 #[tokio::main]
 async fn main() {
 	env_logger::init();


### PR DESCRIPTION
TransferEventArgs was needed when we checked the transition with events (`wait_for_event`). No longer used
Closes https://github.com/scs/substrate-api-client/issues/506