### PR TITLE
Fix the state_tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,7 +216,7 @@ jobs:
 
       - name: Run latest node
         run: |
-          docker run -p 9944:9944 -p 9933:9933 -p 30333:30333 paritypr/substrate:master-1cd6acdf --dev --rpc-external &
+          docker run -p 9944:9944 -p 9933:9933 -p 30333:30333 paritypr/substrate:master-c7bd8804 --dev --rpc-external &
 
       - name: Wait until node has started
         run: sleep 20s

--- a/testing/async/examples/state_tests.rs
+++ b/testing/async/examples/state_tests.rs
@@ -20,7 +20,6 @@ use pallet_balances::AccountData as GenericAccountData;
 use pallet_staking::Exposure;
 use sp_core::{crypto::Ss58Codec, sr25519};
 use sp_keyring::AccountKeyring;
-use sp_runtime::print;
 use sp_staking::EraIndex;
 use substrate_api_client::{
 	ac_primitives::{AssetRuntimeConfig, Config},
@@ -69,11 +68,11 @@ async fn main() {
 		.unwrap();
 	println!("Could fetch storage_keys: {:?}", double_map_storage_keys);
 	let era_stakers: ErasStakers = api
-		.get_storage_double_map("Staking", "ErasStakers", EraIndex::default(), "", None)
+		.get_storage_double_map("Staking", "ErasStakers", EraIndex::default(), alice_stash, None)
 		.await
 		.unwrap()
 		.unwrap();
-	println!("{:?}", era_stakers);
+	println!("ErasStakers: {:?}", era_stakers);
 
 	// Ensure the prefix matches the actual storage key:
 	let storage_key_prefix = api.get_storage_map_key_prefix("System", "Account").await.unwrap();

--- a/testing/async/examples/state_tests.rs
+++ b/testing/async/examples/state_tests.rs
@@ -69,7 +69,6 @@ async fn main() {
 		.await
 		.unwrap()
 		.unwrap();
-	println!("ErasStakers: {:?}", era_stakers);
 
 	// Ensure the prefix matches the actual storage key:
 	let storage_key_prefix = api.get_storage_map_key_prefix("System", "Account").await.unwrap();

--- a/testing/async/examples/state_tests.rs
+++ b/testing/async/examples/state_tests.rs
@@ -20,6 +20,7 @@ use pallet_balances::AccountData as GenericAccountData;
 use pallet_staking::Exposure;
 use sp_core::{crypto::Ss58Codec, sr25519};
 use sp_keyring::AccountKeyring;
+use sp_runtime::print;
 use sp_staking::EraIndex;
 use substrate_api_client::{
 	ac_primitives::{AssetRuntimeConfig, Config},
@@ -57,11 +58,22 @@ async fn main() {
 		.unwrap();
 	let _account_info: AccountData =
 		api.get_storage_map("System", "Account", &alice, None).await.unwrap().unwrap();
-	let _era_stakers: ErasStakers = api
-		.get_storage_double_map("Staking", "ErasStakers", EraIndex::default(), alice_stash, None)
+
+	let storage_double_map_key_prefix = api
+		.get_storage_double_map_key_prefix("Staking", "ErasStakers", 0)
+		.await
+		.unwrap();
+	let double_map_storage_keys = api
+		.get_storage_keys_paged(Some(storage_double_map_key_prefix), 3, None, None)
+		.await
+		.unwrap();
+	println!("Could fetch storage_keys: {:?}", double_map_storage_keys);
+	let era_stakers: ErasStakers = api
+		.get_storage_double_map("Staking", "ErasStakers", EraIndex::default(), "", None)
 		.await
 		.unwrap()
 		.unwrap();
+	println!("{:?}", era_stakers);
 
 	// Ensure the prefix matches the actual storage key:
 	let storage_key_prefix = api.get_storage_map_key_prefix("System", "Account").await.unwrap();

--- a/testing/async/examples/state_tests.rs
+++ b/testing/async/examples/state_tests.rs
@@ -59,7 +59,7 @@ async fn main() {
 		api.get_storage_map("System", "Account", &alice, None).await.unwrap().unwrap();
 
 	let storage_double_map_key_prefix = api
-		.get_storage_double_map_key_prefix("Staking", "ErasStakers", 0)
+		.get_storage_double_map_key_prefix("Staking", "ErasStakersOverview", 0)
 		.await
 		.unwrap();
 	let double_map_storage_keys = api
@@ -68,7 +68,7 @@ async fn main() {
 		.unwrap();
 	println!("Could fetch storage_keys: {:?}", double_map_storage_keys);
 	let era_stakers: ErasStakers = api
-		.get_storage_double_map("Staking", "ErasStakers", EraIndex::default(), alice_stash, None)
+		.get_storage_double_map("Staking", "ErasStakersOverview", EraIndex::default(), alice_stash, None)
 		.await
 		.unwrap()
 		.unwrap();

--- a/testing/async/examples/state_tests.rs
+++ b/testing/async/examples/state_tests.rs
@@ -58,15 +58,6 @@ async fn main() {
 	let _account_info: AccountData =
 		api.get_storage_map("System", "Account", &alice, None).await.unwrap().unwrap();
 
-	let storage_double_map_key_prefix = api
-		.get_storage_double_map_key_prefix("Staking", "ErasStakersOverview", 0)
-		.await
-		.unwrap();
-	let double_map_storage_keys = api
-		.get_storage_keys_paged(Some(storage_double_map_key_prefix), 3, None, None)
-		.await
-		.unwrap();
-	println!("Could fetch storage_keys: {:?}", double_map_storage_keys);
 	let era_stakers: ErasStakers = api
 		.get_storage_double_map(
 			"Staking",

--- a/testing/async/examples/state_tests.rs
+++ b/testing/async/examples/state_tests.rs
@@ -68,7 +68,13 @@ async fn main() {
 		.unwrap();
 	println!("Could fetch storage_keys: {:?}", double_map_storage_keys);
 	let era_stakers: ErasStakers = api
-		.get_storage_double_map("Staking", "ErasStakersOverview", EraIndex::default(), alice_stash, None)
+		.get_storage_double_map(
+			"Staking",
+			"ErasStakersOverview",
+			EraIndex::default(),
+			alice_stash,
+			None,
+		)
 		.await
 		.unwrap()
 		.unwrap();


### PR DESCRIPTION
Add debug output
Docker images:
- master-00b85c51 broken (01.11.2023)
- master-f50054cf working (01.11.2023)

It seems it is broken since this commit: https://github.com/paritytech/polkadot-sdk/commit/00b85c51dfbc0fecbb8a4dd3635d4c177a6527a6

According to this PR `ErasStakers` has been deprecated:
https://github.com/paritytech/polkadot-sdk/commit/00b85c51dfbc0fecbb8a4dd3635d4c177a6527a6