### PR TITLE
Fix license check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,12 @@ jobs:
           crate: cargo-about
           version: "0.6"
 
+      - name: Cargo update
+        # Run a cargo update in nightly build for the license check 
+        # (in case newer versions changed their license)
+        if: ${{ github.event_name == 'schedule' }}
+        run: cargo update
+
       - name: Run license check
         # Explicitly use stable because otherwise cargo will trigger a download of
         # the nightly version specified in rust-toolchain.toml

--- a/about.toml
+++ b/about.toml
@@ -10,7 +10,8 @@ accepted = [
     "OpenSSL",
     "Unicode-DFS-2016",
     "NOASSERTION",
-    "GPL-3.0"
+    "GPL-3.0",
+    "Unicode-3.0"
 ]
 ignore-dev-dependencies = true
 ignore-build-dependencies = true


### PR DESCRIPTION
- Update the allowed licenses
- Run a cargo update in the license check of a nightly build to test the newest versions