### PR TITLE
Add subscription ID recognition to tungstenite and ws-rpc client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,8 +153,10 @@ jobs:
           pallet_balances_tests,
           pallet_transaction_payment_tests,
           state_tests,
+          tungstenite_client_test,
+          state_tests,
           runtime_update_sync,
-          runtime_update_async,
+          ws_client_test,
         ]
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,7 @@ jobs:
           ws_client_test,
           state_tests,
           runtime_update_sync,
-          runtime_update_async
+          runtime_update_async,
         ]
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,9 +154,10 @@ jobs:
           pallet_transaction_payment_tests,
           state_tests,
           tungstenite_client_test,
+          ws_client_test,
           state_tests,
           runtime_update_sync,
-          ws_client_test,
+          runtime_update_async
         ]
     steps:
       - uses: actions/checkout@v3

--- a/examples/examples/transfer_with_ws_client.rs
+++ b/examples/examples/transfer_with_ws_client.rs
@@ -54,8 +54,22 @@ fn main() {
 	let bob_balance = api.get_account_data(&bob.into()).unwrap().unwrap_or_default().free;
 	println!("[+] Bob's Free Balance is {}\n", bob_balance);
 
-	// Generate extrinsic.
-	let xt = api.balance_transfer_allow_death(MultiAddress::Id(bob.into()), 1000000000000);
+	// We first generate an extrinsic that will fail to be executed due to missing funds.
+	let xt = api.balance_transfer_allow_death(MultiAddress::Id(bob.into()), bob_balance + 1);
+	println!(
+		"Sending an extrinsic from Alice (Key = {}),\n\nto Bob (Key = {})\n",
+		alice.public(),
+		bob
+	);
+	println!("[+] Composed extrinsic: {:?}\n", xt);
+
+	// Send and watch extrinsic until it fails onchain.
+	let result = api.submit_and_watch_extrinsic_until(xt, XtStatus::InBlock);
+	assert!(result.is_err());
+	println!("[+] Extrinsic did not get included due to: {:?}\n", result);
+
+	// This time, we generate an extrinsic that will succeed.
+	let xt = api.balance_transfer_allow_death(MultiAddress::Id(bob.into()), bob_balance / 2);
 	println!(
 		"Sending an extrinsic from Alice (Key = {}),\n\nto Bob (Key = {})\n",
 		alice.public(),
@@ -69,7 +83,7 @@ fn main() {
 		.unwrap()
 		.block_hash
 		.unwrap();
-	println!("[+] Extrinsic got included. Hash: {:?}\n", block_hash);
+	println!("[+] Extrinsic got included. Block Hash: {:?}\n", block_hash);
 
 	// Verify that Bob's free Balance increased.
 	let bob_new_balance = api.get_account_data(&bob.into()).unwrap().unwrap().free;

--- a/src/rpc/error.rs
+++ b/src/rpc/error.rs
@@ -22,7 +22,7 @@ pub type Result<T> = core::result::Result<T, Error>;
 #[derive(Debug)]
 pub enum Error {
 	SerdeJson(serde_json::error::Error),
-	UnexpectedResponse(String),
+	ExtrinsicFailed(String),
 	MpscSend(String),
 	InvalidUrl(String),
 	RecvError(String),

--- a/src/rpc/error.rs
+++ b/src/rpc/error.rs
@@ -22,6 +22,7 @@ pub type Result<T> = core::result::Result<T, Error>;
 #[derive(Debug)]
 pub enum Error {
 	SerdeJson(serde_json::error::Error),
+	UnexpectedResponse(String),
 	MpscSend(String),
 	InvalidUrl(String),
 	RecvError(String),

--- a/src/rpc/helpers.rs
+++ b/src/rpc/helpers.rs
@@ -1,0 +1,144 @@
+/*
+   Copyright 2019 Supercomputing Systems AG
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+	   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+*/
+
+use serde_json::Value;
+
+pub fn read_subscription_id(value: &Value) -> Option<String> {
+	value["result"].as_str().map(|str| str.to_string())
+}
+
+pub fn read_error_message(value: &Value, msg: &str) -> String {
+	match value["error"].as_str() {
+		Some(error_message) => error_message.to_string(),
+		None => format!("Unexpected Response: {}", msg),
+	}
+}
+
+pub fn subscription_id_matches(value: &Value, subscription_id: &str) -> bool {
+	match value["params"]["subscription"].as_str() {
+		Some(retrieved_subscription_id) => subscription_id == retrieved_subscription_id,
+		None => false,
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use serde_json::json;
+
+	#[test]
+	fn read_valid_subscription_response() {
+		let subcription_id = "tejkataa12124a";
+		let value = json!({
+			"result": subcription_id,
+			"id": 43,
+			"and_so_on": "test",
+		});
+
+		let maybe_subcription_id = read_subscription_id(&value);
+		assert_eq!(maybe_subcription_id, Some(subcription_id.to_string()));
+	}
+
+	#[test]
+	fn read_invalid_subscription_response() {
+		let subcription_id = "tejkataa12124a";
+		let value = json!({
+			"error": subcription_id,
+			"id": 43,
+			"and_so_on": "test",
+		});
+
+		let maybe_subcription_id = read_subscription_id(&value);
+		assert!(maybe_subcription_id.is_none());
+	}
+
+	#[test]
+	fn read_error_message_returns_error_if_available() {
+		let error_message = "some_error_message";
+		let value = json!({
+			"error": error_message,
+			"id": 43,
+			"and_so_on": "test",
+		});
+
+		let msg = serde_json::to_string(&value).unwrap();
+
+		let message = read_error_message(&value, &msg);
+		assert!(message.contains(error_message));
+		assert!(message.contains("error"));
+	}
+
+	#[test]
+	fn read_error_message_returns_full_msg_if_error_is_not_available() {
+		let error_message = "some_error_message";
+		let value = json!({
+			"result": error_message,
+			"id": 43,
+			"and_so_on": "test",
+		});
+
+		let msg = serde_json::to_string(&value).unwrap();
+
+		let message = read_error_message(&value, &msg);
+		assert!(message.contains(&msg));
+	}
+
+	#[test]
+	fn subscription_id_matches_returns_true_for_equal_id() {
+		let subcription_id = "tejkataa12124a";
+		let value = json!({
+			"params": {
+				"subscription": subcription_id,
+				"message": "Test"
+			},
+			"id": 43,
+			"and_so_on": "test",
+		});
+
+		assert!(subscription_id_matches(&value, subcription_id));
+	}
+
+	#[test]
+	fn subscription_id_matches_returns_false_for_not_equal_id() {
+		let subcription_id = "tejkataa12124a";
+		let value = json!({
+			"params": {
+				"subscription": "something else",
+				"message": "Test"
+			},
+			"id": 43,
+			"and_so_on": "test",
+		});
+
+		assert!(!subscription_id_matches(&value, subcription_id));
+	}
+
+	#[test]
+	fn subscription_id_matches_returns_false_for_missing_subscription() {
+		let subcription_id = "tejkataa12124a";
+		let value = json!({
+			"params": {
+				"result": subcription_id,
+				"message": "Test"
+			},
+			"id": 43,
+			"and_so_on": "test",
+		});
+
+		assert!(!subscription_id_matches(&value, subcription_id));
+	}
+}

--- a/src/rpc/helpers.rs
+++ b/src/rpc/helpers.rs
@@ -15,6 +15,10 @@
 
 */
 
+use alloc::{
+	format,
+	string::{String, ToString},
+};
 use serde_json::Value;
 
 pub fn read_subscription_id(value: &Value) -> Option<String> {

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -35,6 +35,7 @@ pub use jsonrpsee_client::JsonrpseeClient;
 pub mod jsonrpsee_client;
 
 pub mod error;
+#[cfg(any(feature = "ws-client", feature = "tungstenite-client"))]
 mod helpers;
 
 pub use error::{Error, Result};

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -35,6 +35,7 @@ pub use jsonrpsee_client::JsonrpseeClient;
 pub mod jsonrpsee_client;
 
 pub mod error;
+mod helpers;
 
 pub use error::{Error, Result};
 

--- a/src/rpc/tungstenite_client/client.rs
+++ b/src/rpc/tungstenite_client/client.rs
@@ -168,7 +168,7 @@ fn send_message_to_client(
 	message: &str,
 	subscription_id: &str,
 ) -> Result<()> {
-	error!("got on_subscription_msg {}", message);
+	info!("got on_subscription_msg {}", message);
 	let value: Value = serde_json::from_str(message)?;
 
 	if let Some(msg_subscription_id) = value["params"]["subscription"].as_str() {

--- a/src/rpc/tungstenite_client/client.rs
+++ b/src/rpc/tungstenite_client/client.rs
@@ -141,8 +141,6 @@ fn subscribe_to_server(
 	let subcription_id = match value["result"].as_str() {
 		Some(id) => id,
 		None => {
-			error!("response: {:?} ", value["error"]);
-
 			let message = match value["error"]["message"].is_string() {
 				true => serde_json::to_string(&value["error"])?,
 				false => format!("Received unexpected response:  {}", msg),

--- a/src/rpc/tungstenite_client/subscription.rs
+++ b/src/rpc/tungstenite_client/subscription.rs
@@ -15,7 +15,7 @@
 
 */
 
-use crate::rpc::{HandleSubscription, Result};
+use crate::rpc::{Error, HandleSubscription, Result};
 use core::marker::PhantomData;
 use serde::de::DeserializeOwned;
 use std::sync::mpsc::Receiver;
@@ -42,7 +42,10 @@ impl<Notification: DeserializeOwned> HandleSubscription<Notification>
 			// Sender was disconnected, therefore no further messages are to be expected.
 			Err(_e) => return None,
 		};
-		Some(serde_json::from_str(&notification).map_err(|e| e.into()))
+		Some(
+			serde_json::from_str(&notification)
+				.map_err(|_| Error::UnexpectedResponse(notification)),
+		)
 	}
 
 	async fn unsubscribe(self) -> Result<()> {

--- a/src/rpc/tungstenite_client/subscription.rs
+++ b/src/rpc/tungstenite_client/subscription.rs
@@ -42,10 +42,7 @@ impl<Notification: DeserializeOwned> HandleSubscription<Notification>
 			// Sender was disconnected, therefore no further messages are to be expected.
 			Err(_e) => return None,
 		};
-		Some(
-			serde_json::from_str(&notification)
-				.map_err(|_| Error::UnexpectedResponse(notification)),
-		)
+		Some(serde_json::from_str(&notification).map_err(|_| Error::ExtrinsicFailed(notification)))
 	}
 
 	async fn unsubscribe(self) -> Result<()> {

--- a/src/rpc/ws_client/client.rs
+++ b/src/rpc/ws_client/client.rs
@@ -50,7 +50,7 @@ impl WsRpcClient {
 impl Request for WsRpcClient {
 	async fn request<R: DeserializeOwned>(&self, method: &str, params: RpcParams) -> Result<R> {
 		let json_req = to_json_req(method, params)?;
-		let response = self.direct_rpc_request(json_req, RequestHandler::default())??;
+		let response = self.direct_rpc_request(json_req, RequestHandler)??;
 		let deserialized_value: R = serde_json::from_str(&response)?;
 		Ok(deserialized_value)
 	}

--- a/src/rpc/ws_client/mod.rs
+++ b/src/rpc/ws_client/mod.rs
@@ -118,7 +118,7 @@ impl HandleMessage for SubscriptionHandler {
 		let value: serde_json::Value = serde_json::from_str(msg.as_text()?).map_err(Box::new)?;
 
 		if value["error"]["message"].is_string() {
-			let _ result.send(serde_json::to_string(&value["error"]).map_err(Box::new)?);
+			let _ = result.send(serde_json::to_string(&value["error"]).map_err(Box::new)?);
 			out.close(CloseCode::Normal)?;
 			return Ok(())
 		}

--- a/src/rpc/ws_client/mod.rs
+++ b/src/rpc/ws_client/mod.rs
@@ -118,7 +118,7 @@ impl HandleMessage for SubscriptionHandler {
 		let value: serde_json::Value = serde_json::from_str(msg.as_text()?).map_err(Box::new)?;
 
 		if value["error"]["message"].is_string() {
-			result.send(serde_json::to_string(&value["error"]).map_err(Box::new)?);
+			let _ result.send(serde_json::to_string(&value["error"]).map_err(Box::new)?);
 			out.close(CloseCode::Normal)?;
 			return Ok(())
 		}
@@ -141,20 +141,6 @@ impl HandleMessage for SubscriptionHandler {
 				},
 			},
 		};
-
-		// let result = if let Some(_subscription_id) = value["params"]["subscription"].as_str() {
-		// 	result.send(serde_json::to_string(&value["params"]["result"]).map_err(Box::new)?)
-		// } else if let Some(error) = value["error"].as_str() {
-		// 	info!("Error {}", error);
-		// 	result.send(serde_json::to_string(&value["error"]).map_err(Box::new)?)
-		// } else {
-		// 	// Id string is accepted, since it is the immediate response to a subscription message.
-		// 	error!(
-		// 		"Got subscription id {}",
-		// 		serde_json::to_string(&value["result"]).map_err(Box::new)?
-		// 	);
-		// 	Ok(())
-		// };
 
 		if let Err(e) = send_result {
 			// This may happen if the receiver has unsubscribed.

--- a/src/rpc/ws_client/mod.rs
+++ b/src/rpc/ws_client/mod.rs
@@ -114,7 +114,7 @@ impl HandleMessage for SubscriptionHandler {
 		let out = &context.out;
 		let msg = &context.msg;
 
-		error!("got on_subscription_msg {}", msg);
+		info!("got on_subscription_msg {}", msg);
 		let value: serde_json::Value = serde_json::from_str(msg.as_text()?).map_err(Box::new)?;
 
 		if value["error"]["message"].is_string() {

--- a/src/rpc/ws_client/subscription.rs
+++ b/src/rpc/ws_client/subscription.rs
@@ -44,10 +44,7 @@ impl<Notification: DeserializeOwned> HandleSubscription<Notification>
 			// Sender was disconnected, therefore no further messages are to be expected.
 			Err(_) => return None,
 		};
-		Some(
-			serde_json::from_str(&notification)
-				.map_err(|_| Error::UnexpectedResponse(notification)),
-		)
+		Some(serde_json::from_str(&notification).map_err(|_| Error::ExtrinsicFailed(notification)))
 	}
 
 	async fn unsubscribe(self) -> Result<()> {

--- a/src/rpc/ws_client/subscription.rs
+++ b/src/rpc/ws_client/subscription.rs
@@ -15,7 +15,7 @@
 
 */
 
-use crate::rpc::{HandleSubscription, Result};
+use crate::rpc::{Error, HandleSubscription, Result};
 use core::marker::PhantomData;
 use serde::de::DeserializeOwned;
 use std::sync::mpsc::Receiver;
@@ -44,7 +44,10 @@ impl<Notification: DeserializeOwned> HandleSubscription<Notification>
 			// Sender was disconnected, therefore no further messages are to be expected.
 			Err(_) => return None,
 		};
-		Some(serde_json::from_str(&notification).map_err(|e| e.into()))
+		Some(
+			serde_json::from_str(&notification)
+				.map_err(|_| Error::UnexpectedResponse(notification)),
+		)
 	}
 
 	async fn unsubscribe(self) -> Result<()> {

--- a/testing/examples/tungstenite_client_test.rs
+++ b/testing/examples/tungstenite_client_test.rs
@@ -19,7 +19,6 @@ use sp_core::{
 };
 use sp_runtime::MultiAddress;
 use substrate_api_client::{
-	ac_node_api::error::{DispatchError, TokenError},
 	ac_primitives::{AssetRuntimeConfig, ExtrinsicSigner},
 	extrinsic::BalancesExtrinsics,
 	rpc::TungsteniteRpcClient,
@@ -53,7 +52,7 @@ fn main() {
 
 	// Check for successful extrinisc
 	let xt = api.balance_transfer_allow_death(MultiAddress::Id(bob.into()), bob_balance / 2);
-	let block_hash = api
+	let _block_hash = api
 		.submit_and_watch_extrinsic_until(xt, XtStatus::InBlock)
 		.unwrap()
 		.block_hash

--- a/testing/examples/tungstenite_client_test.rs
+++ b/testing/examples/tungstenite_client_test.rs
@@ -44,10 +44,7 @@ fn main() {
 	// Check for failed extrinsic failed onchain
 	let xt = api.balance_transfer_allow_death(MultiAddress::Id(bob.into()), bob_balance + 1);
 	let result = api.submit_and_watch_extrinsic_until(xt.clone(), XtStatus::InBlock);
-	match result {
-		Ok(_) => panic!("Expected an error"),
-		Err(e) => assert_eq!(e, DispatchError::Token(TokenError::FundsUnavailable)),
-	};
+	assert!(format!("{:?}", result).contains("DispatchError::Token(TokenError::FundsUnavailable)"));
 
 	// Check directly failed extrinsic (before actually submitted to a block)
 	let result = api.submit_and_watch_extrinsic_until(xt, XtStatus::InBlock);

--- a/testing/examples/tungstenite_client_test.rs
+++ b/testing/examples/tungstenite_client_test.rs
@@ -43,7 +43,7 @@ fn main() {
 	// Check for failed extrinsic failed onchain
 	let xt = api.balance_transfer_allow_death(MultiAddress::Id(bob.into()), bob_balance + 1);
 	let result = api.submit_and_watch_extrinsic_until(xt.clone(), XtStatus::InBlock);
-	assert!(format!("{:?}", result).contains("DispatchError::Token(TokenError::FundsUnavailable)"));
+	assert!(format!("{:?}", result).contains("FundsUnavailable"));
 
 	// Check directly failed extrinsic (before actually submitted to a block)
 	let result = api.submit_and_watch_extrinsic_until(xt, XtStatus::InBlock);

--- a/testing/examples/tungstenite_client_test.rs
+++ b/testing/examples/tungstenite_client_test.rs
@@ -1,0 +1,63 @@
+/*
+	Copyright 2019 Supercomputing Systems AG
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+use sp_core::{
+	crypto::{Pair, Ss58Codec},
+	sr25519,
+};
+use sp_runtime::MultiAddress;
+use substrate_api_client::{
+	ac_node_api::error::{DispatchError, TokenError},
+	ac_primitives::{AssetRuntimeConfig, ExtrinsicSigner},
+	extrinsic::BalancesExtrinsics,
+	rpc::TungsteniteRpcClient,
+	Api, GetAccountInformation, SubmitAndWatch, XtStatus,
+};
+
+fn main() {
+	// Setup
+	let alice: sr25519::Pair = Pair::from_string(
+		"0xe5be9a5092b81bca64be81d212e7f2f9eba183bb7a90954f7b76361f6edb5c0a",
+		None,
+	)
+	.unwrap();
+	let client = TungsteniteRpcClient::with_default_url(100);
+	let mut api = Api::<AssetRuntimeConfig, _>::new(client).unwrap();
+	api.set_signer(ExtrinsicSigner::<AssetRuntimeConfig>::new(alice.clone()));
+
+	let bob = sr25519::Public::from_ss58check("5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty")
+		.unwrap();
+	let bob_balance = api.get_account_data(&bob.into()).unwrap().unwrap_or_default().free;
+
+	// Check for failed extrinsic failed onchain
+	let xt = api.balance_transfer_allow_death(MultiAddress::Id(bob.into()), bob_balance + 1);
+	let result = api.submit_and_watch_extrinsic_until(xt.clone(), XtStatus::InBlock);
+	assert_eq!(result, Err(DispatchError::Token(TokenError::FundsUnavailable)));
+
+	// Check directly failed extrinsic (before actually submitted to a block)
+	let result = api.submit_and_watch_extrinsic_until(xt, XtStatus::InBlock);
+	assert!(result.is_err());
+	assert!(format!("{:?}", result).contains("ExtrinsicFailed"));
+
+	// Check for successful extrinisc
+	let xt = api.balance_transfer_allow_death(MultiAddress::Id(bob.into()), bob_balance / 2);
+	let block_hash = api
+		.submit_and_watch_extrinsic_until(xt, XtStatus::InBlock)
+		.unwrap()
+		.block_hash
+		.unwrap();
+	let bob_new_balance = api.get_account_data(&bob.into()).unwrap().unwrap().free;
+	assert!(bob_new_balance > bob_balance);
+}

--- a/testing/examples/tungstenite_client_test.rs
+++ b/testing/examples/tungstenite_client_test.rs
@@ -44,7 +44,10 @@ fn main() {
 	// Check for failed extrinsic failed onchain
 	let xt = api.balance_transfer_allow_death(MultiAddress::Id(bob.into()), bob_balance + 1);
 	let result = api.submit_and_watch_extrinsic_until(xt.clone(), XtStatus::InBlock);
-	assert_eq!(result, Err(DispatchError::Token(TokenError::FundsUnavailable)));
+	match result {
+		Ok(_) => panic!("Expected an error"),
+		Err(e) => assert_eq!(e, DispatchError::Token(TokenError::FundsUnavailable)),
+	};
 
 	// Check directly failed extrinsic (before actually submitted to a block)
 	let result = api.submit_and_watch_extrinsic_until(xt, XtStatus::InBlock);

--- a/testing/examples/ws_client_test.rs
+++ b/testing/examples/ws_client_test.rs
@@ -19,7 +19,6 @@ use sp_core::{
 };
 use sp_runtime::MultiAddress;
 use substrate_api_client::{
-	ac_node_api::error::{DispatchError, TokenError},
 	ac_primitives::{AssetRuntimeConfig, ExtrinsicSigner},
 	extrinsic::BalancesExtrinsics,
 	rpc::WsRpcClient,
@@ -53,7 +52,7 @@ fn main() {
 
 	// Check for successful extrinisc
 	let xt = api.balance_transfer_allow_death(MultiAddress::Id(bob.into()), bob_balance / 2);
-	let block_hash = api
+	let _block_hash = api
 		.submit_and_watch_extrinsic_until(xt, XtStatus::InBlock)
 		.unwrap()
 		.block_hash

--- a/testing/examples/ws_client_test.rs
+++ b/testing/examples/ws_client_test.rs
@@ -44,7 +44,7 @@ fn main() {
 	// Check for failed extrinsic failed onchain
 	let xt = api.balance_transfer_allow_death(MultiAddress::Id(bob.into()), bob_balance + 1);
 	let result = api.submit_and_watch_extrinsic_until(xt.clone(), XtStatus::InBlock);
-	assert_eq!(result, Err(DispatchError::Token(TokenError::FundsUnavailable)));
+	assert!(format!("{:?}", result).contains("DispatchError::Token(TokenError::FundsUnavailable)"));
 
 	// Check directly failed extrinsic (before actually submitted to a block)
 	let result = api.submit_and_watch_extrinsic_until(xt, XtStatus::InBlock);

--- a/testing/examples/ws_client_test.rs
+++ b/testing/examples/ws_client_test.rs
@@ -1,0 +1,63 @@
+/*
+	Copyright 2019 Supercomputing Systems AG
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+use sp_core::{
+	crypto::{Pair, Ss58Codec},
+	sr25519,
+};
+use sp_runtime::MultiAddress;
+use substrate_api_client::{
+	ac_node_api::error::{DispatchError, TokenError},
+	ac_primitives::{AssetRuntimeConfig, ExtrinsicSigner},
+	extrinsic::BalancesExtrinsics,
+	rpc::WsRpcClient,
+	Api, GetAccountInformation, SubmitAndWatch, XtStatus,
+};
+
+fn main() {
+	// Setup
+	let alice: sr25519::Pair = Pair::from_string(
+		"0xe5be9a5092b81bca64be81d212e7f2f9eba183bb7a90954f7b76361f6edb5c0a",
+		None,
+	)
+	.unwrap();
+	let client = WsRpcClient::with_default_url();
+	let mut api = Api::<AssetRuntimeConfig, _>::new(client).unwrap();
+	api.set_signer(ExtrinsicSigner::<AssetRuntimeConfig>::new(alice.clone()));
+
+	let bob = sr25519::Public::from_ss58check("5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty")
+		.unwrap();
+	let bob_balance = api.get_account_data(&bob.into()).unwrap().unwrap_or_default().free;
+
+	// Check for failed extrinsic failed onchain
+	let xt = api.balance_transfer_allow_death(MultiAddress::Id(bob.into()), bob_balance + 1);
+	let result = api.submit_and_watch_extrinsic_until(xt.clone(), XtStatus::InBlock);
+	assert_eq!(result, Err(DispatchError::Token(TokenError::FundsUnavailable)));
+
+	// Check directly failed extrinsic (before actually submitted to a block)
+	let result = api.submit_and_watch_extrinsic_until(xt, XtStatus::InBlock);
+	assert!(result.is_err());
+	assert!(format!("{:?}", result).contains("ExtrinsicFailed"));
+
+	// Check for successful extrinisc
+	let xt = api.balance_transfer_allow_death(MultiAddress::Id(bob.into()), bob_balance / 2);
+	let block_hash = api
+		.submit_and_watch_extrinsic_until(xt, XtStatus::InBlock)
+		.unwrap()
+		.block_hash
+		.unwrap();
+	let bob_new_balance = api.get_account_data(&bob.into()).unwrap().unwrap().free;
+	assert!(bob_new_balance > bob_balance);
+}

--- a/testing/examples/ws_client_test.rs
+++ b/testing/examples/ws_client_test.rs
@@ -43,7 +43,7 @@ fn main() {
 	// Check for failed extrinsic failed onchain
 	let xt = api.balance_transfer_allow_death(MultiAddress::Id(bob.into()), bob_balance + 1);
 	let result = api.submit_and_watch_extrinsic_until(xt.clone(), XtStatus::InBlock);
-	assert!(format!("{:?}", result).contains("DispatchError::Token(TokenError::FundsUnavailable)"));
+	assert!(format!("{:?}", result).contains("FundsUnavailable"));
 
 	// Check directly failed extrinsic (before actually submitted to a block)
 	let result = api.submit_and_watch_extrinsic_until(xt, XtStatus::InBlock);


### PR DESCRIPTION
Updates the ws-rpc and tungstenite clients with the following features:
- Removal of the warning message "Expected subscription, but received an ID response instead: Object"
- The immediate subscription response (either the subscription ID or an error) is now interpreted by the client. All the following subscription messages are checked by the client if the ID matches, and only then are forwarded to the client. This now removes the need to ignore the "id" response that previously generated the responses, and does not allow mix-up of different subscription messages.
- adds tests to the CI to test the following three cases:
     -  Failed onchain extrinsic (Extrinsic went through successfully, only the Events indicate a failure of the xt)
     - Failed extrinsic before block submission (E.g. no subscription ID is returned but an immediate error response)
     - Successful extrinsic

closes #626 