### PR TITLE
Update rust toolchain

### DIFF
--- a/compose-macros/src/lib.rs
+++ b/compose-macros/src/lib.rs
@@ -56,7 +56,7 @@ macro_rules! compose_call {
 /// * 'pallet_metadata' - This crate's parsed pallet metadata as field of the API.
 /// * 'call_name' - Call name as &str
 /// * 'args' - Optional sequence of arguments of the call. They are not checked against the metadata.
-/// As of now the user needs to check himself that the correct arguments are supplied.
+///    As of now the user needs to check himself that the correct arguments are supplied.
 #[macro_export]
 macro_rules! compose_call_for_pallet_metadata {
 ($pallet_metadata: expr, $call_name: expr $(, $args: expr) *) => {
@@ -145,8 +145,9 @@ macro_rules! compose_extrinsic_with_nonce {
 	};
 }
 
-/// Generates an UncheckedExtrinsic for the given pallet and call, if they are found within the metadata.
-/// Otherwise None is returned.
+/// Generates an UncheckedExtrinsic for the given pallet and call from the metadata.
+///
+/// Returns None if call is not found within metadata.
 /// Fetches the nonce from the given `api` instance. If this fails, zero is taken as default nonce.
 /// See also compose_extrinsic_with_nonce
 #[macro_export]
@@ -164,8 +165,9 @@ macro_rules! compose_extrinsic {
     };
 }
 
-/// Generates an UncheckedExtrinsic for the given pallet and call, if they are found within the metadata.
-/// Otherwise None is returned.
+/// Generates an UncheckedExtrinsic for the given pallet and call from the metadata.
+///
+/// Returns None if call is not found within metadata.
 /// Fetches the nonce from the given `api` instance. If this fails, zero is taken as default nonce.
 /// See also compose_extrinsic_with_nonce
 #[macro_export]

--- a/node-api/src/lib.rs
+++ b/node-api/src/lib.rs
@@ -14,7 +14,6 @@
 //! Contains stuff to instantiate communication with a substrate node.
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(not(feature = "std"), feature(error_in_core))]
 
 extern crate alloc;
 

--- a/primitives/src/config/mod.rs
+++ b/primitives/src/config/mod.rs
@@ -129,6 +129,8 @@ pub trait Config {
 		+ DeserializeOwned;
 }
 
+/// Helper struct for fast Config creation with different Extrinsic Params than the original Config.
+///
 /// Take a type implementing [`Config`] (eg [`AssetRuntimeConfig`]), and some type which describes the
 /// additional and extra parameters to pass to an extrinsic (see [`ExtrinsicParams`]),
 /// and returns a type implementing [`Config`] with those new [`ExtrinsicParams`].

--- a/primitives/src/types.rs
+++ b/primitives/src/types.rs
@@ -105,9 +105,8 @@ pub struct InclusionFee<Balance> {
 	/// - `targeted_fee_adjustment`: This is a multiplier that can tune the final fee based on the
 	///   congestion of the network.
 	/// - `weight_fee`: This amount is computed based on the weight of the transaction. Weight
-	/// accounts for the execution time of a transaction.
-	///
-	/// adjusted_weight_fee = targeted_fee_adjustment * weight_fee
+	///    accounts for the execution time of a transaction.
+	/// - `adjusted_weight_fee`` = targeted_fee_adjustment * weight_fee
 	pub adjusted_weight_fee: Balance,
 }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.80"
+channel = "1.81"
 targets = ["wasm32-unknown-unknown", "wasm32-wasip1"]
 profile = "default" # include rustfmt, clippy

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2024-04-25"
+channel = "1.80"
 targets = ["wasm32-unknown-unknown", "wasm32-wasip1"]
 profile = "default" # include rustfmt, clippy

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.81"
+channel = "nightly-2024-09-01"
 targets = ["wasm32-unknown-unknown", "wasm32-wasip1"]
 profile = "default" # include rustfmt, clippy

--- a/src/api/error.rs
+++ b/src/api/error.rs
@@ -22,11 +22,7 @@ use ac_node_api::{
 };
 use alloc::{boxed::Box, vec::Vec};
 use codec::{Decode, Encode};
-
-#[cfg(not(feature = "std"))]
 use core::error::Error as ErrorT;
-#[cfg(feature = "std")]
-use std::error::Error as ErrorT;
 
 pub type Result<T> = core::result::Result<T, Error>;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,6 @@
 
 */
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(not(feature = "std"), feature(error_in_core))]
 
 extern crate alloc;
 

--- a/src/rpc/error.rs
+++ b/src/rpc/error.rs
@@ -16,10 +16,7 @@
 */
 
 use alloc::{boxed::Box, string::String};
-#[cfg(not(feature = "std"))]
 use core::error::Error as ErrorT;
-#[cfg(feature = "std")]
-use std::error::Error as ErrorT;
 
 pub type Result<T> = core::result::Result<T, Error>;
 

--- a/test-no-std/src/main.rs
+++ b/test-no-std/src/main.rs
@@ -95,7 +95,7 @@ unsafe impl GlobalAlloc for SimpleAllocator {
 		let align_mask_to_round_down = !(align - 1);
 
 		if align > MAX_SUPPORTED_ALIGN {
-			return null_mut()
+			return null_mut();
 		}
 
 		let mut allocated = 0;
@@ -103,7 +103,7 @@ unsafe impl GlobalAlloc for SimpleAllocator {
 			.remaining
 			.fetch_update(SeqCst, SeqCst, |mut remaining| {
 				if size > remaining {
-					return None
+					return None;
 				}
 				remaining -= size;
 				remaining &= align_mask_to_round_down;
@@ -112,7 +112,7 @@ unsafe impl GlobalAlloc for SimpleAllocator {
 			})
 			.is_err()
 		{
-			return null_mut()
+			return null_mut();
 		};
 		(self.arena.get() as *mut u8).add(allocated)
 	}


### PR DESCRIPTION
This PR updates the following:
- Removes `error_in_core` feature, as this has been integrated in the toolchain.
- updates rust toolchain
- fixes clippy lints, such as https://rust-lang.github.io/rust-clippy/master/index.html#/too_long_first_doc_paragraph  and https://rust-lang.github.io/rust-clippy/master/index.html#/doc_lazy_continuation


closes #799 