### PR TITLE
Create a nightly build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
         run: rustup show && rustup component add rust-src
 
       - name: Cargo update
-        if: ${{ github.event_name == 'schedule' }}
+        #if: ${{ github.event_name == 'schedule' }}
         run: cargo update
 
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
     branches: [ master, 'polkadot-v[0-9]+.[0-9]+.[0-9]+*', 'release-polkadot-v[0-9]+.[0-9]+.[0-9]+*' ]
   pull_request:
     branches: [ master, 'polkadot-v[0-9]+.[0-9]+.[0-9]+*', 'release-polkadot-v[0-9]+.[0-9]+.[0-9]+*' ]
+  schedule:
+    - cron: "0 7 * * *"
 
 env:
   CARGO_TERM_COLOR: always
@@ -78,6 +80,11 @@ jobs:
       - uses: actions/checkout@v4
       - name: init-rust-target
         run: rustup show && rustup component add rust-src
+
+      - name: Cargo update
+        runs-on: ${{ matrix.os }}    
+        if: ${{ github.event_name == 'schedule' }}
+        run: cargo update
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,6 @@ jobs:
         run: rustup show && rustup component add rust-src
 
       - name: Cargo update
-        runs-on: ${{ matrix.os }}    
         if: ${{ github.event_name == 'schedule' }}
         run: cargo update
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
     branches: [ master, 'polkadot-v[0-9]+.[0-9]+.[0-9]+*', 'release-polkadot-v[0-9]+.[0-9]+.[0-9]+*' ]
   schedule:
-    - cron: "0 7 * * *"
+    - cron: "0 0 * * *"
 
 env:
   CARGO_TERM_COLOR: always
@@ -82,7 +82,7 @@ jobs:
         run: rustup show && rustup component add rust-src
 
       - name: Cargo update
-        #if: ${{ github.event_name == 'schedule' }}
+        if: ${{ github.event_name == 'schedule' }}
         run: cargo update
 
       - uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
Build should run once per day and also do a `cargo update` in order to make sure the api-client still builds against the latest polkadot master