### PR TITLE
Lower log-level of messages of tungstenite and ws-rpc clients

### DIFF
--- a/src/rpc/tungstenite_client/client.rs
+++ b/src/rpc/tungstenite_client/client.rs
@@ -92,7 +92,7 @@ impl TungsteniteRpcClient {
 
 		let msg = read_until_text_message(&mut socket)?;
 
-		debug!("Got get_request_msg {}", msg);
+		trace!("Got get_request_msg {}", msg);
 		let result_str =
 			serde_json::from_str(msg.as_str()).map(|v: Value| v["result"].to_string())?;
 		Ok(result_str)
@@ -165,7 +165,7 @@ fn send_message_to_client(
 	message: &str,
 	subscription_id: &str,
 ) -> Result<()> {
-	info!("got on_subscription_msg {}", message);
+	trace!("got on_subscription_msg {}", message);
 	let value: Value = serde_json::from_str(message)?;
 
 	if helpers::subscription_id_matches(&value, subscription_id) {
@@ -193,10 +193,7 @@ fn attempt_connection_until(url: &Url, max_attempts: u8) -> Result<(MySocket, Re
 fn read_until_text_message(socket: &mut MySocket) -> Result<String> {
 	loop {
 		match socket.read()? {
-			Message::Text(s) => {
-				debug!("receive text: {:?}", s);
-				break Ok(s)
-			},
+			Message::Text(s) => break Ok(s),
 			Message::Binary(_) => {
 				debug!("skip binary msg");
 			},

--- a/src/rpc/ws_client/mod.rs
+++ b/src/rpc/ws_client/mod.rs
@@ -59,7 +59,7 @@ where
 	MessageHandler::Context: From<MessageContext<MessageHandler::ThreadMessage>>,
 {
 	fn on_open(&mut self, _: Handshake) -> WsResult<()> {
-		info!("sending request: {}", self.request);
+		trace!("sending request: {}", self.request);
 		self.out.send(self.request.clone())?;
 		Ok(())
 	}
@@ -91,7 +91,7 @@ impl HandleMessage for RequestHandler {
 		out.close(CloseCode::Normal)
 			.unwrap_or_else(|_| warn!("Could not close Websocket normally"));
 
-		info!("Got get_request_msg {}", msg);
+		trace!("Got get_request_msg {}", msg);
 		let result_str = serde_json::from_str(msg.as_text()?)
 			.map(|v: serde_json::Value| v["result"].to_string())
 			.map_err(RpcClientError::SerdeJson);
@@ -114,7 +114,7 @@ impl HandleMessage for SubscriptionHandler {
 		let out = &context.out;
 		let msg = &context.msg.as_text()?;
 
-		info!("got on_subscription_msg {}", msg);
+		trace!("got on_subscription_msg {}", msg);
 		let value: serde_json::Value = serde_json::from_str(msg).map_err(Box::new)?;
 
 		let send_result = match self.subscription_id.as_ref() {


### PR DESCRIPTION
Changes the log level of tungstenite and ws-rpc client to lower level or even remove them due to duplicity. This will help the users to reduce potential clustering of log levels, since especially metadata retrieval results in enormous log messages.

closes #623 