### PR TITLE
Rename node-template-runtime dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,7 +95,6 @@ version = "0.9.1"
 dependencies = [
  "frame-system",
  "impl-serde",
- "node-template-runtime",
  "pallet-assets",
  "pallet-balances",
  "pallet-contracts",
@@ -106,6 +105,7 @@ dependencies = [
  "scale-info",
  "serde",
  "serde_json",
+ "solochain-template-runtime",
  "sp-application-crypto",
  "sp-core",
  "sp-crypto-hashing",
@@ -328,6 +328,20 @@ dependencies = [
 
 [[package]]
 name = "aquamarine"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1da02abba9f9063d786eab1509833ebb2fac0f966862ca59439c76b9c566760"
+dependencies = [
+ "include_dir",
+ "itertools",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "aquamarine"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21cc1548309245035eb18aa7f0967da6bc65587005170c56e6ef2788a4cf3f4e"
@@ -337,7 +351,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -641,12 +655,6 @@ checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
 
 [[package]]
 name = "arrayvec"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
-
-[[package]]
-name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
@@ -676,7 +684,7 @@ checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -713,7 +721,7 @@ dependencies = [
  "ark-std",
  "dleq_vrf",
  "fflonk",
- "merlin 3.0.0",
+ "merlin",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "ring 0.1.0",
@@ -759,7 +767,7 @@ dependencies = [
 [[package]]
 name = "binary-merkle-tree"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "hash-db",
  "log",
@@ -775,23 +783,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "bip39"
-version = "2.0.0"
+name = "bitcoin-internals"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f2635620bf0b9d4576eb7bb9a38a55df78bd1205d26fa994b25911a69f212f"
-dependencies = [
- "bitcoin_hashes",
- "rand 0.8.5",
- "rand_core 0.6.4",
- "serde",
- "unicode-normalization",
-]
+checksum = "9425c3bf7089c983facbae04de54513cce73b41c7f9ff8c845b54e7bc64ebbfb"
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.11.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90064b8dee6815a6470d60bad07bbbaee885c0e12d04177138fa3291a01b7bc4"
+checksum = "1930a4dabfebb8d7d9992db18ebe3ae2876f0a305fab206fd168df931ede293b"
+dependencies = [
+ "bitcoin-internals",
+ "hex-conservative",
+]
 
 [[package]]
 name = "bitflags"
@@ -833,7 +838,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23285ad32269793932e830392f2fe2f83e26488fd3ec778883a93c8323735780"
 dependencies = [
  "arrayref",
- "arrayvec 0.7.4",
+ "arrayvec",
  "constant_time_eq",
 ]
 
@@ -1083,7 +1088,7 @@ dependencies = [
  "ark-std",
  "fflonk",
  "getrandom_or_panic",
- "merlin 3.0.0",
+ "merlin",
  "rand_chacha 0.3.1",
 ]
 
@@ -1276,35 +1281,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-mac"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25fab6889090c8133f3deb8f73ba3c65a7f456f66436fc012a1b1e272b1e103e"
-dependencies = [
- "generic-array 0.14.7",
- "subtle",
-]
-
-[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
  "cipher",
-]
-
-[[package]]
-name = "curve25519-dalek"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a9b85542f99a2dfa2a1b8e192662741c9859a846b296bef1c92ef9b58b5a216"
-dependencies = [
- "byteorder",
- "digest 0.8.1",
- "rand_core 0.5.1",
- "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -1345,7 +1327,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1372,7 +1354,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1389,7 +1371,7 @@ checksum = "e2cb1fd8ffae4230c7cfbbaf3698dbeaf750fa8c5dadf7ed897df581b9b572a5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1520,8 +1502,17 @@ dependencies = [
  "ark-serialize",
  "ark-std",
  "ark-transcript",
- "arrayvec 0.7.4",
+ "arrayvec",
  "zeroize",
+]
+
+[[package]]
+name = "docify"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af1b04e6ef3d21119d3eb7b032bca17f99fe041e9c072f30f32cc0e1a2b1f3c4"
+dependencies = [
+ "docify_macros 0.1.16",
 ]
 
 [[package]]
@@ -1530,7 +1521,24 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cc4fd38aaa9fb98ac70794c82a00360d1e165a87fbf96a8a91f9dfc602aaee2"
 dependencies = [
- "docify_macros",
+ "docify_macros 0.2.7",
+]
+
+[[package]]
+name = "docify_macros"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b5610df7f2acf89a1bb5d1a66ae56b1c7fcdcfe3948856fb3ace3f644d70eb7"
+dependencies = [
+ "common-path",
+ "derive-syn-parse",
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.52",
+ "termcolor",
+ "walkdir",
 ]
 
 [[package]]
@@ -1545,7 +1553,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.48",
+ "syn 2.0.52",
  "termcolor",
  "toml",
  "walkdir",
@@ -1594,6 +1602,7 @@ dependencies = [
  "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
+ "serdect",
  "signature",
  "spki",
 ]
@@ -1657,6 +1666,7 @@ dependencies = [
  "pkcs8",
  "rand_core 0.6.4",
  "sec1",
+ "serdect",
  "subtle",
  "zeroize",
 ]
@@ -1684,7 +1694,7 @@ checksum = "5c785274071b1b420972453b306eeca06acf4633829db4223b58a2a8c5953bc4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1763,7 +1773,7 @@ dependencies = [
  "fs-err",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1810,7 +1820,7 @@ dependencies = [
  "ark-poly",
  "ark-serialize",
  "ark-std",
- "merlin 3.0.0",
+ "merlin",
 ]
 
 [[package]]
@@ -1892,7 +1902,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -1917,7 +1927,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-pallet-pov"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -1932,18 +1942,18 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "frame-election-provider-support"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -1960,8 +1970,9 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
+ "aquamarine 0.3.3",
  "frame-support",
  "frame-system",
  "frame-try-runtime",
@@ -2001,12 +2012,12 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
- "aquamarine",
+ "aquamarine 0.5.0",
  "array-bytes",
  "bitflags 1.3.2",
- "docify",
+ "docify 0.2.7",
  "environmental",
  "frame-metadata 16.0.0",
  "frame-support-procedural",
@@ -2042,7 +2053,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -2055,38 +2066,38 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sp-crypto-hashing",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "frame-system"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "cfg-if 1.0.0",
- "docify",
+ "docify 0.2.7",
  "frame-support",
  "log",
  "parity-scale-codec",
@@ -2103,7 +2114,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2118,7 +2129,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -2127,7 +2138,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -2224,7 +2235,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -2440,6 +2451,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hex-conservative"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30ed443af458ccb6d81c1e7e661545f94d3176752fb1df2f543b902a1e0f51e2"
+
+[[package]]
 name = "hkdf"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2454,17 +2471,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
 dependencies = [
- "crypto-mac 0.8.0",
- "digest 0.9.0",
-]
-
-[[package]]
-name = "hmac"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
-dependencies = [
- "crypto-mac 0.11.0",
+ "crypto-mac",
  "digest 0.9.0",
 ]
 
@@ -2865,6 +2872,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "once_cell",
+ "serdect",
  "sha2 0.10.8",
 ]
 
@@ -2890,7 +2898,7 @@ dependencies = [
 [[package]]
 name = "kitchensink-runtime"
 version = "3.0.0-dev"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-benchmarking",
  "frame-benchmarking-pallet-pov",
@@ -2938,6 +2946,7 @@ dependencies = [
  "pallet-lottery",
  "pallet-membership",
  "pallet-message-queue",
+ "pallet-migrations",
  "pallet-mixnet",
  "pallet-mmr",
  "pallet-multisig",
@@ -3146,7 +3155,7 @@ dependencies = [
  "macro_magic_core",
  "macro_magic_macros",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -3160,7 +3169,7 @@ dependencies = [
  "macro_magic_core_macros",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -3171,7 +3180,7 @@ checksum = "9ea73aa640dc01d62a590d48c0c3521ed739d53b27f919b25c3551e233481654"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -3182,7 +3191,7 @@ checksum = "ef9d79ae96aaba821963320eb2b6e34d17df1e5a83d8a1985c29cc5be59577b3"
 dependencies = [
  "macro_magic_core",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -3212,7 +3221,7 @@ checksum = "afc95a651c82daf7004c824405aa1019723644950d488571bd718e3ed84646ed"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -3246,18 +3255,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "808b50db46293432a45e63bc15ea51e0ab4c0a1647b8eb114e31a3e698dd6fbe"
 dependencies = [
  "hash-db",
-]
-
-[[package]]
-name = "merlin"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e261cf0f8b3c42ded9f7d2bb59dea03aa52bc8a1cbc7482f9fc3fd1229d3b42"
-dependencies = [
- "byteorder",
- "keccak",
- "rand_core 0.5.1",
- "zeroize",
 ]
 
 [[package]]
@@ -3394,50 +3391,10 @@ dependencies = [
 [[package]]
 name = "node-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "sp-core",
  "sp-runtime",
-]
-
-[[package]]
-name = "node-template-runtime"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
-dependencies = [
- "frame-benchmarking",
- "frame-executive",
- "frame-support",
- "frame-system",
- "frame-system-benchmarking",
- "frame-system-rpc-runtime-api",
- "frame-try-runtime",
- "pallet-aura",
- "pallet-balances",
- "pallet-grandpa",
- "pallet-sudo",
- "pallet-template",
- "pallet-timestamp",
- "pallet-transaction-payment",
- "pallet-transaction-payment-rpc-runtime-api",
- "parity-scale-codec",
- "scale-info",
- "serde_json",
- "sp-api",
- "sp-block-builder",
- "sp-consensus-aura",
- "sp-consensus-grandpa",
- "sp-core",
- "sp-genesis-builder",
- "sp-inherents",
- "sp-offchain",
- "sp-runtime",
- "sp-session",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
- "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
- "sp-transaction-pool",
- "sp-version",
- "substrate-wasm-builder",
 ]
 
 [[package]]
@@ -3472,7 +3429,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
 dependencies = [
- "arrayvec 0.7.4",
+ "arrayvec",
  "itoa",
 ]
 
@@ -3577,7 +3534,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -3601,7 +3558,7 @@ dependencies = [
 [[package]]
 name = "pallet-alliance"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3621,7 +3578,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-conversion"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3639,8 +3596,9 @@ dependencies = [
 [[package]]
 name = "pallet-asset-conversion-tx-payment"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
+ "frame-benchmarking",
  "frame-support",
  "frame-system",
  "pallet-asset-conversion",
@@ -3654,7 +3612,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-rate"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3669,7 +3627,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-tx-payment"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3687,7 +3645,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3703,7 +3661,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3720,7 +3678,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3736,7 +3694,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3750,7 +3708,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3774,10 +3732,10 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
- "aquamarine",
- "docify",
+ "aquamarine 0.5.0",
+ "docify 0.2.7",
  "frame-benchmarking",
  "frame-election-provider-support",
  "frame-support",
@@ -3796,9 +3754,9 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
- "docify",
+ "docify 0.2.7",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -3812,7 +3770,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3832,7 +3790,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "array-bytes",
  "binary-merkle-tree",
@@ -3857,7 +3815,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3875,7 +3833,7 @@ dependencies = [
 [[package]]
 name = "pallet-broker"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -3892,7 +3850,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3911,7 +3869,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3928,7 +3886,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "bitflags 1.3.2",
  "environmental",
@@ -3959,17 +3917,17 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-proc-macro"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "pallet-contracts-uapi"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -3981,7 +3939,7 @@ dependencies = [
 [[package]]
 name = "pallet-conviction-voting"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -3998,7 +3956,7 @@ dependencies = [
 [[package]]
 name = "pallet-core-fellowship"
 version = "12.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4017,7 +3975,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4035,7 +3993,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -4058,7 +4016,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -4072,7 +4030,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4091,7 +4049,7 @@ dependencies = [
 [[package]]
 name = "pallet-example-tasks"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4108,9 +4066,9 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
- "docify",
+ "docify 0.2.7",
  "frame-benchmarking",
  "frame-election-provider-support",
  "frame-support",
@@ -4127,7 +4085,7 @@ dependencies = [
 [[package]]
 name = "pallet-glutton"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "blake2",
  "frame-benchmarking",
@@ -4145,7 +4103,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4168,7 +4126,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -4185,7 +4143,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4205,7 +4163,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4222,7 +4180,7 @@ dependencies = [
 [[package]]
 name = "pallet-insecure-randomness-collective-flip"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4236,7 +4194,7 @@ dependencies = [
 [[package]]
 name = "pallet-lottery"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4250,7 +4208,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4267,7 +4225,7 @@ dependencies = [
 [[package]]
 name = "pallet-message-queue"
 version = "31.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -4285,9 +4243,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-migrations"
+version = "1.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
+dependencies = [
+ "docify 0.1.16",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "impl-trait-for-tuples",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-runtime",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
+]
+
+[[package]]
 name = "pallet-mixnet"
 version = "0.4.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4307,7 +4283,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4325,7 +4301,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4341,7 +4317,7 @@ dependencies = [
 [[package]]
 name = "pallet-nft-fractionalization"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4358,7 +4334,7 @@ dependencies = [
 [[package]]
 name = "pallet-nfts"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -4376,7 +4352,7 @@ dependencies = [
 [[package]]
 name = "pallet-nfts-runtime-api"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "pallet-nfts",
  "parity-scale-codec",
@@ -4387,7 +4363,7 @@ dependencies = [
 [[package]]
 name = "pallet-nis"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4403,7 +4379,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools"
 version = "25.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4422,7 +4398,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -4442,7 +4418,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
@@ -4453,7 +4429,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4470,7 +4446,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -4494,9 +4470,9 @@ dependencies = [
 [[package]]
 name = "pallet-parameters"
 version = "0.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
- "docify",
+ "docify 0.2.7",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -4512,7 +4488,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4529,7 +4505,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4544,7 +4520,7 @@ dependencies = [
 [[package]]
 name = "pallet-ranked-collective"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4563,7 +4539,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4578,7 +4554,7 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4596,7 +4572,7 @@ dependencies = [
 [[package]]
 name = "pallet-remark"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4613,7 +4589,7 @@ dependencies = [
 [[package]]
 name = "pallet-root-testing"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4628,9 +4604,9 @@ dependencies = [
 [[package]]
 name = "pallet-safe-mode"
 version = "9.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
- "docify",
+ "docify 0.2.7",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -4647,7 +4623,7 @@ dependencies = [
 [[package]]
 name = "pallet-salary"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4666,9 +4642,9 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
- "docify",
+ "docify 0.2.7",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -4684,7 +4660,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4706,7 +4682,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4723,7 +4699,7 @@ dependencies = [
 [[package]]
 name = "pallet-skip-feeless-payment"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4736,7 +4712,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4754,7 +4730,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -4776,18 +4752,18 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "pallet-staking-runtime-api"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -4797,7 +4773,7 @@ dependencies = [
 [[package]]
 name = "pallet-state-trie-migration"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4814,7 +4790,7 @@ dependencies = [
 [[package]]
 name = "pallet-statement"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4832,9 +4808,9 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
- "docify",
+ "docify 0.2.7",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -4847,23 +4823,22 @@ dependencies = [
 
 [[package]]
 name = "pallet-template"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+version = "0.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
 ]
 
 [[package]]
 name = "pallet-timestamp"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
- "docify",
+ "docify 0.2.7",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -4881,7 +4856,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4900,8 +4875,9 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
+ "frame-benchmarking",
  "frame-support",
  "frame-system",
  "parity-scale-codec",
@@ -4916,7 +4892,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -4928,7 +4904,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-storage"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4948,9 +4924,9 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
- "docify",
+ "docify 0.2.7",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -4967,9 +4943,9 @@ dependencies = [
 [[package]]
 name = "pallet-tx-pause"
 version = "9.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
- "docify",
+ "docify 0.2.7",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -4985,7 +4961,7 @@ dependencies = [
 [[package]]
 name = "pallet-uniques"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5000,7 +4976,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5016,7 +4992,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5031,7 +5007,7 @@ dependencies = [
 [[package]]
 name = "pallet-whitelist"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5044,12 +5020,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "parity-bip39"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e69bf016dc406eff7d53a7d3f7cf1c2e72c82b9088aac1118591e36dd2cd3e9"
+dependencies = [
+ "bitcoin_hashes",
+ "rand 0.7.3",
+ "rand_core 0.6.4",
+ "serde",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "parity-scale-codec"
 version = "3.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "881331e34fa842a2fb61cc2db9643a8fedc615e47cfcc52597d1af0db9a7e8fe"
 dependencies = [
- "arrayvec 0.7.4",
+ "arrayvec",
  "bitvec",
  "byte-slice-cast",
  "bytes 1.5.0",
@@ -5106,6 +5095,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5113,11 +5113,12 @@ checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "pbkdf2"
-version = "0.8.0"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95f5254224e617595d2cc3cc73ff0a5eaf2637519e25f03388154e9378b6ffa"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
- "crypto-mac 0.11.0",
+ "digest 0.10.7",
+ "password-hash",
 ]
 
 [[package]]
@@ -5143,7 +5144,7 @@ checksum = "266c042b60c9c76b8d53061e52b2e0d1116abc57cefc8c5cd671619a56ac3690"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -5183,7 +5184,7 @@ checksum = "626dec3cac7cc0e1577a2ec3fc496277ec2baa084bebad95bb6fdbfae235f84c"
 [[package]]
 name = "polkadot-core-primitives"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -5195,7 +5196,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain-primitives"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "bounded-collections",
  "derive_more",
@@ -5217,9 +5218,9 @@ checksum = "88b4e215c80fe876147f3d58158d5dfeae7dabdd6047e175af77095b78d0035c"
 
 [[package]]
 name = "polkavm-common"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92c99f7eee94e7be43ba37eef65ad0ee8cbaf89b7c00001c3f6d2be985cb1817"
+checksum = "1d9428a5cfcc85c5d7b9fc4b6a18c4b802d0173d768182a51cc7751640f08b92"
 
 [[package]]
 name = "polkavm-derive"
@@ -5228,14 +5229,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6380dbe1fb03ecc74ad55d841cfc75480222d153ba69ddcb00977866cbdabdb8"
 dependencies = [
  "polkavm-derive-impl 0.5.0",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "polkavm-derive"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79fa916f7962348bd1bb1a65a83401675e6fc86c51a0fdbcf92a3108e58e6125"
+checksum = "ae8c4bea6f3e11cd89bb18bcdddac10bd9a24015399bd1c485ad68a985a19606"
 dependencies = [
  "polkavm-derive-impl-macro",
 ]
@@ -5249,42 +5250,42 @@ dependencies = [
  "polkavm-common 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "polkavm-derive-impl"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c10b2654a8a10a83c260bfb93e97b262cf0017494ab94a65d389e0eda6de6c9c"
+checksum = "5c4fdfc49717fb9a196e74a5d28e0bc764eb394a2c803eb11133a31ac996c60c"
 dependencies = [
- "polkavm-common 0.8.0",
+ "polkavm-common 0.9.0",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "polkavm-derive-impl-macro"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15e85319a0d5129dc9f021c62607e0804f5fb777a05cdda44d750ac0732def66"
+checksum = "8ba81f7b5faac81e528eb6158a6f3c9e0bb1008e0ffa19653bc8dea925ecb429"
 dependencies = [
- "polkavm-derive-impl 0.8.0",
- "syn 2.0.48",
+ "polkavm-derive-impl 0.9.0",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "polkavm-linker"
-version = "0.8.2"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdec1451cb18261d5d01de82acc15305e417fb59588cdcb3127d3dcc9672b925"
+checksum = "9c7be503e60cf56c0eb785f90aaba4b583b36bff00e93997d93fef97f9553c39"
 dependencies = [
  "gimli 0.28.1",
  "hashbrown 0.14.3",
  "log",
  "object 0.32.2",
- "polkavm-common 0.8.0",
+ "polkavm-common 0.9.0",
  "regalloc2",
  "rustc-demangle",
 ]
@@ -5381,7 +5382,7 @@ checksum = "834da187cfe638ae8abb0203f0b33e5ccdb02a28e7199f2f47b3e2754f50edca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -5540,7 +5541,7 @@ checksum = "5fddb4f8d99b0a2ebafc65a87a69a7b9875e4b1ae1f00db265d300ef7f28bccc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -5623,7 +5624,7 @@ dependencies = [
  "blake2",
  "common",
  "fflonk",
- "merlin 3.0.0",
+ "merlin",
 ]
 
 [[package]]
@@ -5805,7 +5806,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "25.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "array-bytes",
  "parking_lot",
@@ -5947,32 +5948,16 @@ dependencies = [
 
 [[package]]
 name = "schnorrkel"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "021b403afe70d81eea68f6ea12f6b3c9588e5d536a94c3bf80f15e7faa267862"
-dependencies = [
- "arrayref",
- "arrayvec 0.5.2",
- "curve25519-dalek 2.1.3",
- "merlin 2.0.1",
- "rand_core 0.5.1",
- "sha2 0.8.2",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "schnorrkel"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de18f6d8ba0aad7045f5feae07ec29899c1112584a38509a84ad7b04451eaa0"
 dependencies = [
  "aead",
  "arrayref",
- "arrayvec 0.7.4",
+ "arrayvec",
  "curve25519-dalek 4.1.2",
  "getrandom_or_panic",
- "merlin 3.0.0",
+ "merlin",
  "rand_core 0.6.4",
  "serde_bytes",
  "sha2 0.10.8",
@@ -6002,6 +5987,7 @@ dependencies = [
  "der",
  "generic-array 0.14.7",
  "pkcs8",
+ "serdect",
  "subtle",
  "zeroize",
 ]
@@ -6091,9 +6077,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.196"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
 dependencies = [
  "serde_derive",
 ]
@@ -6109,20 +6095,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.196"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.113"
+version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
+checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
 dependencies = [
  "itoa",
  "ryu",
@@ -6135,6 +6121,16 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serdect"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
+dependencies = [
+ "base16ct",
  "serde",
 ]
 
@@ -6172,18 +6168,6 @@ dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.10.7",
-]
-
-[[package]]
-name = "sha2"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a256f46ea78a0c0d9ff00077504903ac881a1dafdc20da66545699e7776b3e69"
-dependencies = [
- "block-buffer 0.7.3",
- "digest 0.8.1",
- "fake-simd",
- "opaque-debug 0.2.3",
 ]
 
 [[package]]
@@ -6254,8 +6238,9 @@ dependencies = [
 
 [[package]]
 name = "simple-mermaid"
-version = "0.1.0"
-source = "git+https://github.com/kianenigma/simple-mermaid.git?rev=e48b187bcfd5cc75111acd9d241f1bd36604344b#e48b187bcfd5cc75111acd9d241f1bd36604344b"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "620a1d43d70e142b1d46a929af51d44f383db9c7a2ec122de2cd992ccfcf3c18"
 
 [[package]]
 name = "slab"
@@ -6305,9 +6290,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "solochain-template-runtime"
+version = "0.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
+dependencies = [
+ "frame-benchmarking",
+ "frame-executive",
+ "frame-support",
+ "frame-system",
+ "frame-system-benchmarking",
+ "frame-system-rpc-runtime-api",
+ "frame-try-runtime",
+ "pallet-aura",
+ "pallet-balances",
+ "pallet-grandpa",
+ "pallet-sudo",
+ "pallet-template",
+ "pallet-timestamp",
+ "pallet-transaction-payment",
+ "pallet-transaction-payment-rpc-runtime-api",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-api",
+ "sp-block-builder",
+ "sp-consensus-aura",
+ "sp-consensus-grandpa",
+ "sp-core",
+ "sp-genesis-builder",
+ "sp-inherents",
+ "sp-offchain",
+ "sp-runtime",
+ "sp-session",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
+ "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
+ "sp-transaction-pool",
+ "sp-version",
+ "substrate-wasm-builder",
+]
+
+[[package]]
 name = "sp-api"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "hash-db",
  "log",
@@ -6329,7 +6353,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "Inflector",
  "blake2",
@@ -6337,13 +6361,13 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "sp-application-crypto"
 version = "30.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -6356,7 +6380,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -6388,7 +6412,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -6401,7 +6425,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -6412,7 +6436,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -6429,7 +6453,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -6448,7 +6472,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-beefy"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "lazy_static",
  "parity-scale-codec",
@@ -6469,7 +6493,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -6487,7 +6511,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -6499,11 +6523,10 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "array-bytes",
  "bandersnatch_vrfs",
- "bip39",
  "bitflags 1.3.2",
  "blake2",
  "bounded-collections",
@@ -6515,16 +6538,18 @@ dependencies = [
  "hash256-std-hasher",
  "impl-serde",
  "itertools",
+ "k256",
  "libsecp256k1",
  "log",
- "merlin 3.0.0",
+ "merlin",
+ "parity-bip39",
  "parity-scale-codec",
  "parking_lot",
  "paste",
  "primitive-types",
  "rand 0.8.5",
  "scale-info",
- "schnorrkel 0.11.4",
+ "schnorrkel",
  "secp256k1",
  "secrecy",
  "serde",
@@ -6545,7 +6570,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-ec-utils"
 version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-377-ext",
@@ -6566,7 +6591,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -6579,37 +6604,37 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "quote",
  "sp-crypto-hashing",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "sp-externalities"
 version = "0.25.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -6620,7 +6645,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.25.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -6631,7 +6656,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "serde_json",
  "sp-api",
@@ -6642,7 +6667,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -6656,13 +6681,14 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "30.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "bytes 1.5.0",
  "ed25519-dalek",
  "libsecp256k1",
  "log",
  "parity-scale-codec",
+ "polkavm-derive 0.9.1",
  "rustversion",
  "secp256k1",
  "sp-core",
@@ -6681,7 +6707,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "31.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -6691,19 +6717,18 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "parity-scale-codec",
  "parking_lot",
  "sp-core",
  "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
- "thiserror",
 ]
 
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "thiserror",
  "zstd",
@@ -6712,7 +6737,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-metadata 16.0.0",
  "parity-scale-codec",
@@ -6723,7 +6748,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.4.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -6735,7 +6760,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "ckb-merkle-mountain-range",
  "log",
@@ -6753,7 +6778,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -6767,7 +6792,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -6777,7 +6802,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -6787,9 +6812,9 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "31.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
- "docify",
+ "docify 0.2.7",
  "either",
  "hash256-std-hasher",
  "impl-trait-for-tuples",
@@ -6806,17 +6831,18 @@ dependencies = [
  "sp-io",
  "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
  "sp-weights",
+ "tuplex",
 ]
 
 [[package]]
 name = "sp-runtime-interface"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "bytes 1.5.0",
  "impl-trait-for-tuples",
  "parity-scale-codec",
- "polkavm-derive 0.8.0",
+ "polkavm-derive 0.9.1",
  "primitive-types",
  "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
  "sp-runtime-interface-proc-macro 17.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
@@ -6830,12 +6856,12 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "bytes 1.5.0",
  "impl-trait-for-tuples",
  "parity-scale-codec",
- "polkavm-derive 0.8.0",
+ "polkavm-derive 0.9.1",
  "primitive-types",
  "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk)",
  "sp-runtime-interface-proc-macro 17.0.0 (git+https://github.com/paritytech/polkadot-sdk)",
@@ -6849,33 +6875,33 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "Inflector",
  "expander",
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "Inflector",
  "expander",
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "sp-session"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -6890,7 +6916,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -6904,7 +6930,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.35.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "hash-db",
  "log",
@@ -6925,7 +6951,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek 4.1.2",
@@ -6950,17 +6976,17 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 
 [[package]]
 name = "sp-storage"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -6973,7 +6999,7 @@ dependencies = [
 [[package]]
 name = "sp-storage"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -6986,7 +7012,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -6999,7 +7025,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "parity-scale-codec",
  "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
@@ -7011,7 +7037,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "parity-scale-codec",
  "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk)",
@@ -7023,7 +7049,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -7032,7 +7058,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -7047,7 +7073,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "ahash 0.8.8",
  "hash-db",
@@ -7071,7 +7097,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -7088,18 +7114,18 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "sp-wasm-interface"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -7112,7 +7138,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -7125,7 +7151,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
@@ -7177,7 +7203,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "staging-xcm"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "array-bytes",
  "bounded-collections",
@@ -7195,7 +7221,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-builder"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7217,7 +7243,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-executor"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -7305,14 +7331,13 @@ dependencies = [
 
 [[package]]
 name = "substrate-bip39"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e620c7098893ba667438b47169c00aacdd9e7c10e042250ce2b60b087ec97328"
+version = "0.4.7"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
- "hmac 0.11.0",
+ "hmac 0.12.1",
  "pbkdf2",
- "schnorrkel 0.9.1",
- "sha2 0.9.9",
+ "schnorrkel",
+ "sha2 0.10.8",
  "zeroize",
 ]
 
@@ -7335,7 +7360,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "build-helper",
  "cargo_metadata",
@@ -7370,9 +7395,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "2.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7430,7 +7455,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -7441,7 +7466,7 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
  "test-case-core",
 ]
 
@@ -7474,7 +7499,7 @@ checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -7536,7 +7561,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -7687,7 +7712,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -7798,14 +7823,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tuplex"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "676ac81d5454c4dcf37955d34fa8626ede3490f744b86ca14a7b90168d2a08aa"
+
+[[package]]
 name = "twox-hash"
 version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "digest 0.10.7",
- "rand 0.8.5",
+ "rand 0.7.3",
  "static_assertions",
 ]
 
@@ -8016,7 +8047,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
  "wasm-bindgen-shared",
 ]
 
@@ -8038,7 +8069,7 @@ checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -8611,12 +8642,12 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#7ec692d11c5b0d749ad89a71df835dae4d3756ed"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a756baf3b211efc57ca4a0089b7ceba4c20b9f12"
 dependencies = [
  "Inflector",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -8636,7 +8667,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -8656,7 +8687,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -37,7 +37,7 @@ pallet-contracts = { optional = true, git = "https://github.com/paritytech/polka
 pallet-staking = { optional = true, git = "https://github.com/paritytech/polkadot-sdk.git", branch = "master" }
 
 [dev-dependencies]
-node-template-runtime = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "master" }
+solochain-template-runtime = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "master" }
 sp-keyring = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "master" }
 pallet-transaction-payment = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "master" }
 

--- a/primitives/src/extrinsics/mod.rs
+++ b/primitives/src/extrinsics/mod.rs
@@ -254,10 +254,10 @@ mod tests {
 		CheckEra, CheckGenesis, CheckNonZeroSender, CheckNonce, CheckSpecVersion, CheckTxVersion,
 		CheckWeight,
 	};
-	use solochain_template_runtime::{
-		BalancesCall, Runtime, RuntimeCall, SignedExtra, SystemCall, UncheckedExtrinsic, VERSION,
-	};
 	use pallet_transaction_payment::ChargeTransactionPayment;
+	use solochain_template_runtime::{
+		BalancesCall, Runtime, RuntimeCall, SystemCall, TxExtension, UncheckedExtrinsic, VERSION,
+	};
 	use sp_core::{crypto::Ss58Codec, Pair, H256 as Hash};
 	use sp_keyring::AccountKeyring;
 	use sp_runtime::{
@@ -312,14 +312,14 @@ mod tests {
 			MultiAddress<AccountId32, u32>,
 			RuntimeCall,
 			MultiSignature,
-			SignedExtra,
+			TxExtension,
 		>::new_unsigned(call1.clone());
 		let json = serde_json::to_string(&xt1).expect("serializing failed");
 		let extrinsic: UncheckedExtrinsicV4<
 			MultiAddress<AccountId32, u32>,
 			RuntimeCall,
 			MultiSignature,
-			SignedExtra,
+			TxExtension,
 		> = serde_json::from_str(&json).expect("deserializing failed");
 		let call = extrinsic.function;
 		assert_eq!(call, call1);
@@ -342,7 +342,7 @@ mod tests {
 		let fee = 100;
 
 		// Create Substrate extrinsic.
-		let substrate_signed_extra: SignedExtra = (
+		let substrate_signed_extra: TxExtension = (
 			CheckNonZeroSender::<Runtime>::new(),
 			CheckSpecVersion::<Runtime>::new(),
 			CheckTxVersion::<Runtime>::new(),
@@ -399,7 +399,7 @@ mod tests {
 		let fee = 100;
 
 		// Create Substrate extrinsic.
-		let substrate_signed_extra: SignedExtra = (
+		let substrate_signed_extra: TxExtension = (
 			CheckNonZeroSender::<Runtime>::new(),
 			CheckSpecVersion::<Runtime>::new(),
 			CheckTxVersion::<Runtime>::new(),

--- a/primitives/src/extrinsics/mod.rs
+++ b/primitives/src/extrinsics/mod.rs
@@ -254,7 +254,7 @@ mod tests {
 		CheckEra, CheckGenesis, CheckNonZeroSender, CheckNonce, CheckSpecVersion, CheckTxVersion,
 		CheckWeight,
 	};
-	use node_template_runtime::{
+	use solochain_template_runtime::{
 		BalancesCall, Runtime, RuntimeCall, SignedExtra, SystemCall, UncheckedExtrinsic, VERSION,
 	};
 	use pallet_transaction_payment::ChargeTransactionPayment;

--- a/primitives/src/extrinsics/signer.rs
+++ b/primitives/src/extrinsics/signer.rs
@@ -139,7 +139,7 @@ where
 mod tests {
 	use super::*;
 	use crate::AssetRuntimeConfig;
-	use node_template_runtime::Signature;
+	use solochain_template_runtime::Signature;
 	use sp_core::sr25519;
 	use sp_keyring::AccountKeyring;
 


### PR DESCRIPTION
Currently our dependencies are broken on master. For example `cargo update` fails with:
```
    Updating crates.io index
    Updating git repository `https://github.com/paritytech/polkadot-sdk.git`
error: no matching package named `node-template-runtime` found
location searched: https://github.com/paritytech/polkadot-sdk.git?branch=master
required by package `ac-primitives v0.9.1 (/home/tniederberger/repos/substrate-api-client/primitives)`
```
Apparently the node-template-runtime dependency has been renamed to solochain-template-runtime. See this PR: https://github.com/paritytech/polkadot-sdk/pull/3460
and especially this line https://github.com/paritytech/polkadot-sdk/blob/4c810609d6c72b48bd748398165da5c27a604778/prdoc/pr_3460.prdoc#L24

Additionaly it seems that `SignedExtra` has been renamed to `TxExtension`. See https://github.com/paritytech/polkadot-sdk/pull/2280