### PR TITLE
CI: Ensure unit tests are run in all crates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,10 +65,8 @@ jobs:
                 cargo clippy --no-default-features -- -D warnings,
                 cargo clippy --all-features --examples -- -D warnings,
 
-                # Run unit tests
-                cargo test --release,
-                cargo test --release --no-default-features --features ws-client,
-                cargo test --release --no-default-features --features tungstenite-client,
+                # Run unit tests of the api crate,
+                cargo test --release --all-features --workspace --exclude test-no-std --exclude "ac-examples-*" --exclude "ac-testing-*",
 
                 # Fmt
                 cargo fmt --all -- --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,8 @@ jobs:
 
                 # Run unit tests
                 cargo test --release,
+                cargo test --release --no-default-features --features ws-client,
+                cargo test --release --no-default-features --features tungstenite-client,
 
                 # Fmt
                 cargo fmt --all -- --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
                 cargo clippy --no-default-features -- -D warnings,
                 cargo clippy --all-features --examples -- -D warnings,
 
-                # Run unit tests of the api crate,
+                # Run unit tests
                 cargo test --release --all-features --workspace --exclude test-no-std --exclude "ac-examples-*" --exclude "ac-testing-*",
 
                 # Fmt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6867,7 +6867,6 @@ dependencies = [
  "derive_more",
  "frame-metadata 16.0.0",
  "frame-support",
- "futures",
  "futures-util",
  "hex",
  "jsonrpsee",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,6 @@ ac-node-api = { path = "node-api", features = ["mocks"] }
 kitchensink-runtime = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "master" }
 scale-info = { version = "2.1.1", features = ["derive"] }
 test-case = "3.1.0"
-futures = "0.3.28"
 
 [features]
 default = ["std", "jsonrpsee-client"]

--- a/src/api/api_client.rs
+++ b/src/api/api_client.rs
@@ -260,7 +260,6 @@ mod tests {
 		PlainTip,
 	};
 	use frame_metadata::{v14::ExtrinsicMetadata, RuntimeMetadata};
-	use futures::executor;
 	use scale_info::form::PortableForm;
 	use sp_core::H256;
 	use std::{collections::HashMap, fs};
@@ -348,7 +347,7 @@ mod tests {
 		assert_ne!(api.runtime_version, runtime_version);
 
 		// Update runtime.
-		executor::block_on(api.update_runtime()).unwrap();
+		api.update_runtime().unwrap();
 
 		// Ensure metadata and runtime version have been updated.
 		assert_eq!(api.metadata.extrinsic(), metadata.extrinsic());

--- a/src/api/rpc_api/events.rs
+++ b/src/api/rpc_api/events.rs
@@ -236,7 +236,6 @@ mod tests {
 	use ac_primitives::DefaultRuntimeConfig;
 	use codec::{Decode, Encode};
 	use frame_metadata::RuntimeMetadataPrefixed;
-	use futures::executor::block_on;
 	use kitchensink_runtime::{BalancesCall, RuntimeCall, UncheckedExtrinsic};
 	use scale_info::TypeInfo;
 	use sp_core::{crypto::Ss58Codec, sr25519, Bytes, H256};
@@ -347,7 +346,7 @@ mod tests {
 
 		let api = create_mock_api(metadata, data);
 
-		let fetched_events = block_on(api.fetch_events_from_block(H256::random())).unwrap();
+		let fetched_events = api.fetch_events_from_block(H256::random()).unwrap();
 
 		assert_eq!(fetched_events.event_bytes(), block_events.event_bytes());
 	}
@@ -397,15 +396,11 @@ mod tests {
 		let api = create_mock_api(metadata, data);
 		let block_hash = H256::default();
 
-		let (index1, index2, index3) = block_on(async {
-			futures::future::try_join3(
-				api.retrieve_extrinsic_index_from_block(block_hash, xt_hash1),
-				api.retrieve_extrinsic_index_from_block(block_hash, xt_hash2),
-				api.retrieve_extrinsic_index_from_block(block_hash, xt_hash3),
-			)
-			.await
-			.unwrap()
-		});
+		let (index1, index2, index3) = (
+			api.retrieve_extrinsic_index_from_block(block_hash, xt_hash1).unwrap(),
+			api.retrieve_extrinsic_index_from_block(block_hash, xt_hash2).unwrap(),
+			api.retrieve_extrinsic_index_from_block(block_hash, xt_hash3).unwrap(),
+		);
 
 		assert_eq!(index1, 0);
 		assert_eq!(index2, 1);


### PR DESCRIPTION
With the `--all-features` the async version of the unit tests is not needed anymore.
Reasoning: Previously, `cargo test --release` has built the api-client in default mode, which is async. With the newly added `--workspace` the client is now built in sync mode. 

I believe that's reasonable, as we already test the async version thoroughly in the system tests.