### PR TITLE
Update mio dependency that has a vulnerability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3315,9 +3315,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
@@ -7545,7 +7545,7 @@ dependencies = [
  "backtrace",
  "bytes 1.5.0",
  "libc",
- "mio 0.8.10",
+ "mio 0.8.11",
  "num_cpus",
  "pin-project-lite",
  "socket2",


### PR DESCRIPTION
This should fix the security advisory:
https://github.com/scs/substrate-api-client/security/dependabot/27