### PR TITLE
Enforce F-label on PRs by CI

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -8,10 +8,12 @@ categories:
       - 'E2-breaksapi'
   - title: ' 🌈 Features'
     labels:
+      - 'F6-optimization'
       - 'F8-newfeature'
       - 'F7-enhancement'
   - title: '🐛 Bug Fixes'
     labels:
+      - 'F1-security'
       - 'F2-bug'
   - title: ' Miscellaneous '
     collapse-after: 5

--- a/.github/workflows/check-lables.yml
+++ b/.github/workflows/check-lables.yml
@@ -21,3 +21,13 @@ jobs:
             if [[  "$MATCH" == '[]' ]]; then
                 exit 1
             fi
+        - name: F Label check
+          env:
+            enforced_labels: "F0-miscellaneous,F1-security,F2-bug,F3-test,F4-documentation,F5-refactor,F6-optimization,F7-enhancement,F8-newfeature,F9-dependencies"
+          run: |
+            MATCH=$(jq -cn '${{ toJSON(github.event.pull_request.labels.*.name) }} as $USER_LABELS |
+            ${{ toJSON(env.enforced_labels)  }} | split(",") as $LABELS |
+            $USER_LABELS - ($USER_LABELS - $LABELS)')
+            if [[  "$MATCH" == '[]' ]]; then
+                exit 1
+            fi


### PR DESCRIPTION
- CI now checks for F-Labels
- Updates release generation to check for more labels

To ensure F-lables can always be set, I introduced the additional F-Labels:
`F0-miscellaneous`
`F9-dependencies`

closes #641

