### PR TITLE
Upload Cargo.lock during build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,8 +87,8 @@ jobs:
 
       - name: Upload Cargo.lock
         uses: actions/upload-artifact@v4
-        #if: ${{ github.event_name == 'schedule' }}
-        if: contains(matrix.check, 'examples-async')
+        # Upload the Cargo.lock from the build with --locked as this one should not update the Cargo.lock anymore
+        if: contains(matrix.check, '--locked')
         with:
           name: cargo-lock
           path: Cargo.lock
@@ -243,5 +243,5 @@ jobs:
         uses: actions/upload-artifact/merge@v4
         with:
           separate-directories: true
-          name: examples
+          name: artifacts
           delete-merged: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,8 +82,16 @@ jobs:
         run: rustup show && rustup component add rust-src
 
       - name: Cargo update
-        if: ${{ github.event_name == 'schedule' }}
+        #if: ${{ github.event_name == 'schedule' }}
         run: cargo update
+
+      - name: Upload Cargo.lock
+        uses: actions/upload-artifact@v4
+        #if: ${{ github.event_name == 'schedule' }}
+        if: contains(matrix.check, 'examples-async')
+        with:
+          name: cargo-lock
+          path: Cargo.lock
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -236,5 +244,4 @@ jobs:
         with:
           separate-directories: true
           name: examples
-          pattern: examples-*
           delete-merged: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
         run: rustup show && rustup component add rust-src
 
       - name: Cargo update
-        #if: ${{ github.event_name == 'schedule' }}
+        if: ${{ github.event_name == 'schedule' }}
         run: cargo update
 
       - name: Upload Cargo.lock


### PR DESCRIPTION
A small improvement to our build such that we also upload the Cargo.lock. This is mostly useful for the nightly build which updates the Cargo.lock but since it is a small file we can include it in all the builds.