### PR TITLE
Fix taplo issue in nightly build

### DIFF
--- a/.taplo.toml
+++ b/.taplo.toml
@@ -19,3 +19,7 @@ keys = ["features"]
 
 [rule.formatting]
 array_auto_expand = true
+
+[[rule]]
+keys = ["package"]
+formatting.reorder_keys = false


### PR DESCRIPTION
Prevent taplo from re-ordering keys in the `package` section