### PR TITLE
Add the crates.io version numbers for local dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,13 +59,13 @@ sp-version = { default-features = false, features = ["serde"], git = "https://gi
 frame-support = { optional = true, git = "https://github.com/paritytech/polkadot-sdk.git", branch = "master" }
 
 # local deps
-ac-compose-macros = { path = "compose-macros", default-features = false }
-ac-node-api = { path = "node-api", default-features = false }
-ac-primitives = { path = "primitives", default-features = false }
+ac-compose-macros = { path = "compose-macros", version = "0.5", default-features = false }
+ac-node-api = { path = "node-api", version = "0.6", default-features = false }
+ac-primitives = { path = "primitives", version = "0.9.1", default-features = false }
 
 
 [dev-dependencies]
-ac-node-api = { path = "node-api", features = ["mocks"] }
+ac-node-api = { path = "node-api", version = "0.6", features = ["mocks"] }
 kitchensink-runtime = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "master" }
 scale-info = { version = "2.1.1", features = ["derive"] }
 test-case = "3.1.0"

--- a/compose-macros/Cargo.toml
+++ b/compose-macros/Cargo.toml
@@ -15,10 +15,10 @@ log = { version = "0.4.14", default-features = false }
 maybe-async = { version = "0.2.7" }
 
 # local
-ac-primitives = { path = "../primitives", default-features = false }
+ac-primitives = { path = "../primitives", version = "0.9.1", default-features = false }
 
 [dev-dependencies]
-ac-node-api = { path = "../node-api" }
+ac-node-api = { path = "../node-api", version = "0.6" }
 frame-metadata = { version = "16.0" }
 codec = { package = "parity-scale-codec", version = "3.6.1" }
 

--- a/examples/async/Cargo.toml
+++ b/examples/async/Cargo.toml
@@ -26,4 +26,4 @@ sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = 
 sp-weights = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "master" }
 
 # local deps
-substrate-api-client = { path = "../..", features = ["staking-xt", "contracts-xt"] }
+substrate-api-client = { path = "../..", version = "0.17", features = ["staking-xt", "contracts-xt"] }

--- a/examples/sync/Cargo.toml
+++ b/examples/sync/Cargo.toml
@@ -15,4 +15,4 @@ sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = 
 sp-weights = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "master" }
 
 # local deps
-substrate-api-client = { path = "../..", default-features = false, features = ["tungstenite-client", "ws-client"] }
+substrate-api-client = { path = "../..", version = "0.17", default-features = false, features = ["tungstenite-client", "ws-client"] }

--- a/node-api/Cargo.toml
+++ b/node-api/Cargo.toml
@@ -36,7 +36,7 @@ sp-application-crypto = { default-features = false, features = ["full_crypto"], 
 sp-runtime-interface = { default-features = false, git = "https://github.com/paritytech/polkadot-sdk.git", branch = "master" }
 
 # local
-ac-primitives = { path = "../primitives", default-features = false }
+ac-primitives = { path = "../primitives", version = "0.9.1", default-features = false }
 
 [dev-dependencies]
 test-case = "3.1.0"

--- a/test-no-std/Cargo.toml
+++ b/test-no-std/Cargo.toml
@@ -9,10 +9,10 @@ edition = "2021"
 libc = { version = "0.2.119", default-features = false }
 
 # local dependencies
-ac-compose-macros = { path = "../compose-macros", default-features = false, optional = true, features = ["disable_target_static_assertions", "sync-api"] }
-ac-node-api = { path = "../node-api", default-features = false, optional = true, features = ["disable_target_static_assertions"] }
-ac-primitives = { path = "../primitives", default-features = false, optional = true, features = ["disable_target_static_assertions"] }
-substrate-api-client = { path = "..", default-features = false, optional = true, features = ["disable_target_static_assertions", "sync-api"] }
+ac-compose-macros = { path = "../compose-macros", version = "0.5", default-features = false, optional = true, features = ["disable_target_static_assertions", "sync-api"] }
+ac-node-api = { path = "../node-api", version = "0.6", default-features = false, optional = true, features = ["disable_target_static_assertions"] }
+ac-primitives = { path = "../primitives", version = "0.9.1", default-features = false, optional = true, features = ["disable_target_static_assertions"] }
+substrate-api-client = { path = "..", version = "0.17", default-features = false, optional = true, features = ["disable_target_static_assertions", "sync-api"] }
 
 # substrate dependencies
 sp-io = { default-features = false, features = ["disable_oom", "disable_panic_handler"], git = "https://github.com/paritytech/polkadot-sdk.git", branch = "master" }

--- a/testing/async/Cargo.toml
+++ b/testing/async/Cargo.toml
@@ -23,4 +23,4 @@ pallet-balances = { git = "https://github.com/paritytech/polkadot-sdk.git", bran
 pallet-staking = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "master" }
 
 # local deps
-substrate-api-client = { path = "../..", features = ["staking-xt", "contracts-xt"] }
+substrate-api-client = { path = "../..", version = "0.17", features = ["staking-xt", "contracts-xt"] }

--- a/testing/sync/Cargo.toml
+++ b/testing/sync/Cargo.toml
@@ -12,5 +12,5 @@ sp-core = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "ma
 sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "master" }
 
 # local deps
-substrate-api-client = { path = "../..", default-features = false, features = ["tungstenite-client", "ws-client"] }
+substrate-api-client = { path = "../..", version = "0.17", default-features = false, features = ["tungstenite-client", "ws-client"] }
 substrate-client-keystore = { path = "../../client-keystore" }


### PR DESCRIPTION
It is allowed to have the local path as well as the version number in the dependencies. For local builds the path is used (but the version number is still verified) and on crates.io the version number is used. 
See also this description:
https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#multiple-locations
This should make releases in the future simpler as we don't have to add the version numbers later. See for example this branch that adds the version numbers:
https://github.com/scs/substrate-api-client/pull/742