### PR TITLE
Switch all internal version numbers to 0.18.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,7 @@ dependencies = [
 
 [[package]]
 name = "ac-compose-macros"
-version = "0.5.0"
+version = "0.18.0"
 dependencies = [
  "ac-node-api",
  "ac-primitives",
@@ -26,7 +26,7 @@ dependencies = [
 
 [[package]]
 name = "ac-examples-async"
-version = "0.5.0"
+version = "0.18.0"
 dependencies = [
  "env_logger 0.11.3",
  "frame-support",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "ac-examples-sync"
-version = "0.5.0"
+version = "0.18.0"
 dependencies = [
  "env_logger 0.11.3",
  "log",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "ac-examples-wasm"
-version = "0.5.0"
+version = "0.18.0"
 dependencies = [
  "pallet-balances",
  "sp-core",
@@ -73,7 +73,7 @@ dependencies = [
 
 [[package]]
 name = "ac-keystore"
-version = "0.10.0"
+version = "0.18.0"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -89,7 +89,7 @@ dependencies = [
 
 [[package]]
 name = "ac-node-api"
-version = "0.6.0"
+version = "0.18.0"
 dependencies = [
  "ac-primitives",
  "bitvec",
@@ -117,7 +117,7 @@ dependencies = [
 
 [[package]]
 name = "ac-primitives"
-version = "0.9.1"
+version = "0.18.0"
 dependencies = [
  "frame-system",
  "impl-serde",
@@ -145,7 +145,7 @@ dependencies = [
 
 [[package]]
 name = "ac-testing-async"
-version = "0.4.0"
+version = "0.18.0"
 dependencies = [
  "frame-support",
  "jsonrpsee",
@@ -164,7 +164,7 @@ dependencies = [
 
 [[package]]
 name = "ac-testing-sync"
-version = "0.4.0"
+version = "0.18.0"
 dependencies = [
  "ac-keystore",
  "sp-application-crypto",
@@ -9940,7 +9940,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-api-client"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "ac-compose-macros",
  "ac-node-api",
@@ -10123,7 +10123,7 @@ dependencies = [
 
 [[package]]
 name = "test-no-std"
-version = "0.7.1"
+version = "0.18.0"
 dependencies = [
  "ac-compose-macros",
  "ac-node-api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-api-client"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["Supercomputing Systems AG <info@scs.ch>"]
 license = "Apache-2.0"
 edition = "2021"
@@ -60,13 +60,13 @@ sp-version = { default-features = false, features = ["serde"], git = "https://gi
 frame-support = { optional = true, git = "https://github.com/paritytech/polkadot-sdk.git", branch = "master" }
 
 # local deps
-ac-compose-macros = { path = "compose-macros", version = "0.5", default-features = false }
-ac-node-api = { path = "node-api", version = "0.6", default-features = false }
-ac-primitives = { path = "primitives", version = "0.9.1", default-features = false }
+ac-compose-macros = { path = "compose-macros", version = "0.18", default-features = false }
+ac-node-api = { path = "node-api", version = "0.18", default-features = false }
+ac-primitives = { path = "primitives", version = "0.18", default-features = false }
 
 
 [dev-dependencies]
-ac-node-api = { path = "node-api", version = "0.6", features = ["mocks"] }
+ac-node-api = { path = "node-api", version = "0.18", features = ["mocks"] }
 kitchensink-runtime = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "master" }
 scale-info = { version = "2.1.1", features = ["derive"] }
 test-case = "3.1.0"

--- a/compose-macros/Cargo.toml
+++ b/compose-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ac-compose-macros"
-version = "0.5.0"
+version = "0.18.0"
 authors = ["Supercomputing Systems AG <info@scs.ch>"]
 license = "Apache-2.0"
 edition = "2021"
@@ -15,10 +15,10 @@ log = { version = "0.4.14", default-features = false }
 maybe-async = { version = "0.2.7" }
 
 # local
-ac-primitives = { path = "../primitives", version = "0.9.1", default-features = false }
+ac-primitives = { path = "../primitives", version = "0.18", default-features = false }
 
 [dev-dependencies]
-ac-node-api = { path = "../node-api", version = "0.6" }
+ac-node-api = { path = "../node-api", version = "0.18" }
 frame-metadata = { version = "16.0" }
 codec = { package = "parity-scale-codec", version = "3.6.1" }
 

--- a/examples/async/Cargo.toml
+++ b/examples/async/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ac-examples-async"
-version = "0.5.0"
+version = "0.18.0"
 license = "Apache-2.0"
 edition = "2021"
 
@@ -26,4 +26,4 @@ sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = 
 sp-weights = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "master" }
 
 # local deps
-substrate-api-client = { path = "../..", version = "0.17", features = ["staking-xt", "contracts-xt", "disable-metadata-hash-check"] }
+substrate-api-client = { path = "../..", version = "0.18", features = ["staking-xt", "contracts-xt", "disable-metadata-hash-check"] }

--- a/examples/sync/Cargo.toml
+++ b/examples/sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ac-examples-sync"
-version = "0.5.0"
+version = "0.18.0"
 license = "Apache-2.0"
 edition = "2021"
 
@@ -15,4 +15,4 @@ sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = 
 sp-weights = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "master" }
 
 # local deps
-substrate-api-client = { path = "../..", version = "0.17", default-features = false, features = ["tungstenite-client", "ws-client", "disable-metadata-hash-check"] }
+substrate-api-client = { path = "../..", version = "0.18", default-features = false, features = ["tungstenite-client", "ws-client", "disable-metadata-hash-check"] }

--- a/examples/wasm/Cargo.toml
+++ b/examples/wasm/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "ac-examples-wasm"
-version = "0.5.0"
+version = "0.18.0"
 license = "Apache-2.0"
 edition = "2021"
 
 [dev-dependencies]
 sp-core = { default-features = false, features = ["full_crypto", "serde"], git = "https://github.com/paritytech/polkadot-sdk.git", branch = "master" }
 sp-runtime = { default-features = false, git = "https://github.com/paritytech/polkadot-sdk.git", branch = "master" }
-substrate-api-client = { default-features = false, path = "../..", version = "0.17" }
+substrate-api-client = { path = "../..", version = "0.18", default-features = false }
 pallet-balances = { default-features = false, git = "https://github.com/paritytech/polkadot-sdk.git", branch = "master" }

--- a/keystore/Cargo.toml
+++ b/keystore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ac-keystore"
-version = "0.10.0"
+version = "0.18.0"
 authors = ["Supercomputing Systems AG <info@scs.ch>"]
 license = "Apache-2.0"
 edition = "2021"

--- a/node-api/Cargo.toml
+++ b/node-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ac-node-api"
-version = "0.6.0"
+version = "0.18.0"
 authors = ["Supercomputing Systems AG <info@scs.ch>"]
 license = "Apache-2.0"
 edition = "2021"
@@ -36,7 +36,7 @@ sp-application-crypto = { default-features = false, features = ["full_crypto"], 
 sp-runtime-interface = { default-features = false, git = "https://github.com/paritytech/polkadot-sdk.git", branch = "master" }
 
 # local
-ac-primitives = { path = "../primitives", version = "0.9.1", default-features = false }
+ac-primitives = { path = "../primitives", version = "0.18", default-features = false }
 
 [dev-dependencies]
 test-case = "3.1.0"

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ac-primitives"
-version = "0.9.1"
+version = "0.18.0"
 authors = ["Supercomputing Systems AG <info@scs.ch>"]
 license = "Apache-2.0"
 edition = "2021"

--- a/test-no-std/Cargo.toml
+++ b/test-no-std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test-no-std"
-version = "0.7.1"
+version = "0.18.0"
 authors = ["Supercomputing Systems AG <info@scs.ch>"]
 license = "Apache-2.0"
 edition = "2021"
@@ -9,10 +9,10 @@ edition = "2021"
 libc = { version = "0.2.119", default-features = false }
 
 # local dependencies
-ac-compose-macros = { path = "../compose-macros", version = "0.5", default-features = false, optional = true, features = ["disable_target_static_assertions", "sync-api"] }
-ac-node-api = { path = "../node-api", version = "0.6", default-features = false, optional = true, features = ["disable_target_static_assertions"] }
-ac-primitives = { path = "../primitives", version = "0.9.1", default-features = false, optional = true, features = ["disable_target_static_assertions"] }
-substrate-api-client = { path = "..", version = "0.17", default-features = false, optional = true, features = ["disable_target_static_assertions", "sync-api"] }
+ac-compose-macros = { path = "../compose-macros", version = "0.18", default-features = false, optional = true, features = ["disable_target_static_assertions", "sync-api"] }
+ac-node-api = { path = "../node-api", version = "0.18", default-features = false, optional = true, features = ["disable_target_static_assertions"] }
+ac-primitives = { path = "../primitives", version = "0.18", default-features = false, optional = true, features = ["disable_target_static_assertions"] }
+substrate-api-client = { path = "..", version = "0.18", default-features = false, optional = true, features = ["disable_target_static_assertions", "sync-api"] }
 
 # substrate dependencies
 sp-io = { default-features = false, features = ["disable_oom", "disable_panic_handler"], git = "https://github.com/paritytech/polkadot-sdk.git", branch = "master" }

--- a/testing/async/Cargo.toml
+++ b/testing/async/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ac-testing-async"
-version = "0.4.0"
+version = "0.18.0"
 authors = ["Supercomputing Systems AG <info@scs.ch>"]
 license = "Apache-2.0"
 edition = "2021"
@@ -23,4 +23,4 @@ pallet-balances = { git = "https://github.com/paritytech/polkadot-sdk.git", bran
 pallet-staking = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "master" }
 
 # local deps
-substrate-api-client = { path = "../..", version = "0.17", features = ["staking-xt", "contracts-xt", "disable-metadata-hash-check"] }
+substrate-api-client = { path = "../..", version = "0.18", features = ["staking-xt", "contracts-xt", "disable-metadata-hash-check"] }

--- a/testing/sync/Cargo.toml
+++ b/testing/sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ac-testing-sync"
-version = "0.4.0"
+version = "0.18.0"
 authors = ["Supercomputing Systems AG <info@scs.ch>"]
 license = "Apache-2.0"
 edition = "2021"
@@ -12,5 +12,5 @@ sp-core = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "ma
 sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "master" }
 
 # local deps
-substrate-api-client = { path = "../..", version = "0.17", default-features = false, features = ["tungstenite-client", "ws-client", "disable-metadata-hash-check"] }
-ac-keystore = { path = "../../keystore" }
+substrate-api-client = { path = "../..", version = "0.18", default-features = false, features = ["tungstenite-client", "ws-client", "disable-metadata-hash-check"] }
+ac-keystore = { path = "../../keystore", version = "0.18" }


### PR DESCRIPTION
Preparation for release on crates.io. Moved all version numbers to 0.18.0