### PR TITLE
Fix reported extrinsic hash

### DIFF
--- a/examples/examples/check_extrinsic_events.rs
+++ b/examples/examples/check_extrinsic_events.rs
@@ -100,7 +100,6 @@ async fn main() {
 			println!("[+] Extrinsic with hash {extrinsic_hash:?} was successfully executed.",);
 			println!("[+] Extrinsic got included in block with hash {block_hash:?}");
 			println!("[+] Watched extrinsic until it reached the status {extrinsic_status:?}");
-			println!("[+] The following events were thrown when the extrinsic was executed: {extrinsic_events:?}");
 
 			assert!(matches!(extrinsic_status, TransactionStatus::InBlock(_block_hash)));
 			assert_associated_events_match_expected(extrinsic_events);

--- a/src/api/rpc_api/author.rs
+++ b/src/api/rpc_api/author.rs
@@ -358,7 +358,7 @@ where
 		encoded_extrinsic: &Bytes,
 		watch_until: XtStatus,
 	) -> Result<ExtrinsicReport<Self::Hash>> {
-		let tx_hash = T::Hasher::hash_of(&encoded_extrinsic.0);
+		let tx_hash = T::Hasher::hash(encoded_extrinsic);
 		let mut subscription: TransactionSubscriptionFor<Self::Client, Self::Hash> =
 			self.submit_and_watch_opaque_extrinsic(encoded_extrinsic).await?;
 

--- a/src/api/rpc_api/events.rs
+++ b/src/api/rpc_api/events.rs
@@ -379,9 +379,9 @@ mod tests {
 		let xt2: Bytes = UncheckedExtrinsic::new_unsigned(call2).encode().into();
 		let xt3: Bytes = UncheckedExtrinsic::new_unsigned(call3).encode().into();
 
-		let xt_hash1 = <DefaultRuntimeConfig as Config>::Hasher::hash_of(&xt1.0);
-		let xt_hash2 = <DefaultRuntimeConfig as Config>::Hasher::hash_of(&xt2.0);
-		let xt_hash3 = <DefaultRuntimeConfig as Config>::Hasher::hash_of(&xt3.0);
+		let xt_hash1 = <DefaultRuntimeConfig as Config>::Hasher::hash(&xt1);
+		let xt_hash2 = <DefaultRuntimeConfig as Config>::Hasher::hash(&xt2);
+		let xt_hash3 = <DefaultRuntimeConfig as Config>::Hasher::hash(&xt3);
 
 		let block = Block { header: default_header(), extrinsics: vec![xt1, xt2, xt3] };
 		let signed_block = SignedBlock { block, justifications: None };

--- a/src/api/rpc_api/events.rs
+++ b/src/api/rpc_api/events.rs
@@ -20,7 +20,7 @@ use ac_compose_macros::rpc_params;
 use ac_node_api::{metadata::Metadata, EventDetails, EventRecord, Events, Phase};
 use ac_primitives::config::Config;
 use alloc::{vec, vec::Vec};
-use codec::{Decode, Encode};
+use codec::Decode;
 use core::marker::PhantomData;
 use log::*;
 use serde::de::DeserializeOwned;

--- a/src/api/rpc_api/events.rs
+++ b/src/api/rpc_api/events.rs
@@ -194,7 +194,7 @@ where
 			.extrinsics()
 			.iter()
 			.position(|xt| {
-				let xt_hash = T::Hasher::hash_of(&xt.encode());
+				let xt_hash = T::Hasher::hash_of(&xt);
 				trace!("Looking for: {:?}, got xt_hash {:?}", extrinsic_hash, xt_hash);
 				extrinsic_hash == xt_hash
 			})

--- a/testing/examples/author_tests.rs
+++ b/testing/examples/author_tests.rs
@@ -67,6 +67,8 @@ async fn main() {
 	thread::sleep(Duration::from_secs(6)); // Wait a little to avoid transaction too low priority error.
 	let xt2 = api.balance_transfer_allow_death(bob.clone(), 1000);
 	let report = api.submit_and_watch_extrinsic_until(xt2, XtStatus::Ready).unwrap();
+	let extrinsic_hash = sp_core::blake2_256(xt2.encode()).into();
+	assert_eq!(extrinsic_hash, report.extrinsic_hash);
 	assert!(report.block_hash.is_none());
 	assert!(matches!(report.status, TransactionStatus::Ready));
 	assert!(report.events.is_none());

--- a/testing/examples/author_tests.rs
+++ b/testing/examples/author_tests.rs
@@ -16,6 +16,7 @@
 //! Tests for the author rpc interface functions.
 
 use kitchensink_runtime::AccountId;
+use sp_core::{Encode, H256};
 use sp_keyring::AccountKeyring;
 use std::{thread, time::Duration};
 use substrate_api_client::{
@@ -66,8 +67,8 @@ async fn main() {
 	// Test different _watch_untils with events
 	thread::sleep(Duration::from_secs(6)); // Wait a little to avoid transaction too low priority error.
 	let xt2 = api.balance_transfer_allow_death(bob.clone(), 1000);
+	let extrinsic_hash: H256 = sp_core::blake2_256(&xt2.encode()).into();
 	let report = api.submit_and_watch_extrinsic_until(xt2, XtStatus::Ready).unwrap();
-	let extrinsic_hash = sp_core::blake2_256(xt2.encode()).into();
 	assert_eq!(extrinsic_hash, report.extrinsic_hash);
 	assert!(report.block_hash.is_none());
 	assert!(matches!(report.status, TransactionStatus::Ready));


### PR DESCRIPTION
The problem was that we encoded the extrinsic twice: `T::Hasher::hash_of(..) ` encodes the input automatically. We therefore need to use `T::Hasher::hash(..) ` for the already encoded extrinsic.


The extrinsic hash can be manually checked by:
 - run a local node `docker run -p 9944:9944 -p 9933:9933 -p 30333:30333 parity/substrate:latest --dev --rpc-external`
 - run example printing xt_hash: `cargo run -p ac-examples --example check_extrinsic_events`
 - compare printed extrinsic hash with the one on polkadot.js (https://polkadot.js.org/apps/?rpc=ws%3A%2F%2F127.0.0.1%3A9944#/explorer)

closes https://github.com/scs/substrate-api-client/issues/621