### PR TITLE
Fix disk issues with Github runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,20 @@ jobs:
         with:
           access_token: ${{ secrets.GITHUB_TOKEN }}
 
+  free-disk-space:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Free Disk Space (Ubuntu)
+      uses: jlumbroso/free-disk-space@main
+      with:
+        tool-cache: false
+        android: true
+        dotnet: true
+        haskell: true
+        large-packages: false
+        docker-images: false
+        swap-storage: false
+
   build:
     name: ${{ matrix.check }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
   build:
     name: ${{ matrix.check }}
     runs-on: ${{ matrix.os }}
+    needs: free-disk-space
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Recently our builds failed multiple times due to lack of disk space (`No space left on device`). For example here: https://github.com/scs/substrate-api-client/actions/runs/10171581409
I suspect this has become a problem because we added compilation to WebAssembly to the build a while ago.

Solution:
Remove some pre-installed tools from the runner that we don't need