### PR TITLE
Use stabilized chainSpec calls in `unstable_rpc_api_calls`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,7 +216,7 @@ jobs:
 
       - name: Run latest node
         run: |
-          docker run -p 9944:9944 -p 9933:9933 -p 30333:30333 paritypr/substrate:master-0400ed90 --dev --rpc-external &
+          docker run -p 9944:9944 -p 9933:9933 -p 30333:30333 paritypr/substrate:master-cb944dc5 --dev --rpc-external &
 
       - name: Wait until node has started
         run: sleep 20s

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,7 +216,7 @@ jobs:
 
       - name: Run latest node
         run: |
-          docker run -p 9944:9944 -p 9933:9933 -p 30333:30333 paritypr/substrate:master-cb944dc5 --dev --rpc-external &
+          docker run -p 9944:9944 -p 9933:9933 -p 30333:30333 paritypr/substrate:master-1cd6acdf --dev --rpc-external &
 
       - name: Wait until node has started
         run: sleep 20s

--- a/examples/async/examples/unstable_rpc_api_calls.rs
+++ b/examples/async/examples/unstable_rpc_api_calls.rs
@@ -50,8 +50,8 @@ async fn main() {
 
 	// Since it's an unstable api and might change anytime, we first check if our calls are still
 	// available:
-	let chain_name_request = "chainSpec_unstable_chainName";
-	let chain_genesis_hash_request = "chainSpec_unstable_genesisHash";
+	let chain_name_request = "chainSpec_v1_chainName";
+	let chain_genesis_hash_request = "chainSpec_v1_genesisHash";
 	let transaction_submit_watch = "transaction_unstable_submitAndWatch";
 	let transaction_unwatch = "transaction_unstable_unwatch";
 


### PR DESCRIPTION
This is a quick fix to get the test working again. I created a follow up issue to provide an actual API for the functionality in the `unstable_rpc_api_calls.rs` test. See https://github.com/scs/substrate-api-client/issues/779

In this PR:
- Use stabilized versions of chainSpec calls
- Use newer docker image (From 01.11.2023)