### PR TITLE
Use stabilized transaction calls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,7 +216,7 @@ jobs:
 
       - name: Run latest node
         run: |
-          docker run -p 9944:9944 -p 9933:9933 -p 30333:30333 paritypr/substrate:master-c7bd8804 --dev --rpc-external &
+          docker run -p 9944:9944 -p 9933:9933 -p 30333:30333 paritypr/substrate:master-1680977e --dev --rpc-external &
 
       - name: Wait until node has started
         run: sleep 20s

--- a/examples/async/examples/unstable_rpc_api_calls.rs
+++ b/examples/async/examples/unstable_rpc_api_calls.rs
@@ -52,8 +52,8 @@ async fn main() {
 	// available:
 	let chain_name_request = "chainSpec_v1_chainName";
 	let chain_genesis_hash_request = "chainSpec_v1_genesisHash";
-	let transaction_submit_watch = "transaction_v1_submitAndWatch";
-	let transaction_unwatch = "transaction_v1_unwatch";
+	let transaction_submit_watch = "transactionWatch_v1_submitAndWatch";
+	let transaction_unwatch = "transactionWatch_v1_unwatch";
 
 	let request_vec = [
 		chain_name_request,

--- a/examples/async/examples/unstable_rpc_api_calls.rs
+++ b/examples/async/examples/unstable_rpc_api_calls.rs
@@ -52,8 +52,8 @@ async fn main() {
 	// available:
 	let chain_name_request = "chainSpec_v1_chainName";
 	let chain_genesis_hash_request = "chainSpec_v1_genesisHash";
-	let transaction_submit_watch = "transaction_unstable_submitAndWatch";
-	let transaction_unwatch = "transaction_unstable_unwatch";
+	let transaction_submit_watch = "transaction_v1_submitAndWatch";
+	let transaction_unwatch = "transaction_v1_unwatch";
 
 	let request_vec = [
 		chain_name_request,


### PR DESCRIPTION
- Use stabilized transaction calls
  - Again just the minimal change to get the test working. For proper integration see #779 
  - Corresponding polkadot branch: https://github.com/paritytech/polkadot-sdk/pull/4171
- Use newer docker image
  - The docker image is no special version. Just old enough that it does not yet contain the merkelized metadata (See #777)