### PR TITLE
node-api: Box Error::DecodeValue and Error::EncodeValue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,8 @@ jobs:
                 cargo build --release -p ac-examples --example runtime_update_async --no-default-features,
 
                 # Clippy
-                cargo clippy --workspace --exclude test-no-std -- -D warnings,
+                cargo clippy -- -D warnings,
+                cargo clippy --no-default-features -- -D warnings,
                 cargo clippy --all-features --examples -- -D warnings,
 
                 # Run tests and build examples

--- a/node-api/src/error/mod.rs
+++ b/node-api/src/error/mod.rs
@@ -8,7 +8,7 @@
 
 //! General node-api Error implementation.
 
-use alloc::{string::String, vec::Vec};
+use alloc::{boxed::Box, string::String, vec::Vec};
 use core::fmt::Debug;
 use derive_more::From;
 
@@ -40,9 +40,9 @@ pub enum Error {
 	/// Runtime error.
 	Runtime(DispatchError),
 	/// Error decoding to a [`crate::dynamic::Value`].
-	DecodeValue(DecodeError),
+	DecodeValue(Box<DecodeError>),
 	/// Error encoding from a [`crate::dynamic::Value`].
-	EncodeValue(EncodeError),
+	EncodeValue(Box<EncodeError>),
 	/// The bytes representing an error that we were unable to decode.
 	Unknown(Vec<u8>),
 	/// Other error.
@@ -52,5 +52,17 @@ pub enum Error {
 impl From<&str> for Error {
 	fn from(error: &str) -> Self {
 		Error::Other(error.into())
+	}
+}
+
+impl From<DecodeError> for Error {
+	fn from(error: DecodeError) -> Self {
+		Error::DecodeValue(Box::new(error))
+	}
+}
+
+impl From<EncodeError> for Error {
+	fn from(error: EncodeError) -> Self {
+		Error::EncodeValue(Box::new(error))
 	}
 }


### PR DESCRIPTION
Clippy warned about too large error in node-api, once it was actually run there. Therefore, this PR updates:
- CI : Now also tests node-api with  clippy
- Adds Box around Decode and EncodeError to constrain the error.

