### PR TITLE
Update rust version to newest nightly

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2024-02-07"
+channel = "nightly-2024-04-25"
 targets = ["wasm32-unknown-unknown"]
 profile = "default" # include rustfmt, clippy


### PR DESCRIPTION
I'm currently looking a bit into the WebAssembly compatibility and there were quite a few changes recently. So I would like to update to the newest nightly.