### PR TITLE
CI: update github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,16 +26,15 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        # We need to compile `test-no-std` separately, otherwise we have std leaks from the build-deps.
-        #
-        # `test-no-std` is only meant to check if the `substrate-api-client` compiles to `no_std`, hence
-        # we omit clippy and test there.
         check: [
                 # Test for no-std compatibility.
                 # `--locked` to enforce an up-to-date Cargo.lock
                 cargo build --release --workspace --locked --exclude test-no-std,
 
-                # Test for no-std compatibility.
+                # We need to compile `test-no-std` separately, otherwise we have std leaks from the build-deps.
+                #
+                # `test-no-std` is only meant to check if the `substrate-api-client` compiles to `no_std`, hence
+                # we omit clippy and test there.
                 cargo build --release -p test-no-std --features api-client,
                 cargo build --release -p test-no-std --features compose-macros,
                 cargo build --release -p test-no-std --features node-api,
@@ -84,11 +83,41 @@ jobs:
       - name: ${{ matrix.check }}
         run: ${{ matrix.check }}
 
-      - name: Upload examples
+      - name: Upload async examples
         uses: actions/upload-artifact@v4
-        if: contains(matrix.check, 'cargo test')
+        if: contains(matrix.check, 'examples-async')
         with:
-          name: examples
+          name: examples-async
+          path:  |
+            target/release/examples/*
+            !target/release/examples/*.d
+            !target/release/examples/*-*
+
+      - name: Upload sync examples
+        uses: actions/upload-artifact@v4
+        if: contains(matrix.check, 'examples-sync')
+        with:
+          name: examples-sync
+          path:  |
+            target/release/examples/*
+            !target/release/examples/*.d
+            !target/release/examples/*-*
+
+      - name: Upload async testing examples
+        uses: actions/upload-artifact@v4
+        if: contains(matrix.check, 'testing-async')
+        with:
+          name: examples-testing-async
+          path:  |
+            target/release/examples/*
+            !target/release/examples/*.d
+            !target/release/examples/*-*
+
+      - name: Upload sync testing examples
+        uses: actions/upload-artifact@v4
+        if: contains(matrix.check, 'testing-sync')
+        with:
+          name: examples-testing-sync
           path:  |
             target/release/examples/*
             !target/release/examples/*.d
@@ -173,10 +202,13 @@ jobs:
         run: sleep 20s
         shell: bash
 
-      - name: Download example from previous run
+      - name: Download examples from previous run
         uses: actions/download-artifact@v4
         with:
-          name: examples
+          pattern: examples-*
++         merge-multiple: true
+
+      -
 
       - name: Run Examples
         timeout-minutes: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     name: Cancel Previous Runs
     runs-on: ubuntu-20.04
     steps:
-      - uses: styfle/cancel-workflow-action@0.12
+      - uses: styfle/cancel-workflow-action@0.12.1
         with:
           access_token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   cancel_previous_runs:
     name: Cancel Previous Runs
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: styfle/cancel-workflow-action@0.12.1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
       - name: init-rust-target
         run: rustup show && rustup component add rust-src
 
-      - uses: Swatinem/rust-cache@v3
+      - uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.check }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,3 +223,6 @@ jobs:
         uses: actions/upload-artifact/merge@v4
         with:
           separate-directories: true
+          name: examples
+          pattern: examples-*
+          delete-merged: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
         uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-about
-          version: "0.5"
+          version: "0.6"
 
       - name: Run license check
         # Explicitly use stable because otherwise cargo will trigger a download of

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
   taplo-fmt:
     name: "Taplo fmt"
     runs-on: ubuntu-latest
-    container: "tamasfe/taplo:0.8.1-alpine"
+    container: "tamasfe/taplo:latest"
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,6 +217,7 @@ jobs:
           ./${{ matrix.example }}
   merge:
     runs-on: ubuntu-latest
+    needs: examples
     steps:
       - name: Merge Artifacts
         uses: actions/upload-artifact/merge@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,9 +206,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           pattern: examples-*
-+         merge-multiple: true
-
-      -
+          merge-multiple: true
 
       - name: Run Examples
         timeout-minutes: 5
@@ -217,3 +215,10 @@ jobs:
           nc -z -v 127.0.0.1 9944
           chmod +x ${{ matrix.example }}
           ./${{ matrix.example }}
+  merge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Merge Artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          separate-directories: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
   taplo-fmt:
     name: "Taplo fmt"
     runs-on: ubuntu-latest
-    container: "tamasfe/taplo:0.7.0-alpine"
+    container: "tamasfe/taplo:0.8.1-alpine"
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,11 +73,11 @@ jobs:
 
         ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: init-rust-target
         run: rustup show && rustup component add rust-src
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@v3
         with:
           key: ${{ matrix.check }}
 
@@ -85,7 +85,7 @@ jobs:
         run: ${{ matrix.check }}
 
       - name: Upload sync examples
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: contains(matrix.check, 'cargo test')
         with:
           name: examples
@@ -96,7 +96,7 @@ jobs:
             !target/release/examples/*-*
 
       - name: Upload async examples
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: contains(matrix.check, 'async')
         with:
           name: examples
@@ -108,7 +108,7 @@ jobs:
     runs-on: ubuntu-latest
     container: "tamasfe/taplo:0.7.0-alpine"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Run Taplo fmt
         run: taplo fmt --check
@@ -117,10 +117,10 @@ jobs:
     name: "License check"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install cargo-about
-        uses: baptiste0928/cargo-install@v2
+        uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-about
           version: "0.5"
@@ -130,7 +130,7 @@ jobs:
         # the nightly version specified in rust-toolchain.toml
         run: cargo +stable about generate about.hbs > license.html
       - name: Archive license file
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: license
           path: license.html
@@ -172,7 +172,7 @@ jobs:
           runtime_update_async,
         ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Run latest node
         run: |
@@ -183,7 +183,7 @@ jobs:
         shell: bash
 
       - name: Download example from previous run
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: examples
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,24 +84,15 @@ jobs:
       - name: ${{ matrix.check }}
         run: ${{ matrix.check }}
 
-      - name: Upload sync examples
+      - name: Upload examples
         uses: actions/upload-artifact@v4
         if: contains(matrix.check, 'cargo test')
         with:
           name: examples
           path:  |
             target/release/examples/*
-            !target/release/examples/*async*
             !target/release/examples/*.d
             !target/release/examples/*-*
-
-      - name: Upload async examples
-        uses: actions/upload-artifact@v4
-        if: contains(matrix.check, 'async')
-        with:
-          name: examples
-          path:  |
-            target/release/examples/*async
 
   taplo-fmt:
     name: "Taplo fmt"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     name: Cancel Previous Runs
     runs-on: ubuntu-20.04
     steps:
-      - uses: styfle/cancel-workflow-action@0.11.0
+      - uses: styfle/cancel-workflow-action@0.12
         with:
           access_token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ cargo run -p ac-examples-sync --example runtime_update_sync
 or download the already built binaries from [GitHub Actions](https://github.com/scs/substrate-api-client/actions) and run them without any previous building:
 
 ```bash
-# Add execution rights to the chosen example.
+# Enter the async or sync example directory and add execution rights to the chosen example.
+cd examples-<sync/async>
 chmod +x <example>
 # And run it.
 ./<example>


### PR DESCRIPTION
Updated GitHub Actions to use the most up-to-date actions.

Please note: GitHub actions artifacts are immutable once uploaded in v4. Therefore, every upload needs a unique name. To still have one upload artifact at the end the step `merge` was introduced. This ensures that users can still download all examples as one zip.
See https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md for more information

closes #723 

