### PR TITLE
Rework submit and watch extrinsics

### DIFF
--- a/examples/examples/compose_extrinsic_offline.rs
+++ b/examples/examples/compose_extrinsic_offline.rs
@@ -66,7 +66,7 @@ async fn main() {
 
 	// Send and watch extrinsic until in block (online).
 	let block_hash = api
-		.submit_and_watch_extrinsic_until(xt, XtStatus::InBlock)
+		.submit_and_watch_extrinsic_until_without_events(xt, XtStatus::InBlock)
 		.unwrap()
 		.block_hash
 		.unwrap();

--- a/examples/examples/contract_instantiate_with_code.rs
+++ b/examples/examples/contract_instantiate_with_code.rs
@@ -21,7 +21,7 @@ use sp_keyring::AccountKeyring;
 use substrate_api_client::{
 	ac_compose_macros::primitives::AssetRuntimeConfig, ac_node_api::StaticEvent,
 	ac_primitives::ExtrinsicSigner, extrinsic::ContractsExtrinsics, rpc::JsonrpseeClient, Api,
-	SubmitAndWatch, SubmitAndWatchUntilSuccess, XtStatus,
+	SubmitAndWatch, XtStatus,
 };
 
 // To test this example in CI, we run it against the Substrate kitchensink node. Therefore, we use the AssetRuntimeConfig

--- a/examples/examples/contract_instantiate_with_code.rs
+++ b/examples/examples/contract_instantiate_with_code.rs
@@ -69,7 +69,7 @@ async fn main() {
 	);
 
 	println!("[+] Creating a contract instance with extrinsic:\n\n{:?}\n", xt);
-	let report = api.submit_and_watch_extrinsic_until_success(xt, false).unwrap();
+	let report = api.submit_and_watch_extrinsic_until(xt, XtStatus::InBlock).unwrap();
 	println!("[+] Extrinsic is in Block. Hash: {:?}\n", report.block_hash.unwrap());
 
 	println!("[+] Waiting for the contracts.Instantiated event");
@@ -89,6 +89,8 @@ async fn main() {
 	let xt = api.contract_call(contract.into(), 500_000, 500_000, vec![0u8]);
 
 	println!("[+] Calling the contract with extrinsic Extrinsic:\n{:?}\n\n", xt);
-	let report = api.submit_and_watch_extrinsic_until(xt, XtStatus::Finalized).unwrap();
+	let report = api
+		.submit_and_watch_extrinsic_until_without_events(xt, XtStatus::Finalized)
+		.unwrap();
 	println!("[+] Extrinsic got finalized. Extrinsic Hash: {:?}", report.extrinsic_hash);
 }

--- a/examples/examples/custom_nonce.rs
+++ b/examples/examples/custom_nonce.rs
@@ -61,7 +61,7 @@ async fn main() {
 	println!("[+] Composed Extrinsic:\n {:?}\n", xt);
 
 	// Send and watch extrinsic until InBlock.
-	let result = api.submit_and_watch_extrinsic_until(xt, XtStatus::InBlock);
+	let result = api.submit_and_watch_extrinsic_until_without_events(xt, XtStatus::InBlock);
 	println!("Returned Result {:?}", result);
 	match result {
 		Err(Error::UnexpectedTxStatus(UnexpectedTxStatus::Future)) => {

--- a/examples/examples/event_error_details.rs
+++ b/examples/examples/event_error_details.rs
@@ -21,7 +21,7 @@ use substrate_api_client::{
 	ac_primitives::{AssetRuntimeConfig, ExtrinsicSigner},
 	extrinsic::BalancesExtrinsics,
 	rpc::JsonrpseeClient,
-	Api, GetAccountInformation, SubmitAndWatchUntilSuccess, XtStatus,
+	Api, GetAccountInformation, SubmitAndWatch, XtStatus,
 };
 
 // To test this example in CI, we run it against the Substrate kitchensink node. Therefore, we use the AssetRuntimeConfig

--- a/examples/examples/event_error_details.rs
+++ b/examples/examples/event_error_details.rs
@@ -21,7 +21,7 @@ use substrate_api_client::{
 	ac_primitives::{AssetRuntimeConfig, ExtrinsicSigner},
 	extrinsic::BalancesExtrinsics,
 	rpc::JsonrpseeClient,
-	Api, GetAccountInformation, SubmitAndWatchUntilSuccess,
+	Api, GetAccountInformation, SubmitAndWatchUntilSuccess, XtStatus,
 };
 
 // To test this example in CI, we run it against the Substrate kitchensink node. Therefore, we use the AssetRuntimeConfig
@@ -51,7 +51,7 @@ async fn main() {
 	println!("[+] Composed extrinsic: {:?}\n", xt);
 
 	// Send and watch extrinsic until InBlock.
-	let result = api.submit_and_watch_extrinsic_until_success(xt, false);
+	let result = api.submit_and_watch_extrinsic_until(xt, XtStatus::InBlock);
 	println!("[+] Transaction got included into the TxPool.");
 
 	// We expect the transfer to fail as Alice wants to transfer all her balance.

--- a/examples/examples/get_account_identity.rs
+++ b/examples/examples/get_account_identity.rs
@@ -65,7 +65,7 @@ async fn main() {
 
 	// Send and watch extrinsic until InBlock.
 	let _block_hash = api
-		.submit_and_watch_extrinsic_until(xt, XtStatus::InBlock)
+		.submit_and_watch_extrinsic_until_without_events(xt, XtStatus::InBlock)
 		.unwrap()
 		.block_hash
 		.unwrap();

--- a/examples/examples/staking_batch_payout.rs
+++ b/examples/examples/staking_batch_payout.rs
@@ -19,7 +19,7 @@ use substrate_api_client::{
 	ac_primitives::{AssetRuntimeConfig, ExtrinsicSigner},
 	extrinsic::{StakingExtrinsics, UtilityExtrinsics},
 	rpc::JsonrpseeClient,
-	Api, GetStorage, SubmitAndWatch, SubmitAndWatchUntilSuccess, XtStatus,
+	Api, GetStorage, SubmitAndWatch, XtStatus,
 };
 
 const MAX_BATCHED_TRANSACTION: u32 = 9;

--- a/examples/examples/staking_batch_payout.rs
+++ b/examples/examples/staking_batch_payout.rs
@@ -71,7 +71,7 @@ async fn main() {
 	// Sidenote: We could theoretically force a new era with sudo, but this takes at least 10 minutes ( = 1 epoch) in the
 	// kitchensink rutime. We don't want to wait that long.
 	let payout_staker_xt = api.payout_stakers(0, validator_stash);
-	let result = api.submit_and_watch_extrinsic_until_success(payout_staker_xt, false);
+	let result = api.submit_and_watch_extrinsic_until(payout_staker_xt, XtStatus::InBlock);
 	assert!(result.is_err());
 	assert!(format!("{result:?}").contains("InvalidEraToReward"));
 
@@ -130,7 +130,9 @@ async fn main() {
 			num_of_unclaimed_payouts -= tx_limit_in_current_batch;
 			let batch_xt = api.batch(payout_calls);
 
-			let report = api.submit_and_watch_extrinsic_until(batch_xt, XtStatus::InBlock).unwrap();
+			let report = api
+				.submit_and_watch_extrinsic_until_without_events(batch_xt, XtStatus::InBlock)
+				.unwrap();
 			results.push(format!("{report:?}"));
 		}
 		println!("{:?}", results);

--- a/examples/examples/sudo.rs
+++ b/examples/examples/sudo.rs
@@ -75,7 +75,7 @@ async fn main() {
 
 	// Send and watch extrinsic until in block.
 	let block_hash = api
-		.submit_and_watch_extrinsic_until(xt, XtStatus::InBlock)
+		.submit_and_watch_extrinsic_until_without_events(xt, XtStatus::InBlock)
 		.unwrap()
 		.block_hash
 		.unwrap();

--- a/examples/examples/transfer_with_tungstenite_client.rs
+++ b/examples/examples/transfer_with_tungstenite_client.rs
@@ -64,7 +64,7 @@ fn main() {
 
 	// Send and watch extrinsic until in block.
 	let block_hash = api
-		.submit_and_watch_extrinsic_until(xt, XtStatus::InBlock)
+		.submit_and_watch_extrinsic_until_without_events(xt, XtStatus::InBlock)
 		.unwrap()
 		.block_hash
 		.unwrap();

--- a/examples/examples/transfer_with_ws_client.rs
+++ b/examples/examples/transfer_with_ws_client.rs
@@ -63,7 +63,7 @@ fn main() {
 
 	// Send and watch extrinsic until in block.
 	let block_hash = api
-		.submit_and_watch_extrinsic_until(xt, XtStatus::InBlock)
+		.submit_and_watch_extrinsic_until_without_events(xt, XtStatus::InBlock)
 		.unwrap()
 		.block_hash
 		.unwrap();

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -25,8 +25,8 @@ pub use api_client::Api;
 pub use error::{Error, Result};
 pub use rpc_api::{
 	FetchEvents, GetAccountInformation, GetBalance, GetChainInfo, GetStorage,
-	GetTransactionPayment, SubmitAndWatch, SubmitAndWatchUntilSuccess, SubmitExtrinsic,
-	SubscribeChain, SubscribeEvents, SystemApi,
+	GetTransactionPayment, SubmitAndWatch, SubmitExtrinsic, SubscribeChain, SubscribeEvents,
+	SystemApi,
 };
 
 pub mod api_client;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -64,7 +64,7 @@ impl<Hash: Decode> ExtrinsicReport<Hash> {
 /// Simplified TransactionStatus to allow the user to choose until when to watch
 /// an extrinsic.
 // Indexes must match the TransactionStatus::as_u8 from below.
-#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+#[derive(Debug, PartialEq, PartialOrd, Eq, Copy, Clone)]
 pub enum XtStatus {
 	Ready = 1,
 	Broadcast = 2,

--- a/src/api/rpc_api/author.rs
+++ b/src/api/rpc_api/author.rs
@@ -163,7 +163,10 @@ pub trait SubmitAndWatchUntilSuccess {
 	/// - last known extrinsic (transaction) status
 	/// - associated events of the extrinsic
 	/// This method is blocking.
-	#[deprecated(note = "please use `submit_and_watch_extrinsic_until` instead")]
+	#[deprecated(
+		since = "0.14.0",
+		note = "please use `submit_and_watch_extrinsic_until` instead, this will be removed in the next release."
+	)]
 	async fn submit_and_watch_extrinsic_until_success<Address, Call, Signature, SignedExtra>(
 		&self,
 		extrinsic: UncheckedExtrinsicV4<Address, Call, Signature, SignedExtra>,
@@ -185,7 +188,10 @@ pub trait SubmitAndWatchUntilSuccess {
 	/// - last known extrinsic (transaction) status
 	/// - associated events of the extrinsic
 	/// This method is blocking.
-	#[deprecated(note = "please use `submit_and_watch_opaque_extrinsic_until` instead")]
+	#[deprecated(
+		since = "0.14.0",
+		note = "please use `submit_and_watch_opaque_extrinsic_until` instead, this will be removed in the next release."
+	)]
 	async fn submit_and_watch_opaque_extrinsic_until_success(
 		&self,
 		encoded_extrinsic: &Bytes,

--- a/src/api/rpc_api/author.rs
+++ b/src/api/rpc_api/author.rs
@@ -113,11 +113,11 @@ pub trait SubmitAndWatch {
 	/// - extrinsic hash
 	/// - hash of the block the extrinsic was included in
 	/// - last known extrinsic (transaction) status
-	/// - associated events of the extrinsic (only for InBlock or Finalized)
+	/// - associated events of the extrinsic
 	///
 	/// If not watched until at least `InBlock`, this function will not know if the extrinsic
-	/// has been executed on chain or not and will therefore not return an error if execution fails..
-	/// An error will be returned, if the extrinsic has failed to be sent or if it has not been
+	/// has been executed on chain or not and will therefore not return an error if execution fails.
+	/// An error will be returned if the extrinsic has failed to be sent or if it has not been
 	/// included into the transaction pool of the node.
 	/// If no error occurs, a report containing the following is returned:
 	/// - extrinsic hash
@@ -190,7 +190,7 @@ pub trait SubmitAndWatch {
 	/// Submit an encoded, opaque extrinsic and watch it until the desired status
 	/// is reached, if no error is encountered previously.
 	/// The events are not fetched. So no events are listed in the report.
-	/// To fetch the triggered events, please use submit_and_watch_opaque_extrinsic_until_success.
+	/// To fetch the triggered events, please use submit_and_watch_opaque_extrinsic_until.
 	/// Upon success, a report containing the following information is returned:
 	/// - extrinsic hash
 	/// - if watched until at least `InBlock`:

--- a/src/api/rpc_api/author.rs
+++ b/src/api/rpc_api/author.rs
@@ -106,13 +106,23 @@ pub trait SubmitAndWatch {
 
 	/// Submit an extrinsic and watch it until the desired status
 	/// is reached, if no error is encountered previously.
-	/// When status is InBlock or Finalized, the triggered events are listed in the report.
-	/// Returns and error if the extrinsic was not successfully executed.
+	///
+	/// If watched until `InBlock` or `Finalized`, this function will
+	/// return an error if the extrinsic was not successfully executed.
 	/// If it was successful, a report containing the following is returned:
 	/// - extrinsic hash
 	/// - hash of the block the extrinsic was included in
 	/// - last known extrinsic (transaction) status
 	/// - associated events of the extrinsic (only for InBlock or Finalized)
+	///
+	/// If not watched until at least `InBlock`, this function will not know if the extrinsic
+	/// has been executed on chain or not and will therefore not return an error if execution fails..
+	/// An error will be returned, if the extrinsic has failed to be sent or if it has not been
+	/// included into the transaction pool of the node.
+	/// If no error occurs, a report containing the following is returned:
+	/// - extrinsic hash
+	/// - last known extrinsic (transaction) status
+	///
 	/// This method is blocking.
 	async fn submit_and_watch_extrinsic_until<Address, Call, Signature, SignedExtra>(
 		&self,
@@ -127,13 +137,23 @@ pub trait SubmitAndWatch {
 
 	/// Submit an encoded, opaque extrinsic until the desired status
 	/// is reached, if no error is encountered previously.
-	/// When status is InBlock or Finalized, the triggered events are listed in the report.
-	/// Returns and error if the extrinsic was not successfully executed.
+	///
+	/// If watched until `InBlock` or `Finalized`, this function will
+	/// return an error if the extrinsic was not successfully executed.
 	/// If it was successful, a report containing the following is returned:
 	/// - extrinsic hash
 	/// - hash of the block the extrinsic was included in
 	/// - last known extrinsic (transaction) status
 	/// - associated events of the extrinsic (only for InBlock or Finalized)
+	///
+	/// If not watched until at least `InBlock`, this function will not know if the extrinsic
+	/// has been executed on chain or not and will therefore not return an error if execution fails..
+	/// An error will be returned, if the extrinsic has failed to be sent or if it has not been
+	/// included into the transaction pool of the node.
+	/// If no error occurs, a report containing the following is returned:
+	/// - extrinsic hash
+	/// - last known extrinsic (transaction) status
+	///
 	/// This method is blocking.
 	async fn submit_and_watch_opaque_extrinsic_until(
 		&self,

--- a/testing/examples/author_tests.rs
+++ b/testing/examples/author_tests.rs
@@ -67,11 +67,10 @@ async fn main() {
 
 	thread::sleep(Duration::from_secs(6)); // Wait a little to avoid transaction too low priority error.
 	let xt2 = api.balance_transfer_allow_death(bob.clone(), 1000);
-	let report = api
-		.submit_and_watch_extrinsic_until_without_events(xt2, XtStatus::Ready)
-		.unwrap();
+	let report = api.submit_and_watch_extrinsic_until(xt2, XtStatus::Ready).unwrap();
 	assert!(report.block_hash.is_none());
-	println!("Success: submit_and_watch_extrinsic_until_without_events Ready");
+	assert!(report.events.is_none());
+	println!("Success: submit_and_watch_extrinsic_until Ready");
 
 	thread::sleep(Duration::from_secs(6)); // Wait a little to avoid transaction too low priority error.
 	let xt3 = api.balance_transfer_allow_death(bob.clone(), 1000);

--- a/testing/examples/author_tests.rs
+++ b/testing/examples/author_tests.rs
@@ -67,30 +67,32 @@ async fn main() {
 
 	thread::sleep(Duration::from_secs(6)); // Wait a little to avoid transaction too low priority error.
 	let xt2 = api.balance_transfer_allow_death(bob.clone(), 1000);
-	let report = api.submit_and_watch_extrinsic_until(xt2, XtStatus::Ready).unwrap();
+	let report = api
+		.submit_and_watch_extrinsic_until_without_events(xt2, XtStatus::Ready)
+		.unwrap();
 	assert!(report.block_hash.is_none());
-	println!("Success: submit_and_watch_extrinsic_until Ready");
+	println!("Success: submit_and_watch_extrinsic_until_without_events Ready");
 
 	thread::sleep(Duration::from_secs(6)); // Wait a little to avoid transaction too low priority error.
 	let xt3 = api.balance_transfer_allow_death(bob.clone(), 1000);
 	// The xt is not broadcast - we only have one node running. Therefore, InBlock is returned.
 	let _some_hash = api
-		.submit_and_watch_extrinsic_until(xt3, XtStatus::Broadcast)
+		.submit_and_watch_extrinsic_until_without_events(xt3, XtStatus::Broadcast)
 		.unwrap()
 		.block_hash
 		.unwrap();
-	println!("Success: submit_and_watch_extrinsic_until Broadcast");
+	println!("Success: submit_and_watch_extrinsic_until_without_events Broadcast");
 
 	let api2 = api.clone();
 	thread::sleep(Duration::from_secs(6)); // Wait a little to avoid transaction too low priority error.
 	let xt4 = api2.balance_transfer_allow_death(bob.clone(), 1000);
 	let until_in_block_handle = thread::spawn(move || {
 		let _block_hash = api2
-			.submit_and_watch_extrinsic_until(xt4, XtStatus::InBlock)
+			.submit_and_watch_extrinsic_until_without_events(xt4, XtStatus::InBlock)
 			.unwrap()
 			.block_hash
 			.unwrap();
-		println!("Success: submit_and_watch_extrinsic_until InBlock");
+		println!("Success: submit_and_watch_extrinsic_until_without_events InBlock");
 	});
 
 	let api3 = api.clone();
@@ -98,11 +100,11 @@ async fn main() {
 	let xt5 = api.balance_transfer_allow_death(bob.clone(), 1000);
 	let until_finalized_handle = thread::spawn(move || {
 		let _block_hash = api3
-			.submit_and_watch_extrinsic_until(xt5, XtStatus::Finalized)
+			.submit_and_watch_extrinsic_until_without_events(xt5, XtStatus::Finalized)
 			.unwrap()
 			.block_hash
 			.unwrap();
-		println!("Success: submit_and_watch_extrinsic_until Finalized");
+		println!("Success: submit_and_watch_extrinsic_until_without_events Finalized");
 	});
 
 	// Test Success.
@@ -110,7 +112,7 @@ async fn main() {
 	let xt6 = api.balance_transfer_allow_death(bob, 1000);
 
 	let events = api
-		.submit_and_watch_extrinsic_until_success(xt6, false)
+		.submit_and_watch_extrinsic_until(xt6, XtStatus::InBlock)
 		.unwrap()
 		.events
 		.unwrap();

--- a/testing/examples/author_tests.rs
+++ b/testing/examples/author_tests.rs
@@ -25,7 +25,7 @@ use substrate_api_client::{
 	},
 	extrinsic::BalancesExtrinsics,
 	rpc::{HandleSubscription, JsonrpseeClient},
-	Api, SubmitAndWatch, SubmitAndWatchUntilSuccess, SubmitExtrinsic, TransactionStatus, XtStatus,
+	Api, SubmitAndWatch, SubmitExtrinsic, TransactionStatus, XtStatus,
 };
 
 type ExtrinsicSigner = GenericExtrinsicSigner<AssetRuntimeConfig>;

--- a/testing/examples/dispatch_errors_tests.rs
+++ b/testing/examples/dispatch_errors_tests.rs
@@ -21,7 +21,7 @@ use substrate_api_client::{
 	ac_primitives::{AssetRuntimeConfig, ExtrinsicSigner},
 	extrinsic::BalancesExtrinsics,
 	rpc::JsonrpseeClient,
-	Api, GetAccountInformation, SubmitAndWatchUntilSuccess, XtStatus,
+	Api, GetAccountInformation, SubmitAndWatch, XtStatus,
 };
 
 #[tokio::main]

--- a/testing/examples/dispatch_errors_tests.rs
+++ b/testing/examples/dispatch_errors_tests.rs
@@ -21,7 +21,7 @@ use substrate_api_client::{
 	ac_primitives::{AssetRuntimeConfig, ExtrinsicSigner},
 	extrinsic::BalancesExtrinsics,
 	rpc::JsonrpseeClient,
-	Api, GetAccountInformation, SubmitAndWatchUntilSuccess,
+	Api, GetAccountInformation, SubmitAndWatchUntilSuccess, XtStatus,
 };
 
 #[tokio::main]
@@ -49,7 +49,7 @@ async fn main() {
 	//Can only be called by root
 	let xt = api.balance_force_set_balance(MultiAddress::Id(alice.clone()), 10);
 
-	let result = api.submit_and_watch_extrinsic_until_success(xt, false);
+	let result = api.submit_and_watch_extrinsic_until(xt, XtStatus::InBlock);
 	assert!(result.is_err());
 	assert!(format!("{result:?}").contains("BadOrigin"));
 	println!("[+] BadOrigin error: Bob can't force set balance");
@@ -57,7 +57,7 @@ async fn main() {
 	//BelowMinimum
 	api.set_signer(ExtrinsicSigner::<AssetRuntimeConfig>::new(alice_signer));
 	let xt = api.balance_transfer_allow_death(MultiAddress::Id(one.clone()), 999999);
-	let result = api.submit_and_watch_extrinsic_until_success(xt, false);
+	let result = api.submit_and_watch_extrinsic_until(xt, XtStatus::InBlock);
 	assert!(result.is_err());
 	assert!(format!("{result:?}").contains("(BelowMinimum"));
 	println!("[+] BelowMinimum error: balance (999999) is below the existential deposit");

--- a/testing/examples/events_tests.rs
+++ b/testing/examples/events_tests.rs
@@ -59,7 +59,9 @@ async fn main() {
 
 	// Submit a test-extrinisc to test `fetch_events_for_extrinsic`.
 	let xt = api.balance_transfer_allow_death(bob.into(), 1000);
-	let report = api.submit_and_watch_extrinsic_until(xt, XtStatus::InBlock).unwrap();
+	let report = api
+		.submit_and_watch_extrinsic_until_without_events(xt, XtStatus::InBlock)
+		.unwrap();
 
 	let extrinisc_events = api
 		.fetch_events_for_extrinsic(report.extrinsic_hash, report.block_hash.unwrap())


### PR DESCRIPTION
Rename functions to clarify that events are not always listed in the extrinisc report:
- Light version: `submit_and_watch_extrinsic_until_without_events`: submit and watch the extrinsic until the desired status is reached. No events are fetched, so no events are listed in the report. 
- `submit_and_watch_extrinsic_until`: submit and watch the extrinsic until the desired status is reached. When the extrinisc is InBlock or Finalized, the events are retrieved and added in the report.

**Caution**: The previous function `submit_and_watch_extrinsic_until_success ` is deprecated, but `submit_and_watch_extrinsic_until` has different behaviour. Previously it didn't fetch the events. Now it does so for InBlock and Finalized status

Closes https://github.com/scs/substrate-api-client/issues/592
 