### PR TITLE
Cargo update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,14 +15,14 @@ env:
 jobs:
   cancel_previous_runs:
     name: Cancel Previous Runs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: styfle/cancel-workflow-action@0.12.1
         with:
           access_token: ${{ secrets.GITHUB_TOKEN }}
 
   free-disk-space:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Free Disk Space (Ubuntu)
       uses: jlumbroso/free-disk-space@main
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-22.04 ]
         check: [
                 # Test for no-std compatibility.
                 # `--locked` to enforce an up-to-date Cargo.lock
@@ -166,7 +166,7 @@ jobs:
 
   taplo-fmt:
     name: "Taplo fmt"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: "tamasfe/taplo:latest"
     steps:
       - uses: actions/checkout@v4
@@ -176,7 +176,7 @@ jobs:
 
   license-check:
     name: "License check"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -202,7 +202,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-22.04 ]
         example: [
           benchmark_bulk_xt,
           compose_extrinsic,
@@ -263,7 +263,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-22.04 ]
         example: [
           wasm_example,
         ]
@@ -283,7 +283,7 @@ jobs:
         run: wasmtime --invoke main ${{ matrix.example }}.wasm 0 0
 
   merge:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [examples, wasm_examples]
     steps:
       - name: Merge Artifacts

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1802,7 +1802,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4583,8 +4583,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e69bf016dc406eff7d53a7d3f7cf1c2e72c82b9088aac1118591e36dd2cd3e9"
 dependencies = [
  "bitcoin_hashes",
- "rand 0.7.3",
- "rand_core 0.5.1",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "serde",
  "unicode-normalization",
 ]
@@ -5506,7 +5506,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6378,7 +6378,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-ec-utils"
 version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#89b022842c7ab922de5bf026cd45e43b9cd8c654"
+source = "git+https://github.com/paritytech/polkadot-sdk#fb2e414f44d4bfa2d47aba4a868fb3f8932f7930"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-377-ext",
@@ -6431,7 +6431,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#89b022842c7ab922de5bf026cd45e43b9cd8c654"
+source = "git+https://github.com/paritytech/polkadot-sdk#fb2e414f44d4bfa2d47aba4a868fb3f8932f7930"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6451,7 +6451,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.25.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#89b022842c7ab922de5bf026cd45e43b9cd8c654"
+source = "git+https://github.com/paritytech/polkadot-sdk#fb2e414f44d4bfa2d47aba4a868fb3f8932f7930"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -6648,7 +6648,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#89b022842c7ab922de5bf026cd45e43b9cd8c654"
+source = "git+https://github.com/paritytech/polkadot-sdk#fb2e414f44d4bfa2d47aba4a868fb3f8932f7930"
 dependencies = [
  "bytes 1.9.0",
  "impl-trait-for-tuples",
@@ -6680,7 +6680,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#89b022842c7ab922de5bf026cd45e43b9cd8c654"
+source = "git+https://github.com/paritytech/polkadot-sdk#fb2e414f44d4bfa2d47aba4a868fb3f8932f7930"
 dependencies = [
  "Inflector",
  "expander",
@@ -6745,7 +6745,7 @@ source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#89b022842c7ab922de5bf026cd45e43b9cd8c654"
+source = "git+https://github.com/paritytech/polkadot-sdk#fb2e414f44d4bfa2d47aba4a868fb3f8932f7930"
 
 [[package]]
 name = "sp-storage"
@@ -6762,7 +6762,7 @@ dependencies = [
 [[package]]
 name = "sp-storage"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#89b022842c7ab922de5bf026cd45e43b9cd8c654"
+source = "git+https://github.com/paritytech/polkadot-sdk#fb2e414f44d4bfa2d47aba4a868fb3f8932f7930"
 dependencies = [
  "impl-serde 0.5.0",
  "parity-scale-codec",
@@ -6797,7 +6797,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#89b022842c7ab922de5bf026cd45e43b9cd8c654"
+source = "git+https://github.com/paritytech/polkadot-sdk#fb2e414f44d4bfa2d47aba4a868fb3f8932f7930"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -6879,7 +6879,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#89b022842c7ab922de5bf026cd45e43b9cd8c654"
+source = "git+https://github.com/paritytech/polkadot-sdk#fb2e414f44d4bfa2d47aba4a868fb3f8932f7930"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -7192,7 +7192,7 @@ dependencies = [
  "getrandom 0.2.15",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7595,9 +7595,9 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "digest 0.10.7",
- "rand 0.7.3",
+ "rand 0.8.5",
  "static_assertions",
 ]
 
@@ -7943,7 +7943,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,7 +181,7 @@ version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
- "gimli",
+ "gimli 0.31.1",
 ]
 
 [[package]]
@@ -764,9 +764,9 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "miniz_oxide",
- "object",
+ "object 0.36.7",
  "rustc-demangle",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -817,7 +817,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 [[package]]
 name = "binary-merkle-tree"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "hash-db",
  "log",
@@ -1158,19 +1158,6 @@ dependencies = [
  "once_cell",
  "unicode-width 0.2.0",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "const-hex"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b0485bab839b018a8f1723fc5391819fea5f8f0f32288ef8a735fd096b6160c"
-dependencies = [
- "cfg-if 1.0.0",
- "cpufeatures",
- "hex",
- "proptest",
- "serde",
 ]
 
 [[package]]
@@ -1538,27 +1525,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs"
-version = "5.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1836,7 +1802,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1990,7 +1956,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -2014,7 +1980,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
@@ -2025,7 +1991,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -2041,7 +2007,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "aquamarine",
  "frame-support",
@@ -2080,24 +2046,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "frame-metadata"
-version = "18.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daaf440c68eb2c3d88e5760fe8c7af3f9fee9181fab6c2f2c4e7cc48dcc40bb8"
-dependencies = [
- "cfg-if 1.0.0",
- "parity-scale-codec",
- "scale-info",
- "serde",
-]
-
-[[package]]
 name = "frame-metadata-hash-extension"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "array-bytes",
- "const-hex",
  "docify",
  "frame-support",
  "frame-system",
@@ -2110,7 +2063,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "aquamarine",
  "array-bytes",
@@ -2118,7 +2071,7 @@ dependencies = [
  "bitflags 1.3.2",
  "docify",
  "environmental",
- "frame-metadata 18.0.0",
+ "frame-metadata 16.0.0",
  "frame-support-procedural",
  "impl-trait-for-tuples",
  "k256",
@@ -2153,7 +2106,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -2173,7 +2126,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 3.2.0",
@@ -2185,7 +2138,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2195,7 +2148,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "cfg-if 1.0.0",
  "docify",
@@ -2207,6 +2160,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
  "sp-version",
  "sp-weights",
 ]
@@ -2214,7 +2168,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2228,7 +2182,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -2238,7 +2192,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -2427,13 +2381,19 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.31.1"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 dependencies = [
  "fallible-iterator",
  "stable_deref_trait",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "glob"
@@ -3575,6 +3535,15 @@ dependencies = [
 
 [[package]]
 name = "object"
+version = "0.32.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
@@ -3645,12 +3614,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3659,7 +3622,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "pallet-asset-conversion"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3677,7 +3640,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-rate"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3691,7 +3654,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets"
 version = "29.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3707,7 +3670,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3723,7 +3686,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3738,7 +3701,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3751,7 +3714,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3774,7 +3737,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -3789,7 +3752,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3808,7 +3771,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "array-bytes",
  "binary-merkle-tree",
@@ -3833,7 +3796,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3850,7 +3813,7 @@ dependencies = [
 [[package]]
 name = "pallet-broker"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -3868,7 +3831,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3886,7 +3849,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -3903,7 +3866,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "bitflags 1.3.2",
  "environmental",
@@ -3925,6 +3888,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
  "staging-xcm",
  "staging-xcm-builder",
  "wasm-instrument",
@@ -3934,7 +3898,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-proc-macro"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3944,7 +3908,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-uapi"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -3955,7 +3919,7 @@ dependencies = [
 [[package]]
 name = "pallet-conviction-voting"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -3971,7 +3935,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3988,7 +3952,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -4010,7 +3974,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -4023,7 +3987,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4041,7 +4005,7 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -4059,7 +4023,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4081,7 +4045,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -4097,7 +4061,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4113,7 +4077,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4129,7 +4093,7 @@ dependencies = [
 [[package]]
 name = "pallet-message-queue"
 version = "31.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -4146,50 +4110,41 @@ dependencies = [
 ]
 
 [[package]]
-name = "pallet-migrations"
-version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+name = "pallet-mmr"
+version = "27.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
- "cfg-if 1.0.0",
- "docify",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-runtime",
-]
-
-[[package]]
-name = "pallet-mmr"
-version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
-dependencies = [
- "log",
- "parity-scale-codec",
- "polkadot-sdk-frame",
- "scale-info",
+ "sp-io",
  "sp-mmr-primitives",
+ "sp-runtime",
 ]
 
 [[package]]
 name = "pallet-multisig"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
- "polkadot-sdk-frame",
  "scale-info",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
 name = "pallet-nis"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4204,7 +4159,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4220,7 +4175,7 @@ dependencies = [
 [[package]]
 name = "pallet-parameters"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -4237,7 +4192,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4253,17 +4208,21 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
- "polkadot-sdk-frame",
  "scale-info",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
 name = "pallet-ranked-collective"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4281,7 +4240,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4295,7 +4254,7 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4312,7 +4271,7 @@ dependencies = [
 [[package]]
 name = "pallet-root-testing"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4326,7 +4285,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -4343,7 +4302,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4364,7 +4323,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4381,7 +4340,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -4402,7 +4361,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -4411,7 +4370,7 @@ dependencies = [
 [[package]]
 name = "pallet-state-trie-migration"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4427,7 +4386,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -4442,7 +4401,7 @@ dependencies = [
 [[package]]
 name = "pallet-template"
 version = "0.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4454,7 +4413,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -4473,7 +4432,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4491,9 +4450,8 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
- "frame-benchmarking",
  "frame-support",
  "frame-system",
  "parity-scale-codec",
@@ -4507,7 +4465,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -4519,14 +4477,13 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "docify",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
  "impl-trait-for-tuples",
- "log",
  "pallet-balances",
  "parity-scale-codec",
  "scale-info",
@@ -4538,7 +4495,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4553,7 +4510,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4567,7 +4524,7 @@ dependencies = [
 [[package]]
 name = "pallet-whitelist"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4581,12 +4538,13 @@ dependencies = [
 [[package]]
 name = "pallet-xcm"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "bounded-collections",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
+ "log",
  "pallet-balances",
  "parity-scale-codec",
  "scale-info",
@@ -4597,14 +4555,13 @@ dependencies = [
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
- "tracing",
  "xcm-runtime-apis",
 ]
 
 [[package]]
 name = "pallet-xcm-benchmarks"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4626,8 +4583,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e69bf016dc406eff7d53a7d3f7cf1c2e72c82b9088aac1118591e36dd2cd3e9"
 dependencies = [
  "bitcoin_hashes",
- "rand 0.8.5",
- "rand_core 0.6.4",
+ "rand 0.7.3",
+ "rand_core 0.5.1",
  "serde",
  "unicode-normalization",
 ]
@@ -4685,7 +4642,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -4782,7 +4739,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -4793,7 +4750,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain-primitives"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "bounded-collections",
  "derive_more 0.99.18",
@@ -4809,7 +4766,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "bitvec",
  "hex-literal",
@@ -4831,13 +4788,12 @@ dependencies = [
  "sp-runtime",
  "sp-staking",
  "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
- "thiserror",
 ]
 
 [[package]]
 name = "polkadot-runtime-common"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -4873,7 +4829,6 @@ dependencies = [
  "sp-core",
  "sp-inherents",
  "sp-io",
- "sp-keyring",
  "sp-npos-elections",
  "sp-runtime",
  "sp-session",
@@ -4887,7 +4842,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "bs58",
  "frame-benchmarking",
@@ -4899,7 +4854,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
@@ -4945,38 +4900,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "polkadot-sdk-frame"
-version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
-dependencies = [
- "docify",
- "frame-benchmarking",
- "frame-executive",
- "frame-support",
- "frame-system",
- "frame-system-benchmarking",
- "frame-system-rpc-runtime-api",
- "frame-try-runtime",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-api",
- "sp-arithmetic",
- "sp-block-builder",
- "sp-consensus-aura",
- "sp-consensus-grandpa",
- "sp-core",
- "sp-genesis-builder",
- "sp-inherents",
- "sp-io",
- "sp-keyring",
- "sp-offchain",
- "sp-runtime",
- "sp-session",
- "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
- "sp-transaction-pool",
- "sp-version",
-]
+name = "polkavm-common"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9428a5cfcc85c5d7b9fc4b6a18c4b802d0173d768182a51cc7751640f08b92"
 
 [[package]]
 name = "polkavm-common"
@@ -4986,11 +4913,32 @@ checksum = "31ff33982a807d8567645d4784b9b5d7ab87bcb494f534a57cadd9012688e102"
 
 [[package]]
 name = "polkavm-derive"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae8c4bea6f3e11cd89bb18bcdddac10bd9a24015399bd1c485ad68a985a19606"
+dependencies = [
+ "polkavm-derive-impl-macro 0.9.0",
+]
+
+[[package]]
+name = "polkavm-derive"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2eb703f3b6404c13228402e98a5eae063fd16b8f58afe334073ec105ee4117e"
 dependencies = [
- "polkavm-derive-impl-macro",
+ "polkavm-derive-impl-macro 0.18.0",
+]
+
+[[package]]
+name = "polkavm-derive-impl"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c4fdfc49717fb9a196e74a5d28e0bc764eb394a2c803eb11133a31ac996c60c"
+dependencies = [
+ "polkavm-common 0.9.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -4999,9 +4947,19 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f2116a92e6e96220a398930f4c8a6cda1264206f3e2034fc9982bfd93f261f7"
 dependencies = [
- "polkavm-common",
+ "polkavm-common 0.18.0",
  "proc-macro2",
  "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "polkavm-derive-impl-macro"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ba81f7b5faac81e528eb6158a6f3c9e0bb1008e0ffa19653bc8dea925ecb429"
+dependencies = [
+ "polkavm-derive-impl 0.9.0",
  "syn 2.0.96",
 ]
 
@@ -5011,22 +4969,21 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c16669ddc7433e34c1007d31080b80901e3e8e523cb9d4b441c3910cf9294b"
 dependencies = [
- "polkavm-derive-impl",
+ "polkavm-derive-impl 0.18.1",
  "syn 2.0.96",
 ]
 
 [[package]]
 name = "polkavm-linker"
-version = "0.18.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9bfe793b094d9ea5c99b7c43ba46e277b0f8f48f4bbfdbabf8d3ebf701a4bd3"
+checksum = "9c7be503e60cf56c0eb785f90aaba4b583b36bff00e93997d93fef97f9553c39"
 dependencies = [
- "dirs",
- "gimli",
+ "gimli 0.28.1",
  "hashbrown 0.14.5",
  "log",
- "object",
- "polkavm-common",
+ "object 0.32.2",
+ "polkavm-common 0.9.0",
  "regalloc2",
  "rustc-demangle",
 ]
@@ -5078,8 +5035,6 @@ dependencies = [
  "fixed-hash",
  "impl-codec 0.7.0",
  "impl-num-traits",
- "impl-serde 0.5.0",
- "scale-info",
  "uint 0.10.0",
 ]
 
@@ -5144,22 +5099,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "proptest"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
-dependencies = [
- "bitflags 2.8.0",
- "lazy_static",
- "num-traits",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
- "rand_xorshift",
- "regex-syntax 0.8.5",
- "unarray",
 ]
 
 [[package]]
@@ -5249,15 +5188,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_xorshift"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
-dependencies = [
- "rand_core 0.6.4",
-]
-
-[[package]]
 name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5290,17 +5220,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
  "bitflags 2.8.0",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
-dependencies = [
- "getrandom 0.2.15",
- "libredox",
- "thiserror",
 ]
 
 [[package]]
@@ -5425,7 +5344,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -5457,7 +5376,6 @@ dependencies = [
  "pallet-indices",
  "pallet-membership",
  "pallet-message-queue",
- "pallet-migrations",
  "pallet-mmr",
  "pallet-multisig",
  "pallet-nis",
@@ -5507,7 +5425,6 @@ dependencies = [
  "sp-genesis-builder",
  "sp-inherents",
  "sp-io",
- "sp-keyring",
  "sp-mmr-primitives",
  "sp-offchain",
  "sp-runtime",
@@ -5527,7 +5444,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime-constants"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -5589,7 +5506,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5706,7 +5623,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "25.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "array-bytes",
  "parking_lot",
@@ -6146,7 +6063,7 @@ checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
 [[package]]
 name = "slot-range-helper"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -6189,7 +6106,7 @@ dependencies = [
 [[package]]
 name = "solochain-template-runtime"
 version = "0.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",
@@ -6230,7 +6147,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "docify",
  "hash-db",
@@ -6252,7 +6169,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "Inflector",
  "blake2",
@@ -6266,7 +6183,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "30.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -6278,7 +6195,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -6310,7 +6227,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -6322,7 +6239,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -6332,7 +6249,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -6348,7 +6265,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -6366,7 +6283,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-beefy"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -6386,7 +6303,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -6403,7 +6320,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -6414,7 +6331,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "array-bytes",
  "bandersnatch_vrfs",
@@ -6427,7 +6344,7 @@ dependencies = [
  "futures",
  "hash-db",
  "hash256-std-hasher",
- "impl-serde 0.5.0",
+ "impl-serde 0.4.0",
  "itertools 0.11.0",
  "k256",
  "libsecp256k1",
@@ -6437,7 +6354,7 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot",
  "paste",
- "primitive-types 0.13.1",
+ "primitive-types 0.12.2",
  "rand 0.8.5",
  "scale-info",
  "schnorrkel",
@@ -6461,7 +6378,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-ec-utils"
 version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk#89b022842c7ab922de5bf026cd45e43b9cd8c654"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-377-ext",
@@ -6481,7 +6398,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -6494,7 +6411,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "quote",
  "sp-crypto-hashing",
@@ -6504,7 +6421,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6514,7 +6431,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk#89b022842c7ab922de5bf026cd45e43b9cd8c654"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6524,7 +6441,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.25.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -6534,7 +6451,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.25.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk#89b022842c7ab922de5bf026cd45e43b9cd8c654"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -6544,7 +6461,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -6556,7 +6473,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -6569,7 +6486,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "30.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "bytes 1.9.0",
  "docify",
@@ -6577,7 +6494,7 @@ dependencies = [
  "libsecp256k1",
  "log",
  "parity-scale-codec",
- "polkavm-derive",
+ "polkavm-derive 0.9.1",
  "rustversion",
  "secp256k1",
  "sp-core",
@@ -6595,7 +6512,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "31.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -6605,7 +6522,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "parity-scale-codec",
  "parking_lot",
@@ -6616,7 +6533,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "thiserror",
  "zstd",
@@ -6625,9 +6542,9 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
- "frame-metadata 18.0.0",
+ "frame-metadata 16.0.0",
  "parity-scale-codec",
  "scale-info",
 ]
@@ -6635,7 +6552,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -6652,7 +6569,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -6665,7 +6582,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -6675,7 +6592,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "backtrace",
  "regex",
@@ -6684,7 +6601,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "31.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "binary-merkle-tree",
  "docify",
@@ -6707,19 +6624,18 @@ dependencies = [
  "sp-trie",
  "sp-weights",
  "tracing",
- "tuplex",
 ]
 
 [[package]]
 name = "sp-runtime-interface"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "bytes 1.9.0",
  "impl-trait-for-tuples",
  "parity-scale-codec",
- "polkavm-derive",
- "primitive-types 0.13.1",
+ "polkavm-derive 0.9.1",
+ "primitive-types 0.12.2",
  "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
  "sp-runtime-interface-proc-macro 17.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
  "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
@@ -6732,12 +6648,12 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk#89b022842c7ab922de5bf026cd45e43b9cd8c654"
 dependencies = [
  "bytes 1.9.0",
  "impl-trait-for-tuples",
  "parity-scale-codec",
- "polkavm-derive",
+ "polkavm-derive 0.18.0",
  "primitive-types 0.13.1",
  "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk)",
  "sp-runtime-interface-proc-macro 17.0.0 (git+https://github.com/paritytech/polkadot-sdk)",
@@ -6751,7 +6667,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "Inflector",
  "expander",
@@ -6764,7 +6680,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk#89b022842c7ab922de5bf026cd45e43b9cd8c654"
 dependencies = [
  "Inflector",
  "expander",
@@ -6777,7 +6693,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -6791,7 +6707,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -6804,7 +6720,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.35.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "hash-db",
  "log",
@@ -6824,19 +6740,19 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk#89b022842c7ab922de5bf026cd45e43b9cd8c654"
 
 [[package]]
 name = "sp-storage"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
- "impl-serde 0.5.0",
+ "impl-serde 0.4.0",
  "parity-scale-codec",
  "ref-cast",
  "serde",
@@ -6846,7 +6762,7 @@ dependencies = [
 [[package]]
 name = "sp-storage"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk#89b022842c7ab922de5bf026cd45e43b9cd8c654"
 dependencies = [
  "impl-serde 0.5.0",
  "parity-scale-codec",
@@ -6858,7 +6774,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -6870,7 +6786,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -6881,7 +6797,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk#89b022842c7ab922de5bf026cd45e43b9cd8c654"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -6892,7 +6808,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -6901,7 +6817,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "ahash",
  "hash-db",
@@ -6923,9 +6839,9 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
- "impl-serde 0.5.0",
+ "impl-serde 0.4.0",
  "parity-scale-codec",
  "parity-wasm",
  "scale-info",
@@ -6940,7 +6856,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-warning",
@@ -6952,7 +6868,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -6963,7 +6879,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk#89b022842c7ab922de5bf026cd45e43b9cd8c654"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -6974,7 +6890,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
@@ -7025,14 +6941,12 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "staging-xcm"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "array-bytes",
  "bounded-collections",
  "derivative",
  "environmental",
- "frame-support",
- "hex-literal",
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
@@ -7046,7 +6960,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-builder"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7068,7 +6982,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-executor"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -7192,7 +7106,7 @@ dependencies = [
 [[package]]
 name = "substrate-bip39"
 version = "0.4.7"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
@@ -7204,7 +7118,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "build-helper",
  "cargo_metadata",
@@ -7278,7 +7192,7 @@ dependencies = [
  "getrandom 0.2.15",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7676,20 +7590,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "tuplex"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "676ac81d5454c4dcf37955d34fa8626ede3490f744b86ca14a7b90168d2a08aa"
-
-[[package]]
 name = "twox-hash"
 version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "digest 0.10.7",
- "rand 0.8.5",
+ "rand 0.7.3",
  "static_assertions",
 ]
 
@@ -7722,12 +7630,6 @@ dependencies = [
  "hex",
  "static_assertions",
 ]
-
-[[package]]
-name = "unarray"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
@@ -8041,7 +7943,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8052,20 +7954,11 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -8074,22 +7967,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -8098,21 +7976,15 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -8122,21 +7994,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -8152,21 +8012,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -8176,21 +8024,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -8269,7 +8105,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -8280,7 +8116,7 @@ dependencies = [
 [[package]]
 name = "xcm-runtime-apis"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#f8807d1e185ccd281052106599a2c55694d02fc1"
 dependencies = [
  "frame-support",
  "parity-scale-codec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,7 +94,7 @@ version = "0.18.0"
 dependencies = [
  "ac-primitives",
  "bitvec",
- "derive_more",
+ "derive_more 0.99.18",
  "either",
  "frame-metadata 16.0.0",
  "hex",
@@ -122,14 +122,14 @@ version = "0.18.0"
 dependencies = [
  "frame-metadata-hash-extension",
  "frame-system",
- "impl-serde",
+ "impl-serde 0.4.0",
  "pallet-assets",
  "pallet-balances",
  "pallet-contracts",
  "pallet-staking",
  "pallet-transaction-payment",
  "parity-scale-codec",
- "primitive-types",
+ "primitive-types 0.12.2",
  "scale-info",
  "serde",
  "serde_json",
@@ -177,18 +177,18 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.22.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
- "gimli 0.29.0",
+ "gimli",
 ]
 
 [[package]]
-name = "adler"
-version = "1.0.2"
+name = "adler2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "aead"
@@ -224,15 +224,15 @@ dependencies = [
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.18"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "anstream"
-version = "0.6.15"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -245,43 +245,44 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.8"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.4"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
 dependencies = [
  "anstyle",
- "windows-sys 0.52.0",
+ "once_cell",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.86"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
+checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
 name = "approx"
@@ -303,7 +304,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -312,9 +313,9 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb00293ba84f51ce3bd026bd0de55899c4e68f0a39a5728cebae3a73ffdc0a4f"
 dependencies = [
- "ark-ec",
- "ark-ff",
- "ark-std",
+ "ark-ec 0.4.2",
+ "ark-ff 0.4.2",
+ "ark-std 0.4.0",
 ]
 
 [[package]]
@@ -324,9 +325,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20c7021f180a0cbea0380eba97c2af3c57074cdaffe0eef7e840e1c9f2841e55"
 dependencies = [
  "ark-bls12-377",
- "ark-ec",
+ "ark-ec 0.4.2",
  "ark-models-ext",
- "ark-std",
+ "ark-std 0.4.0",
 ]
 
 [[package]]
@@ -335,10 +336,10 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c775f0d12169cba7aae4caeb547bb6a50781c7449a8aa53793827c9ec4abf488"
 dependencies = [
- "ark-ec",
- "ark-ff",
- "ark-serialize",
- "ark-std",
+ "ark-ec 0.4.2",
+ "ark-ff 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
 ]
 
 [[package]]
@@ -348,11 +349,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1dc4b3d08f19e8ec06e949712f95b8361e43f1391d94f65e4234df03480631c"
 dependencies = [
  "ark-bls12-381",
- "ark-ec",
- "ark-ff",
+ "ark-ec 0.4.2",
+ "ark-ff 0.4.2",
  "ark-models-ext",
- "ark-serialize",
- "ark-std",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
 ]
 
 [[package]]
@@ -362,9 +363,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e0605daf0cc5aa2034b78d008aaf159f56901d92a52ee4f6ecdfdac4f426700"
 dependencies = [
  "ark-bls12-377",
- "ark-ec",
- "ark-ff",
- "ark-std",
+ "ark-ec 0.4.2",
+ "ark-ff 0.4.2",
+ "ark-std 0.4.0",
 ]
 
 [[package]]
@@ -374,10 +375,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccee5fba47266f460067588ee1bf070a9c760bf2050c1c509982c5719aadb4f2"
 dependencies = [
  "ark-bw6-761",
- "ark-ec",
- "ark-ff",
+ "ark-ec 0.4.2",
+ "ark-ff 0.4.2",
  "ark-models-ext",
- "ark-std",
+ "ark-std 0.4.0",
 ]
 
 [[package]]
@@ -386,15 +387,36 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defd9a439d56ac24968cca0571f598a61bc8c55f71d50a89cda591cb750670ba"
 dependencies = [
- "ark-ff",
- "ark-poly",
- "ark-serialize",
- "ark-std",
+ "ark-ff 0.4.2",
+ "ark-poly 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
  "derivative",
  "hashbrown 0.13.2",
  "itertools 0.10.5",
  "num-traits",
  "rayon",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ec"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d68f2d516162846c1238e755a7c4d131b892b70cc70c471a8e3ca3ed818fce"
+dependencies = [
+ "ahash",
+ "ark-ff 0.5.0",
+ "ark-poly 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "educe",
+ "fnv",
+ "hashbrown 0.15.2",
+ "itertools 0.13.0",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
  "zeroize",
 ]
 
@@ -405,9 +427,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b10d901b9ac4b38f9c32beacedfadcdd64e46f8d7f8e88c1ae1060022cf6f6c6"
 dependencies = [
  "ark-bls12-377",
- "ark-ec",
- "ark-ff",
- "ark-std",
+ "ark-ec 0.4.2",
+ "ark-ff 0.4.2",
+ "ark-std 0.4.0",
 ]
 
 [[package]]
@@ -416,11 +438,11 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524a4fb7540df2e1a8c2e67a83ba1d1e6c3947f4f9342cc2359fc2e789ad731d"
 dependencies = [
- "ark-ec",
+ "ark-ec 0.4.2",
  "ark-ed-on-bls12-377",
- "ark-ff",
+ "ark-ff 0.4.2",
  "ark-models-ext",
- "ark-std",
+ "ark-std 0.4.0",
 ]
 
 [[package]]
@@ -430,9 +452,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9cde0f2aa063a2a5c28d39b47761aa102bda7c13c84fc118a61b87c7b2f785c"
 dependencies = [
  "ark-bls12-381",
- "ark-ec",
- "ark-ff",
- "ark-std",
+ "ark-ec 0.4.2",
+ "ark-ff 0.4.2",
+ "ark-std 0.4.0",
 ]
 
 [[package]]
@@ -441,11 +463,11 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d15185f1acb49a07ff8cbe5f11a1adc5a93b19e211e325d826ae98e98e124346"
 dependencies = [
- "ark-ec",
+ "ark-ec 0.4.2",
  "ark-ed-on-bls12-381-bandersnatch",
- "ark-ff",
+ "ark-ff 0.4.2",
  "ark-models-ext",
- "ark-std",
+ "ark-std 0.4.0",
 ]
 
 [[package]]
@@ -454,10 +476,10 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
 dependencies = [
- "ark-ff-asm",
- "ark-ff-macros",
- "ark-serialize",
- "ark-std",
+ "ark-ff-asm 0.4.2",
+ "ark-ff-macros 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
  "derivative",
  "digest 0.10.7",
  "itertools 0.10.5",
@@ -469,6 +491,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-ff"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a177aba0ed1e0fbb62aa9f6d0502e9b46dad8c2eab04c14258a1212d2557ea70"
+dependencies = [
+ "ark-ff-asm 0.5.0",
+ "ark-ff-macros 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "arrayvec",
+ "digest 0.10.7",
+ "educe",
+ "itertools 0.13.0",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "zeroize",
+]
+
+[[package]]
 name = "ark-ff-asm"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -476,6 +518,16 @@ checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
 dependencies = [
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
+dependencies = [
+ "quote",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -492,15 +544,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-ff-macros"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
 name = "ark-models-ext"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e9eab5d4b5ff2f228b763d38442adc9b084b0a465409b059fac5c2308835ec2"
 dependencies = [
- "ark-ec",
- "ark-ff",
- "ark-serialize",
- "ark-std",
+ "ark-ec 0.4.2",
+ "ark-ff 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
  "derivative",
 ]
 
@@ -510,11 +575,26 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d320bfc44ee185d899ccbadfa8bc31aab923ce1558716e1997a1e74057fe86bf"
 dependencies = [
- "ark-ff",
- "ark-serialize",
- "ark-std",
+ "ark-ff 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
  "derivative",
  "hashbrown 0.13.2",
+]
+
+[[package]]
+name = "ark-poly"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "579305839da207f02b89cd1679e50e67b4331e2f9294a57693e5051b7703fe27"
+dependencies = [
+ "ahash",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "educe",
+ "fnv",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -523,10 +603,10 @@ version = "0.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f69c00b3b529be29528a6f2fd5fa7b1790f8bed81b9cdca17e326538545a179"
 dependencies = [
- "ark-ec",
- "ark-ff",
- "ark-serialize",
- "ark-std",
+ "ark-ec 0.4.2",
+ "ark-ff 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
  "parity-scale-codec",
  "scale-info",
 ]
@@ -536,10 +616,10 @@ name = "ark-secret-scalar"
 version = "0.0.2"
 source = "git+https://github.com/w3f/ring-vrf?rev=0fef826#0fef8266d851932ad25d6b41bc4b34d834d1e11d"
 dependencies = [
- "ark-ec",
- "ark-ff",
- "ark-serialize",
- "ark-std",
+ "ark-ec 0.4.2",
+ "ark-ff 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
  "ark-transcript",
  "digest 0.10.7",
  "getrandom_or_panic",
@@ -552,8 +632,21 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
 dependencies = [
- "ark-serialize-derive",
- "ark-std",
+ "ark-serialize-derive 0.4.2",
+ "ark-std 0.4.0",
+ "digest 0.10.7",
+ "num-bigint",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
+dependencies = [
+ "ark-serialize-derive 0.5.0",
+ "ark-std 0.5.0",
+ "arrayvec",
  "digest 0.10.7",
  "num-bigint",
 ]
@@ -570,6 +663,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-serialize-derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
 name = "ark-std"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -581,13 +685,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-std"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "ark-transcript"
 version = "0.0.2"
 source = "git+https://github.com/w3f/ring-vrf?rev=0fef826#0fef8266d851932ad25d6b41bc4b34d834d1e11d"
 dependencies = [
- "ark-ff",
- "ark-serialize",
- "ark-std",
+ "ark-ff 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
  "digest 0.10.7",
  "rand_core 0.6.4",
  "sha3",
@@ -601,9 +715,9 @@ checksum = "5d5dde061bd34119e902bbb2d9b90c5692635cf59fb91d582c2b68043f1b8293"
 
 [[package]]
 name = "arrayref"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d151e35f61089500b617991b791fc8bfd237ae50cd5950803758a179b41e67a"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
@@ -619,13 +733,13 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "async-trait"
-version = "0.1.81"
+version = "0.1.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
+checksum = "3f934833b4b7233644e5848f235df3f57ed8c80f1528a26c3dfa13d2147fa056"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -636,23 +750,23 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "backtrace"
-version = "0.3.73"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
 dependencies = [
  "addr2line",
- "cc",
  "cfg-if 1.0.0",
  "libc",
  "miniz_oxide",
- "object 0.36.3",
+ "object",
  "rustc-demangle",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -661,11 +775,11 @@ version = "0.0.4"
 source = "git+https://github.com/w3f/ring-vrf?rev=0fef826#0fef8266d851932ad25d6b41bc4b34d834d1e11d"
 dependencies = [
  "ark-bls12-381",
- "ark-ec",
+ "ark-ec 0.4.2",
  "ark-ed-on-bls12-381-bandersnatch",
- "ark-ff",
- "ark-serialize",
- "ark-std",
+ "ark-ff 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
  "dleq_vrf",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
@@ -703,10 +817,11 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 [[package]]
 name = "binary-merkle-tree"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "hash-db",
  "log",
+ "parity-scale-codec",
 ]
 
 [[package]]
@@ -733,9 +848,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
 name = "bitvec"
@@ -811,9 +926,9 @@ dependencies = [
 
 [[package]]
 name = "bounded-collections"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32385ecb91a31bddaf908e8dcf4a15aef1bcd3913cc03ebfad02ff6d568abc1"
+checksum = "3d077619e9c237a5d1875166f5e8033e8f6bff0c96f8caf81e1c2d7738c431bf"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -853,9 +968,9 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "bytemuck"
-version = "1.17.0"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fd4c6dcc3b0aea2f5c0b4b82c2b15fe39ddbc76041a310848f4706edf76bb31"
+checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
 
 [[package]]
 name = "byteorder"
@@ -875,9 +990,9 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "1.7.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
+checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "camino"
@@ -890,9 +1005,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24b1f0365a6c6bb4020cd05806fd0d33c44d38046b8bd7f0e40814b9763cabfc"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
 dependencies = [
  "serde",
 ]
@@ -905,7 +1020,7 @@ checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver 1.0.23",
+ "semver 1.0.25",
  "serde",
  "serde_json",
  "thiserror",
@@ -913,9 +1028,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.14"
+version = "1.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d2eb3cd3d1bf4529e31c215ee6f93ec5a3d536d9f578f93d9d33ee19562932"
+checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
 dependencies = [
  "jobserver",
  "libc",
@@ -950,10 +1065,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "cmake"
-version = "0.1.51"
+name = "clap"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb1e43aa7fd152b1f968787f7dbcdeb306d1867ff373c69955211876c053f91a"
+checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+ "strsim 0.11.1",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+
+[[package]]
+name = "cmake"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c682c223677e0e5b6b7f63a64b9351844c3f1b1678a68b7ee617e30fb082620e"
 dependencies = [
  "cc",
 ]
@@ -965,14 +1106,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
 dependencies = [
  "termcolor",
- "unicode-width",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
 name = "colorchoice"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "combine"
@@ -980,7 +1121,7 @@ version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
- "bytes 1.7.1",
+ "bytes 1.9.0",
  "memchr",
 ]
 
@@ -989,11 +1130,11 @@ name = "common"
 version = "0.1.0"
 source = "git+https://github.com/w3f/ring-proof?rev=665f5f5#665f5f51af5734c7b6d90b985dd6861d4c5b4752"
 dependencies = [
- "ark-ec",
- "ark-ff",
- "ark-poly",
- "ark-serialize",
- "ark-std",
+ "ark-ec 0.4.2",
+ "ark-ff 0.4.2",
+ "ark-poly 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
  "fflonk",
  "getrandom_or_panic",
  "merlin",
@@ -1008,15 +1149,28 @@ checksum = "2382f75942f4b3be3690fe4f86365e9c853c1587d6ee58212cebf6e2a9ccd101"
 
 [[package]]
 name = "console"
-version = "0.15.8"
+version = "0.15.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
+checksum = "ea3c6ecd8059b57859df5c69830340ed3c41d30e3da0c1cbed90a96ac853041b"
 dependencies = [
  "encode_unicode",
- "lazy_static",
  "libc",
- "unicode-width",
- "windows-sys 0.52.0",
+ "once_cell",
+ "unicode-width 0.2.0",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "const-hex"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b0485bab839b018a8f1723fc5391819fea5f8f0f32288ef8a735fd096b6160c"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "hex",
+ "proptest",
+ "serde",
 ]
 
 [[package]]
@@ -1047,9 +1201,9 @@ dependencies = [
 
 [[package]]
 name = "constant_time_eq"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "constcat"
@@ -1081,18 +1235,18 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.13"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51e852e6dc9a5bed1fae92dd2375037bf2b768725bf3be87811edee3249d09ad"
+checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -1109,9 +1263,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
@@ -1176,51 +1330,66 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "cxx"
-version = "1.0.126"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c4eae4b7fc8dcb0032eb3b1beee46b38d371cdeaf2d0c64b9944f6f69ad7755"
+checksum = "0fc894913dccfed0f84106062c284fa021c3ba70cb1d78797d6f5165d4492e45"
 dependencies = [
  "cc",
+ "cxxbridge-cmd",
  "cxxbridge-flags",
  "cxxbridge-macro",
+ "foldhash",
  "link-cplusplus",
 ]
 
 [[package]]
 name = "cxx-build"
-version = "1.0.126"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c822bf7fb755d97328d6c337120b6f843678178751cba33c9da25cf522272e0"
+checksum = "503b2bfb6b3e8ce7f95d865a67419451832083d3186958290cee6c53e39dfcfe"
 dependencies = [
  "cc",
  "codespan-reporting",
- "once_cell",
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.76",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "cxxbridge-cmd"
+version = "1.0.137"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0d2cb64a95b4b5a381971482235c4db2e0208302a962acdbe314db03cbbe2fb"
+dependencies = [
+ "clap",
+ "codespan-reporting",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.126"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719d6197dc016c88744aff3c0d0340a01ecce12e8939fc282e7c8f583ee64bc6"
+checksum = "5f797b0206463c9c2a68ed605ab28892cca784f1ef066050f4942e3de26ad885"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.126"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35de3b547387863c8f82013c4f79f1c2162edee956383e4089e1d04c18c4f16c"
+checksum = "e79010a2093848e65a3e0f7062d3f02fb2ef27f866416dfe436fccfa73d3bb59"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "rustversion",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1243,7 +1412,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.10.0",
  "syn 1.0.109",
 ]
 
@@ -1260,9 +1429,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
+checksum = "0e60eed09d8c01d3cee5b7d30acb059b76614c918fa0f992e0dd6eeb10daad6f"
 
 [[package]]
 name = "der"
@@ -1302,7 +1471,7 @@ checksum = "d65d7ce8132b7c0e54497a4d9a55a1c2a0912a0d786cf894472ba818fba45762"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1315,7 +1484,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.76",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "derive_more"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1349,16 +1538,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
 name = "dleq_vrf"
 version = "0.0.2"
 source = "git+https://github.com/w3f/ring-vrf?rev=0fef826#0fef8266d851932ad25d6b41bc4b34d834d1e11d"
 dependencies = [
- "ark-ec",
- "ark-ff",
+ "ark-ec 0.4.2",
+ "ark-ff 0.4.2",
  "ark-scale",
  "ark-secret-scalar",
- "ark-serialize",
- "ark-std",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
  "ark-transcript",
  "arrayvec",
  "zeroize",
@@ -1366,18 +1587,18 @@ dependencies = [
 
 [[package]]
 name = "docify"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a2f138ad521dc4a2ced1a4576148a6a610b4c5923933b062a263130a6802ce"
+checksum = "a772b62b1837c8f060432ddcc10b17aae1453ef17617a99bc07789252d2a5896"
 dependencies = [
  "docify_macros",
 ]
 
 [[package]]
 name = "docify_macros"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a081e51fb188742f5a7a1164ad752121abcb22874b21e2c3b0dd040c515fdad"
+checksum = "60e6be249b0a462a14784a99b19bf35a667bb5e09de611738bb7362fa4c95ff7"
 dependencies = [
  "common-path",
  "derive-syn-parse",
@@ -1385,7 +1606,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.76",
+ "syn 2.0.96",
  "termcolor",
  "toml",
  "walkdir",
@@ -1479,6 +1700,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "educe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1506,28 +1739,48 @@ dependencies = [
 
 [[package]]
 name = "encode_unicode"
-version = "0.3.6"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "enum-ordinalize"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea0dcfa4e54eeb516fe454635a95753ddd39acda650ce703031c6973e315dd5"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
 
 [[package]]
 name = "enumflags2"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d232db7f5956f3f14313dc2f87985c58bd2c695ce124c8cdd984e08e15ac133d"
+checksum = "ba2f4b465f5318854c6f8dd686ede6c0a9dc67d4b1ac241cf0eb51521a309147"
 dependencies = [
  "enumflags2_derive",
 ]
 
 [[package]]
 name = "enumflags2_derive"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0d48a183585823424a4ce1aa132d174a6a81bd540895822eb4c8373a8e49e8"
+checksum = "fc4caf64a58d7a6d65ab00639b046ff54399a39f5f2554728895ace4b297cd79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1538,14 +1791,14 @@ checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "env_filter"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2c92ceda6ceec50f43169f9ee8424fe2db276791afde7b2cd8bc084cb376ab"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
 dependencies = [
  "log",
  "regex",
@@ -1553,9 +1806,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13fa619b91fb2381732789fc5de83b45675e882f66623b7d8cb4f643017018d"
+checksum = "dcaee3d8e3cfc3fd92428d477bc97fc29ec8716d180c0d74c643bb26166660e0"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1578,12 +1831,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1598,7 +1851,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1615,9 +1868,9 @@ checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
 name = "fastrand"
-version = "2.1.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ff"
@@ -1631,14 +1884,14 @@ dependencies = [
 
 [[package]]
 name = "fflonk"
-version = "0.1.0"
-source = "git+https://github.com/w3f/fflonk#1e854f35e9a65d08b11a86291405cdc95baa0a35"
+version = "0.1.1"
+source = "git+https://github.com/w3f/fflonk#eda051ea3b80042e844a3ebd17c2f60536e6ee3f"
 dependencies = [
- "ark-ec",
- "ark-ff",
- "ark-poly",
- "ark-serialize",
- "ark-std",
+ "ark-ec 0.5.0",
+ "ark-ff 0.5.0",
+ "ark-poly 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
  "merlin",
 ]
 
@@ -1660,9 +1913,9 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.24"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf401df4a4e3872c4fe8151134cf483738e74b67fc934d6532c882b3d24a4550"
+checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -1705,6 +1958,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1731,7 +1990,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -1755,18 +2014,18 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
- "proc-macro-crate 3.1.0",
+ "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "frame-election-provider-support"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -1782,7 +2041,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "aquamarine",
  "frame-support",
@@ -1821,11 +2080,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "frame-metadata"
+version = "18.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daaf440c68eb2c3d88e5760fe8c7af3f9fee9181fab6c2f2c4e7cc48dcc40bb8"
+dependencies = [
+ "cfg-if 1.0.0",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+]
+
+[[package]]
 name = "frame-metadata-hash-extension"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "array-bytes",
+ "const-hex",
  "docify",
  "frame-support",
  "frame-system",
@@ -1838,14 +2110,15 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "aquamarine",
  "array-bytes",
+ "binary-merkle-tree",
  "bitflags 1.3.2",
  "docify",
  "environmental",
- "frame-metadata 16.0.0",
+ "frame-metadata 18.0.0",
  "frame-support-procedural",
  "impl-trait-for-tuples",
  "k256",
@@ -1871,6 +2144,7 @@ dependencies = [
  "sp-state-machine",
  "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
  "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
+ "sp-trie",
  "sp-weights",
  "static_assertions",
  "tt-call",
@@ -1879,7 +2153,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -1893,35 +2167,35 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sp-crypto-hashing",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "frame-support-procedural-tools-derive",
- "proc-macro-crate 3.1.0",
+ "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "frame-system"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "cfg-if 1.0.0",
  "docify",
@@ -1933,7 +2207,6 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
  "sp-version",
  "sp-weights",
 ]
@@ -1941,7 +2214,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -1955,7 +2228,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -1965,7 +2238,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -2006,9 +2279,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2021,9 +2294,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2031,15 +2304,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2049,32 +2322,32 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-timer"
@@ -2084,9 +2357,9 @@ checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2154,19 +2427,13 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.28.1"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 dependencies = [
  "fallible-iterator",
  "stable_deref_trait",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
 name = "glob"
@@ -2187,12 +2454,12 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
+checksum = "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
 dependencies = [
  "atomic-waker",
- "bytes 1.7.1",
+ "bytes 1.9.0",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -2235,6 +2502,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
+ "allocator-api2",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
  "allocator-api2",
 ]
 
@@ -2306,11 +2582,11 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
 dependencies = [
- "bytes 1.7.1",
+ "bytes 1.9.0",
  "fnv",
  "itoa",
 ]
@@ -2321,7 +2597,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
- "bytes 1.7.1",
+ "bytes 1.9.0",
  "http",
 ]
 
@@ -2331,7 +2607,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
- "bytes 1.7.1",
+ "bytes 1.9.0",
  "futures-util",
  "http",
  "http-body",
@@ -2340,9 +2616,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.9.4"
+version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
+checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
 
 [[package]]
 name = "httpdate"
@@ -2358,11 +2634,11 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "1.4.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
+checksum = "256fb8d4bd6413123cc9d91832d78325c48ff41677595be797d90f42969beae0"
 dependencies = [
- "bytes 1.7.1",
+ "bytes 1.9.0",
  "futures-channel",
  "futures-util",
  "h2",
@@ -2378,19 +2654,136 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.7"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde7055719c54e36e95e8719f95883f22072a48ede39db7fc17a4e1d5281e9b9"
+checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
 dependencies = [
- "bytes 1.7.1",
+ "bytes 1.9.0",
  "futures-util",
  "http",
  "http-body",
  "hyper",
  "pin-project-lite",
  "tokio",
- "tower",
  "tower-service",
+]
+
+[[package]]
+name = "icu_collections"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_locid_transform_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
+
+[[package]]
+name = "icu_normalizer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+
+[[package]]
+name = "icu_properties"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locid_transform",
+ "icu_properties_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+
+[[package]]
+name = "icu_provider"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_provider_macros",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_provider_macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2401,12 +2794,23 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.5.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
 dependencies = [
- "unicode-bidi",
- "unicode-normalization",
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]
@@ -2419,6 +2823,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "impl-codec"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67aa010c1e3da95bf151bd8b4c059b2ed7e75387cdb969b4f8f2723a43f9941"
+dependencies = [
+ "parity-scale-codec",
+]
+
+[[package]]
+name = "impl-num-traits"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "803d15461ab0dcc56706adf266158acbc44ccf719bf7d0af30705f58b90a4b8c"
+dependencies = [
+ "integer-sqrt",
+ "num-traits",
+ "uint 0.10.0",
+]
+
+[[package]]
 name = "impl-serde"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2428,14 +2852,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "impl-trait-for-tuples"
-version = "0.2.2"
+name = "impl-serde"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
+checksum = "4a143eada6a1ec4aefa5049037a26a6d597bfd64f8c026d07b77133e02b7dd0b"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "impl-trait-for-tuples"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2459,12 +2892,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.4.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ead53efc7ea8ed3cfb0c79fc8023fbb782a5432b52830b6518941cebe6505c"
+checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -2516,10 +2949,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "itoa"
-version = "1.0.11"
+name = "itertools"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "jni"
@@ -2552,9 +2994,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee"
-version = "0.24.3"
+version = "0.24.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec465b607a36dc5dd45d48b7689bc83f679f66a3ac6b6b21cc787a11e0f8685"
+checksum = "c5c71d8c1a731cc4227c2f698d377e7848ca12c8a48866fc5e6951c43a4db843"
 dependencies = [
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
@@ -2565,9 +3007,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-client-transport"
-version = "0.24.3"
+version = "0.24.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f0977f9c15694371b8024c35ab58ca043dbbf4b51ccb03db8858a021241df1"
+checksum = "548125b159ba1314104f5bb5f38519e03a41862786aa3925cf349aae9cdd546e"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -2588,12 +3030,12 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-core"
-version = "0.24.3"
+version = "0.24.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e942c55635fbf5dc421938b8558a8141c7e773720640f4f1dbe1f4164ca4e221"
+checksum = "f2882f6f8acb9fdaec7cefc4fd607119a9bd709831df7d7672a1d3b644628280"
 dependencies = [
  "async-trait",
- "bytes 1.7.1",
+ "bytes 1.9.0",
  "futures-timer",
  "futures-util",
  "http",
@@ -2603,7 +3045,7 @@ dependencies = [
  "parking_lot",
  "pin-project",
  "rand 0.8.5",
- "rustc-hash 2.0.0",
+ "rustc-hash 2.1.0",
  "serde",
  "serde_json",
  "thiserror",
@@ -2614,9 +3056,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-server"
-version = "0.24.3"
+version = "0.24.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038fb697a709bec7134e9ccbdbecfea0e2d15183f7140254afef7c5610a3f488"
+checksum = "82ad8ddc14be1d4290cd68046e7d1d37acd408efed6d3ca08aefcc3ad6da069c"
 dependencies = [
  "futures-util",
  "http",
@@ -2641,9 +3083,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-types"
-version = "0.24.3"
+version = "0.24.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b67d6e008164f027afbc2e7bb79662650158d26df200040282d2aa1cbb093b"
+checksum = "a178c60086f24cc35bb82f57c651d0d25d99c4742b4d335de04e97fa1f08a8a1"
 dependencies = [
  "http",
  "serde",
@@ -2653,9 +3095,9 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956ff9b67e26e1a6a866cb758f12c6f8746208489e3e4a4b5580802f2f0a587b"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
 dependencies = [
  "cfg-if 1.0.0",
  "ecdsa",
@@ -2698,15 +3140,15 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.158"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libm"
-version = "0.2.8"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
 name = "libredox"
@@ -2714,7 +3156,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "libc",
  "redox_syscall",
 ]
@@ -2778,18 +3220,24 @@ dependencies = [
 
 [[package]]
 name = "linregress"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4de04dcecc58d366391f9920245b85ffa684558a5ef6e7736e754347c3aea9c2"
+checksum = "a9eda9dcf4f2a99787827661f312ac3219292549c2ee992bf9a6248ffb066bf7"
 dependencies = [
  "nalgebra",
 ]
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "litemap"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
 name = "lock_api"
@@ -2803,9 +3251,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
 name = "macro_magic"
@@ -2816,7 +3264,7 @@ dependencies = [
  "macro_magic_core",
  "macro_magic_macros",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2830,7 +3278,7 @@ dependencies = [
  "macro_magic_core_macros",
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2841,7 +3289,7 @@ checksum = "b02abfe41815b5bd98dbd4260173db2c116dda171dc0fe7838cb206333b83308"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2852,7 +3300,7 @@ checksum = "73ea28ee64b88876bf45277ed9a5817c1817df061a74f2b988971a12570e5869"
 dependencies = [
  "macro_magic_core",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2882,7 +3330,7 @@ checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2914,11 +3362,11 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.4"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
+checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
 dependencies = [
- "adler",
+ "adler2",
 ]
 
 [[package]]
@@ -2942,11 +3390,10 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
+checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
- "hermit-abi",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
@@ -2984,29 +3431,17 @@ checksum = "685a9ac4b61f4e728e1d2c6a7844609c16527aeb5e6c865915c08e619c16410f"
 
 [[package]]
 name = "nalgebra"
-version = "0.32.6"
+version = "0.33.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5c17de023a86f59ed79891b2e5d5a94c705dbe904a5b5c9c952ea6221b03e4"
+checksum = "26aecdf64b707efd1310e3544d709c5c0ac61c13756046aaaba41be5c4f66a3b"
 dependencies = [
  "approx",
  "matrixmultiply",
- "nalgebra-macros",
  "num-complex",
  "num-rational",
  "num-traits",
  "simba",
  "typenum",
-]
-
-[[package]]
-name = "nalgebra-macros"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "254a5372af8fc138e36684761d3c0cdb758a4410e938babcff1c860ce14ddbfc"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.76",
 ]
 
 [[package]]
@@ -3086,7 +3521,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -3114,6 +3549,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -3139,27 +3575,18 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.32.2"
+version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "object"
-version = "0.36.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b64972346851a39438c60b341ebc01bba47464ae329e55cf343eb93964efd9"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "opaque-debug"
@@ -3175,11 +3602,11 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.66"
+version = "0.10.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
+checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "cfg-if 1.0.0",
  "foreign-types",
  "libc",
@@ -3196,7 +3623,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -3207,15 +3634,21 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.103"
+version = "0.9.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
+checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
 dependencies = [
  "cc",
  "libc",
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "overload"
@@ -3226,7 +3659,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "pallet-asset-conversion"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3244,7 +3677,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-rate"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3258,7 +3691,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets"
 version = "29.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3274,7 +3707,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3290,7 +3723,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3305,7 +3738,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3318,7 +3751,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3341,7 +3774,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -3356,7 +3789,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3375,7 +3808,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "array-bytes",
  "binary-merkle-tree",
@@ -3400,7 +3833,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3417,7 +3850,7 @@ dependencies = [
 [[package]]
 name = "pallet-broker"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -3435,7 +3868,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3453,7 +3886,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -3470,7 +3903,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "bitflags 1.3.2",
  "environmental",
@@ -3492,7 +3925,6 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
  "staging-xcm",
  "staging-xcm-builder",
  "wasm-instrument",
@@ -3502,17 +3934,17 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-proc-macro"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "pallet-contracts-uapi"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -3523,7 +3955,7 @@ dependencies = [
 [[package]]
 name = "pallet-conviction-voting"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -3539,7 +3971,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3556,7 +3988,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -3578,7 +4010,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -3591,7 +4023,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3609,7 +4041,7 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -3627,7 +4059,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3649,7 +4081,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -3665,7 +4097,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3681,7 +4113,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3697,7 +4129,7 @@ dependencies = [
 [[package]]
 name = "pallet-message-queue"
 version = "31.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -3714,41 +4146,50 @@ dependencies = [
 ]
 
 [[package]]
-name = "pallet-mmr"
-version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+name = "pallet-migrations"
+version = "1.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
+ "cfg-if 1.0.0",
+ "docify",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
+ "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io",
- "sp-mmr-primitives",
  "sp-runtime",
+]
+
+[[package]]
+name = "pallet-mmr"
+version = "27.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+dependencies = [
+ "log",
+ "parity-scale-codec",
+ "polkadot-sdk-frame",
+ "scale-info",
+ "sp-mmr-primitives",
 ]
 
 [[package]]
 name = "pallet-multisig"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
  "log",
  "parity-scale-codec",
+ "polkadot-sdk-frame",
  "scale-info",
- "sp-io",
- "sp-runtime",
 ]
 
 [[package]]
 name = "pallet-nis"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3763,7 +4204,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3779,7 +4220,7 @@ dependencies = [
 [[package]]
 name = "pallet-parameters"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -3796,7 +4237,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3812,21 +4253,17 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
  "parity-scale-codec",
+ "polkadot-sdk-frame",
  "scale-info",
- "sp-io",
- "sp-runtime",
 ]
 
 [[package]]
 name = "pallet-ranked-collective"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3844,7 +4281,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3858,7 +4295,7 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3875,7 +4312,7 @@ dependencies = [
 [[package]]
 name = "pallet-root-testing"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3889,7 +4326,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -3906,7 +4343,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3927,7 +4364,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3944,7 +4381,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -3965,7 +4402,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -3974,7 +4411,7 @@ dependencies = [
 [[package]]
 name = "pallet-state-trie-migration"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3990,7 +4427,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -4005,7 +4442,7 @@ dependencies = [
 [[package]]
 name = "pallet-template"
 version = "0.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4017,7 +4454,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -4036,7 +4473,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4054,8 +4491,9 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
+ "frame-benchmarking",
  "frame-support",
  "frame-system",
  "parity-scale-codec",
@@ -4069,7 +4507,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -4081,13 +4519,14 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "docify",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
  "impl-trait-for-tuples",
+ "log",
  "pallet-balances",
  "parity-scale-codec",
  "scale-info",
@@ -4099,7 +4538,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4114,7 +4553,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4128,7 +4567,7 @@ dependencies = [
 [[package]]
 name = "pallet-whitelist"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4142,13 +4581,12 @@ dependencies = [
 [[package]]
 name = "pallet-xcm"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "bounded-collections",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log",
  "pallet-balances",
  "parity-scale-codec",
  "scale-info",
@@ -4159,13 +4597,14 @@ dependencies = [
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
+ "tracing",
  "xcm-runtime-apis",
 ]
 
 [[package]]
 name = "pallet-xcm-benchmarks"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4187,8 +4626,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e69bf016dc406eff7d53a7d3f7cf1c2e72c82b9088aac1118591e36dd2cd3e9"
 dependencies = [
  "bitcoin_hashes",
- "rand 0.7.3",
- "rand_core 0.5.1",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "serde",
  "unicode-normalization",
 ]
@@ -4202,7 +4641,7 @@ dependencies = [
  "arrayvec",
  "bitvec",
  "byte-slice-cast",
- "bytes 1.7.1",
+ "bytes 1.9.0",
  "impl-trait-for-tuples",
  "parity-scale-codec-derive",
  "serde",
@@ -4214,7 +4653,7 @@ version = "3.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d830939c76d294956402033aee57a6da7b438f2294eb94864c37b0569053a42c"
 dependencies = [
- "proc-macro-crate 3.1.0",
+ "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -4246,7 +4685,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4284,29 +4723,29 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pin-project"
-version = "1.1.5"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
+checksum = "1e2ec53ad785f4d35dac0adea7f7dc6f1bb277ad84a680c7afefeae05d1f5916"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.5"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
+checksum = "d56a66c0c55993aa927429d0f8a0abfd74f084e4d9c192cffed01e418d83eefb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.14"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pin-utils"
@@ -4326,9 +4765,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "polkadot-ckb-merkle-mountain-range"
@@ -4343,7 +4782,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -4354,10 +4793,10 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain-primitives"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "bounded-collections",
- "derive_more",
+ "derive_more 0.99.18",
  "parity-scale-codec",
  "polkadot-core-primitives",
  "scale-info",
@@ -4370,7 +4809,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "bitvec",
  "hex-literal",
@@ -4392,12 +4831,13 @@ dependencies = [
  "sp-runtime",
  "sp-staking",
  "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
+ "thiserror",
 ]
 
 [[package]]
 name = "polkadot-runtime-common"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -4433,6 +4873,7 @@ dependencies = [
  "sp-core",
  "sp-inherents",
  "sp-io",
+ "sp-keyring",
  "sp-npos-elections",
  "sp-runtime",
  "sp-session",
@@ -4446,7 +4887,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "bs58",
  "frame-benchmarking",
@@ -4458,11 +4899,11 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
- "derive_more",
+ "derive_more 0.99.18",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -4504,52 +4945,87 @@ dependencies = [
 ]
 
 [[package]]
+name = "polkadot-sdk-frame"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
+dependencies = [
+ "docify",
+ "frame-benchmarking",
+ "frame-executive",
+ "frame-support",
+ "frame-system",
+ "frame-system-benchmarking",
+ "frame-system-rpc-runtime-api",
+ "frame-try-runtime",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-api",
+ "sp-arithmetic",
+ "sp-block-builder",
+ "sp-consensus-aura",
+ "sp-consensus-grandpa",
+ "sp-core",
+ "sp-genesis-builder",
+ "sp-inherents",
+ "sp-io",
+ "sp-keyring",
+ "sp-offchain",
+ "sp-runtime",
+ "sp-session",
+ "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
+ "sp-transaction-pool",
+ "sp-version",
+]
+
+[[package]]
 name = "polkavm-common"
-version = "0.9.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d9428a5cfcc85c5d7b9fc4b6a18c4b802d0173d768182a51cc7751640f08b92"
+checksum = "31ff33982a807d8567645d4784b9b5d7ab87bcb494f534a57cadd9012688e102"
 
 [[package]]
 name = "polkavm-derive"
-version = "0.9.1"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae8c4bea6f3e11cd89bb18bcdddac10bd9a24015399bd1c485ad68a985a19606"
+checksum = "c2eb703f3b6404c13228402e98a5eae063fd16b8f58afe334073ec105ee4117e"
 dependencies = [
  "polkavm-derive-impl-macro",
 ]
 
 [[package]]
 name = "polkavm-derive-impl"
-version = "0.9.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c4fdfc49717fb9a196e74a5d28e0bc764eb394a2c803eb11133a31ac996c60c"
+checksum = "2f2116a92e6e96220a398930f4c8a6cda1264206f3e2034fc9982bfd93f261f7"
 dependencies = [
  "polkavm-common",
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "polkavm-derive-impl-macro"
-version = "0.9.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ba81f7b5faac81e528eb6158a6f3c9e0bb1008e0ffa19653bc8dea925ecb429"
+checksum = "48c16669ddc7433e34c1007d31080b80901e3e8e523cb9d4b441c3910cf9294b"
 dependencies = [
  "polkavm-derive-impl",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "polkavm-linker"
-version = "0.9.2"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c7be503e60cf56c0eb785f90aaba4b583b36bff00e93997d93fef97f9553c39"
+checksum = "e9bfe793b094d9ea5c99b7c43ba46e277b0f8f48f4bbfdbabf8d3ebf701a4bd3"
 dependencies = [
- "gimli 0.28.1",
+ "dirs",
+ "gimli",
  "hashbrown 0.14.5",
  "log",
- "object 0.32.2",
+ "object",
  "polkavm-common",
  "regalloc2",
  "rustc-demangle",
@@ -4572,12 +5048,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.22"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba"
+checksum = "6924ced06e1f7dfe3fa48d57b9f74f55d8915f5036121bef647ef4b204895fac"
 dependencies = [
  "proc-macro2",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -4587,10 +5063,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
 dependencies = [
  "fixed-hash",
- "impl-codec",
- "impl-serde",
+ "impl-codec 0.6.0",
+ "impl-serde 0.4.0",
  "scale-info",
- "uint",
+ "uint 0.9.5",
+]
+
+[[package]]
+name = "primitive-types"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d15600a7d856470b7d278b3fe0e311fe28c2526348549f8ef2ff7db3299c87f5"
+dependencies = [
+ "fixed-hash",
+ "impl-codec 0.7.0",
+ "impl-num-traits",
+ "impl-serde 0.5.0",
+ "scale-info",
+ "uint 0.10.0",
 ]
 
 [[package]]
@@ -4605,11 +5095,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
+checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
 dependencies = [
- "toml_edit 0.21.1",
+ "toml_edit 0.22.22",
 ]
 
 [[package]]
@@ -4644,23 +5134,39 @@ checksum = "834da187cfe638ae8abb0203f0b33e5ccdb02a28e7199f2f47b3e2754f50edca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "quote"
-version = "1.0.37"
+name = "proptest"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
+dependencies = [
+ "bitflags 2.8.0",
+ "lazy_static",
+ "num-traits",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_xorshift",
+ "regex-syntax 0.8.5",
+ "unarray",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
@@ -4743,6 +5249,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4770,11 +5285,22 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.3"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
+checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.15",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]
@@ -4794,7 +5320,7 @@ checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -4812,14 +5338,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.6"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.7",
- "regex-syntax 0.8.4",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -4833,13 +5359,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -4850,9 +5376,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rfc6979"
@@ -4869,11 +5395,11 @@ name = "ring"
 version = "0.1.0"
 source = "git+https://github.com/w3f/ring-proof?rev=665f5f5#665f5f51af5734c7b6d90b985dd6861d4c5b4752"
 dependencies = [
- "ark-ec",
- "ark-ff",
- "ark-poly",
- "ark-serialize",
- "ark-std",
+ "ark-ec 0.4.2",
+ "ark-ff 0.4.2",
+ "ark-poly 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
  "arrayvec",
  "blake2",
  "common",
@@ -4899,7 +5425,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -4931,6 +5457,7 @@ dependencies = [
  "pallet-indices",
  "pallet-membership",
  "pallet-message-queue",
+ "pallet-migrations",
  "pallet-mmr",
  "pallet-multisig",
  "pallet-nis",
@@ -4980,6 +5507,7 @@ dependencies = [
  "sp-genesis-builder",
  "sp-inherents",
  "sp-io",
+ "sp-keyring",
  "sp-mmr-primitives",
  "sp-offchain",
  "sp-runtime",
@@ -4999,7 +5527,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime-constants"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -5032,9 +5560,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
+checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
 
 [[package]]
 name = "rustc-hex"
@@ -5044,31 +5572,31 @@ checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustc_version"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver 1.0.23",
+ "semver 1.0.25",
 ]
 
 [[package]]
 name = "rustix"
-version = "0.38.34"
+version = "0.38.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+checksum = "a78891ee6bf2340288408954ac787aa063d8e8817e9f53abb37c695c6d834ef6"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.12"
+version = "0.23.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
+checksum = "8f287924602bf649d949c63dc8ac8b235fa5387d394020705b80c4eb597ce5b8"
 dependencies = [
  "log",
  "once_cell",
@@ -5081,9 +5609,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04182dffc9091a404e0fc069ea5cd60e5b866c3adf881eff99a32d048242dffa"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
 dependencies = [
  "openssl-probe",
  "rustls-pemfile",
@@ -5094,19 +5622,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "2.1.3"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "196fe16b00e106300d3e45ecfcb764fa292a535d7326a29a5875c579c7417425"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
 dependencies = [
- "base64 0.22.1",
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.8.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
+checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
 
 [[package]]
 name = "rustls-platform-verifier"
@@ -5137,9 +5664,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.6"
+version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e6b52d4fda176fd835fdc55a835d4a89b8499cad995885a21149d5ad62f852e"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
  "ring 0.17.8",
  "rustls-pki-types",
@@ -5148,9 +5675,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.17"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
+checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
 name = "ryu"
@@ -5160,9 +5687,9 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "safe_arch"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3460605018fdc9612bce72735cba0d27efbcd9904780d44c7e3a9948f96148a"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
 dependencies = [
  "bytemuck",
 ]
@@ -5179,7 +5706,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "25.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "array-bytes",
  "parking_lot",
@@ -5207,9 +5734,9 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7caaf753f8ed1ab4752c6afb20174f03598c664724e0e32628e161c21000ff76"
 dependencies = [
- "derive_more",
+ "derive_more 0.99.18",
  "parity-scale-codec",
- "primitive-types",
+ "primitive-types 0.12.2",
  "scale-bits",
  "scale-decode-derive",
  "scale-info",
@@ -5235,9 +5762,9 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d70cb4b29360105483fac1ed567ff95d65224a14dd275b6303ed0a654c78de5"
 dependencies = [
- "derive_more",
+ "derive_more 0.99.18",
  "parity-scale-codec",
- "primitive-types",
+ "primitive-types 0.12.2",
  "scale-bits",
  "scale-encode-derive",
  "scale-info",
@@ -5259,13 +5786,13 @@ dependencies = [
 
 [[package]]
 name = "scale-info"
-version = "2.11.3"
+version = "2.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca070c12893629e2cc820a9761bedf6ce1dcddc9852984d1dc734b8bd9bd024"
+checksum = "346a3b32eba2640d17a9cb5927056b08f3de90f65b72fe09402c2ad07d684d0b"
 dependencies = [
  "bitvec",
  "cfg-if 1.0.0",
- "derive_more",
+ "derive_more 1.0.0",
  "parity-scale-codec",
  "scale-info-derive",
  "serde",
@@ -5273,14 +5800,14 @@ dependencies = [
 
 [[package]]
 name = "scale-info-derive"
-version = "2.11.3"
+version = "2.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d35494501194174bda522a32605929eefc9ecf7e0a326c26db1fdd85881eb62"
+checksum = "c6630024bf739e2179b91fb424b28898baf819414262c5d376677dbff1fe7ebf"
 dependencies = [
- "proc-macro-crate 3.1.0",
+ "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -5289,7 +5816,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58223c7691bf0bd46b43c9aea6f0472d1067f378d574180232358d7c6e0a8089"
 dependencies = [
- "derive_more",
+ "derive_more 0.99.18",
  "either",
  "frame-metadata 15.1.0",
  "parity-scale-codec",
@@ -5301,18 +5828,18 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.23"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
+checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "schnellru"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9a8ef13a93c54d20580de1e5c413e624e53121d42fc7e2c11d10ef7f8b02367"
+checksum = "356285bbf17bea63d9e52e96bd18f039672ac92b55b8cb997d6162a2a37d1649"
 dependencies = [
  "ahash",
  "cfg-if 1.0.0",
@@ -5398,7 +5925,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -5408,9 +5935,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.11.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
+checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -5427,9 +5954,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.23"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
 dependencies = [
  "serde",
 ]
@@ -5442,9 +5969,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.210"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
 dependencies = [
  "serde_derive",
 ]
@@ -5460,20 +5987,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.210"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.128"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
+checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
 dependencies = [
  "itoa",
  "memchr",
@@ -5483,9 +6010,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
  "serde",
 ]
@@ -5584,9 +6111,9 @@ dependencies = [
 
 [[package]]
 name = "simba"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061507c94fc6ab4ba1c9a0305018408e312e17c041eb63bef8aa726fa33aceae"
+checksum = "b3a386a501cd104797982c15ae17aafe8b9261315b5d07e3ec803f2ea26be0fa"
 dependencies = [
  "approx",
  "num-complex",
@@ -5619,7 +6146,7 @@ checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
 [[package]]
 name = "slot-range-helper"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -5635,9 +6162,9 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "socket2"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
+checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -5645,12 +6172,12 @@ dependencies = [
 
 [[package]]
 name = "soketto"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37468c595637c10857701c990f93a40ce0e357cedb0953d1c26c8d8027f9bb53"
+checksum = "2e859df029d160cb88608f5d7df7fb4753fd20fdfb4de5644f3d8b8440841721"
 dependencies = [
  "base64 0.22.1",
- "bytes 1.7.1",
+ "bytes 1.9.0",
  "futures",
  "http",
  "httparse",
@@ -5662,7 +6189,7 @@ dependencies = [
 [[package]]
 name = "solochain-template-runtime"
 version = "0.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",
@@ -5682,6 +6209,7 @@ dependencies = [
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec",
  "scale-info",
+ "serde_json",
  "sp-api",
  "sp-block-builder",
  "sp-consensus-aura",
@@ -5689,6 +6217,7 @@ dependencies = [
  "sp-core",
  "sp-genesis-builder",
  "sp-inherents",
+ "sp-keyring",
  "sp-offchain",
  "sp-runtime",
  "sp-session",
@@ -5701,7 +6230,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "docify",
  "hash-db",
@@ -5723,21 +6252,21 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "Inflector",
  "blake2",
  "expander",
- "proc-macro-crate 3.1.0",
+ "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "sp-application-crypto"
 version = "30.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -5749,7 +6278,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -5781,7 +6310,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -5793,7 +6322,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -5803,7 +6332,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -5819,7 +6348,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -5837,9 +6366,8 @@ dependencies = [
 [[package]]
 name = "sp-consensus-beefy"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
- "lazy_static",
  "parity-scale-codec",
  "scale-info",
  "serde",
@@ -5858,7 +6386,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -5875,7 +6403,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -5886,7 +6414,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "array-bytes",
  "bandersnatch_vrfs",
@@ -5899,7 +6427,7 @@ dependencies = [
  "futures",
  "hash-db",
  "hash256-std-hasher",
- "impl-serde",
+ "impl-serde 0.5.0",
  "itertools 0.11.0",
  "k256",
  "libsecp256k1",
@@ -5909,7 +6437,7 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot",
  "paste",
- "primitive-types",
+ "primitive-types 0.13.1",
  "rand 0.8.5",
  "scale-info",
  "schnorrkel",
@@ -5933,7 +6461,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-ec-utils"
 version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-377-ext",
@@ -5941,7 +6469,7 @@ dependencies = [
  "ark-bls12-381-ext",
  "ark-bw6-761",
  "ark-bw6-761-ext",
- "ark-ec",
+ "ark-ec 0.4.2",
  "ark-ed-on-bls12-377",
  "ark-ed-on-bls12-377-ext",
  "ark-ed-on-bls12-381-bandersnatch",
@@ -5953,7 +6481,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -5966,37 +6494,37 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "quote",
  "sp-crypto-hashing",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "sp-externalities"
 version = "0.25.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -6006,7 +6534,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.25.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -6016,7 +6544,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -6028,7 +6556,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -6041,9 +6569,9 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "30.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
- "bytes 1.7.1",
+ "bytes 1.9.0",
  "docify",
  "ed25519-dalek",
  "libsecp256k1",
@@ -6067,7 +6595,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "31.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -6077,7 +6605,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "parity-scale-codec",
  "parking_lot",
@@ -6088,7 +6616,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "thiserror",
  "zstd",
@@ -6097,9 +6625,9 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
- "frame-metadata 16.0.0",
+ "frame-metadata 18.0.0",
  "parity-scale-codec",
  "scale-info",
 ]
@@ -6107,7 +6635,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -6124,7 +6652,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -6137,7 +6665,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -6147,18 +6675,18 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "backtrace",
- "lazy_static",
  "regex",
 ]
 
 [[package]]
 name = "sp-runtime"
 version = "31.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
+ "binary-merkle-tree",
  "docify",
  "either",
  "hash256-std-hasher",
@@ -6179,18 +6707,19 @@ dependencies = [
  "sp-trie",
  "sp-weights",
  "tracing",
+ "tuplex",
 ]
 
 [[package]]
 name = "sp-runtime-interface"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
- "bytes 1.7.1",
+ "bytes 1.9.0",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "polkavm-derive",
- "primitive-types",
+ "primitive-types 0.13.1",
  "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
  "sp-runtime-interface-proc-macro 17.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
  "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
@@ -6203,13 +6732,13 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
- "bytes 1.7.1",
+ "bytes 1.9.0",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "polkavm-derive",
- "primitive-types",
+ "primitive-types 0.13.1",
  "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk)",
  "sp-runtime-interface-proc-macro 17.0.0 (git+https://github.com/paritytech/polkadot-sdk)",
  "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk)",
@@ -6222,33 +6751,33 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "Inflector",
  "expander",
- "proc-macro-crate 3.1.0",
+ "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "Inflector",
  "expander",
- "proc-macro-crate 3.1.0",
+ "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "sp-session"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -6262,7 +6791,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -6275,7 +6804,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.35.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "hash-db",
  "log",
@@ -6295,19 +6824,19 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 
 [[package]]
 name = "sp-storage"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
- "impl-serde",
+ "impl-serde 0.5.0",
  "parity-scale-codec",
  "ref-cast",
  "serde",
@@ -6317,9 +6846,9 @@ dependencies = [
 [[package]]
 name = "sp-storage"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
- "impl-serde",
+ "impl-serde 0.5.0",
  "parity-scale-codec",
  "ref-cast",
  "serde",
@@ -6329,7 +6858,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -6341,7 +6870,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -6352,7 +6881,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -6363,7 +6892,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -6372,11 +6901,10 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "ahash",
  "hash-db",
- "lazy_static",
  "memory-db",
  "nohash-hasher",
  "parity-scale-codec",
@@ -6395,9 +6923,9 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
- "impl-serde",
+ "impl-serde 0.5.0",
  "parity-scale-codec",
  "parity-wasm",
  "scale-info",
@@ -6412,19 +6940,19 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-warning",
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "sp-wasm-interface"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -6435,7 +6963,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -6446,7 +6974,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
@@ -6475,9 +7003,9 @@ dependencies = [
 
 [[package]]
 name = "ss58-registry"
-version = "1.47.0"
+version = "1.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4743ce898933fbff7bbf414f497c459a782d496269644b3d650a398ae6a487ba"
+checksum = "19409f13998e55816d1c728395af0b52ec066206341d939e22e7766df9b494b8"
 dependencies = [
  "Inflector",
  "num-format",
@@ -6497,12 +7025,14 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "staging-xcm"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "array-bytes",
  "bounded-collections",
  "derivative",
  "environmental",
+ "frame-support",
+ "hex-literal",
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
@@ -6516,7 +7046,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-builder"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6538,7 +7068,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-executor"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -6579,6 +7109,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "strum"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6616,7 +7152,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -6627,7 +7163,7 @@ dependencies = [
  "ac-node-api",
  "ac-primitives",
  "async-trait",
- "derive_more",
+ "derive_more 0.99.18",
  "frame-metadata 16.0.0",
  "frame-support",
  "futures-util",
@@ -6656,7 +7192,7 @@ dependencies = [
 [[package]]
 name = "substrate-bip39"
 version = "0.4.7"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
@@ -6668,7 +7204,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "build-helper",
  "cargo_metadata",
@@ -6677,6 +7213,7 @@ dependencies = [
  "jobserver",
  "parity-wasm",
  "polkavm-linker",
+ "shlex",
  "sp-maybe-compressed-blob",
  "strum 0.26.3",
  "tempfile",
@@ -6704,13 +7241,24 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.76"
+version = "2.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578e081a14e0cefc3279b0472138c513f37b41a08d5a3cca9b6e4e8ceb6cd525"
+checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -6721,12 +7269,13 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.12.0"
+version = "3.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
+checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
 dependencies = [
  "cfg-if 1.0.0",
  "fastrand",
+ "getrandom 0.2.15",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -6759,7 +7308,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -6770,7 +7319,7 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
  "test-case-core",
 ]
 
@@ -6788,22 +7337,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.63"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.63"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -6818,9 +7367,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.36"
+version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
 dependencies = [
  "deranged",
  "itoa",
@@ -6839,9 +7388,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
 dependencies = [
  "num-conv",
  "time-core",
@@ -6857,10 +7406,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinyvec"
-version = "1.8.0"
+name = "tinystr"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
+checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "022db8904dfa342efe721985167e9fcd16c29b226db4397ed752a761cfce81e8"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -6873,14 +7432,14 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.39.3"
+version = "1.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babc99b9923bfa4804bd74722ff02c0381021eafa4db9949217e3be8e84fff5"
+checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
 dependencies = [
  "backtrace",
- "bytes 1.7.1",
+ "bytes 1.9.0",
  "libc",
- "mio 1.0.2",
+ "mio 1.0.3",
  "pin-project-lite",
  "socket2",
  "tokio-macros",
@@ -6889,31 +7448,30 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
 dependencies = [
  "rustls",
- "rustls-pki-types",
  "tokio",
 ]
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.15"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -6923,11 +7481,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.11"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
+checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
 dependencies = [
- "bytes 1.7.1",
+ "bytes 1.9.0",
  "futures-core",
  "futures-io",
  "futures-sink",
@@ -6944,7 +7502,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.20",
+ "toml_edit 0.22.22",
 ]
 
 [[package]]
@@ -6969,26 +7527,15 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.21.1"
+version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
-dependencies = [
- "indexmap",
- "toml_datetime",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
+checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.18",
+ "winnow 0.6.24",
 ]
 
 [[package]]
@@ -7001,7 +7548,6 @@ dependencies = [
  "futures-util",
  "pin-project",
  "pin-project-lite",
- "tokio",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -7021,9 +7567,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -7033,20 +7579,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
  "valuable",
@@ -7065,9 +7611,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -7116,7 +7662,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e2ce1e47ed2994fd43b04c8f618008d4cabdd5ee34027cf14f9d918edd9c8"
 dependencies = [
  "byteorder",
- "bytes 1.7.1",
+ "bytes 1.9.0",
  "data-encoding",
  "http",
  "httparse",
@@ -7130,14 +7676,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tuplex"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "676ac81d5454c4dcf37955d34fa8626ede3490f744b86ca14a7b90168d2a08aa"
+
+[[package]]
 name = "twox-hash"
 version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "digest 0.10.7",
- "rand 0.7.3",
+ "rand 0.8.5",
  "static_assertions",
 ]
 
@@ -7160,16 +7712,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-bidi"
-version = "0.3.15"
+name = "uint"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
+checksum = "909988d098b2f738727b161a106cfc7cab00c539c2687a8836f8e565976fb53e"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
 name = "unicode-normalization"
@@ -7182,15 +7746,21 @@ dependencies = [
 
 [[package]]
 name = "unicode-width"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229730647fbc343e3a80e463c1db7f78f3855d3f3739bee0dda773c9a037c90a"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"
@@ -7200,9 +7770,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.2"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -7216,6 +7786,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
+name = "utf16_iter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7223,9 +7805,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "valuable"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"
@@ -7241,16 +7823,16 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "w3f-bls"
-version = "0.1.4"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c5da5fa2c6afa2c9158eaa7cd9aee249765eb32b5fb0c63ad8b9e79336a47ec"
+checksum = "70a3028804c8bbae2a97a15b71ffc0e308c4b01a520994aafa77d56e94e19024"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-381",
- "ark-ec",
- "ark-ff",
- "ark-serialize",
- "ark-serialize-derive",
+ "ark-ec 0.4.2",
+ "ark-ff 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-serialize-derive 0.4.2",
  "arrayref",
  "constcat",
  "digest 0.10.7",
@@ -7408,18 +7990,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.3"
+version = "0.26.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd7c23921eeb1713a4e851530e9b9756e4fb0e89978582942612524cf09f01cd"
+checksum = "5d642ff16b7e79272ae451b7322067cdc17cadf68c23264be9d94a32319efe7e"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "wide"
-version = "0.7.28"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b828f995bf1e9622031f8009f8481a85406ce1f4d4588ff746d872043e855690"
+checksum = "41b5576b9a81633f3e8df296ce0063042a73507636cbe956c61133dd7034ab22"
 dependencies = [
  "bytemuck",
  "safe_arch",
@@ -7470,11 +8052,20 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -7483,7 +8074,22 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -7492,15 +8098,21 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -7510,9 +8122,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7528,9 +8152,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -7540,9 +8176,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -7561,12 +8209,24 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.18"
+version = "0.6.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
+checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+
+[[package]]
+name = "writeable"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
 name = "ws"
@@ -7609,18 +8269,18 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "Inflector",
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "xcm-runtime-apis"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#a34cc8dff09dc3840a304befc2415343244b5fd0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#12ed0f4ffe4dcf3a8fe8928e3791141a110fad8b"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -7629,6 +8289,30 @@ dependencies = [
  "sp-weights",
  "staging-xcm",
  "staging-xcm-executor",
+]
+
+[[package]]
+name = "yoke"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+ "synstructure",
 ]
 
 [[package]]
@@ -7649,7 +8333,28 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+ "synstructure",
 ]
 
 [[package]]
@@ -7669,7 +8374,29 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
 ]
 
 [[package]]

--- a/examples/async/examples/benchmark_bulk_xt.rs
+++ b/examples/async/examples/benchmark_bulk_xt.rs
@@ -16,7 +16,7 @@
 //! This example floods the node with a series of transactions.
 
 use rococo_runtime::{BalancesCall, RuntimeCall};
-use sp_keyring::AccountKeyring;
+use sp_keyring::Sr25519Keyring;
 use substrate_api_client::{
 	ac_primitives::{
 		Config, ExtrinsicSigner as GenericExtrinsicSigner, RococoRuntimeConfig, SignExtrinsic,
@@ -43,12 +43,12 @@ async fn main() {
 	env_logger::init();
 
 	// Initialize api and set the signer (sender) that is used to sign the extrinsics.
-	let signer = AccountKeyring::Alice.pair();
+	let signer = Sr25519Keyring::Alice.pair();
 	let client = JsonrpseeClient::with_default_url().await.unwrap();
 	let mut api = Api::<RococoRuntimeConfig, _>::new(client).await.unwrap();
 	api.set_signer(signer.into());
 
-	let recipient: ExtrinsicAddressOf<ExtrinsicSigner> = AccountKeyring::Bob.to_account_id().into();
+	let recipient: ExtrinsicAddressOf<ExtrinsicSigner> = Sr25519Keyring::Bob.to_account_id().into();
 	// We use a manual nonce input here, because otherwise the api retrieves the nonce via getter and needs
 	// to wait for the response of the node (and the actual execution of the previous extrinsic).
 	// But because we want to spam the node with extrinsic, we simple monotonically increase the nonce, without

--- a/examples/async/examples/check_extrinsic_events.rs
+++ b/examples/async/examples/check_extrinsic_events.rs
@@ -13,7 +13,7 @@
 	limitations under the License.
 */
 
-use sp_keyring::AccountKeyring;
+use sp_keyring::Sr25519Keyring;
 use substrate_api_client::{
 	ac_node_api::RawEventDetails,
 	ac_primitives::{Config, RococoRuntimeConfig},
@@ -32,13 +32,13 @@ async fn main() {
 	env_logger::init();
 
 	// Initialize api and set the signer (sender) that is used to sign the extrinsics.
-	let alice_signer = AccountKeyring::Alice.pair();
+	let alice_signer = Sr25519Keyring::Alice.pair();
 	let client = JsonrpseeClient::with_default_url().await.unwrap();
 	let mut api = Api::<RococoRuntimeConfig, _>::new(client).await.unwrap();
 	api.set_signer(alice_signer.into());
 
-	let alice = AccountKeyring::Alice.to_account_id();
-	let bob = AccountKeyring::Bob.to_account_id();
+	let alice = Sr25519Keyring::Alice.to_account_id();
+	let bob = Sr25519Keyring::Bob.to_account_id();
 
 	let (maybe_data_of_alice, maybe_data_of_bob) =
 		tokio::try_join!(api.get_account_data(&alice), api.get_account_data(&bob)).unwrap();

--- a/examples/async/examples/compose_extrinsic.rs
+++ b/examples/async/examples/compose_extrinsic.rs
@@ -19,7 +19,7 @@
 
 use codec::Compact;
 use rococo_runtime::{Address, BalancesCall, RuntimeCall};
-use sp_keyring::AccountKeyring;
+use sp_keyring::Sr25519Keyring;
 use sp_runtime::{generic::Era, MultiAddress};
 use substrate_api_client::{
 	ac_compose_macros::{compose_call, compose_extrinsic_offline},
@@ -48,7 +48,7 @@ async fn main() {
 	env_logger::init();
 
 	// Initialize api and set the signer (sender) that is used to sign the extrinsics.
-	let signer = AccountKeyring::Alice.pair();
+	let signer = Sr25519Keyring::Alice.pair();
 	let client = JsonrpseeClient::with_default_url().await.unwrap();
 
 	let mut api = Api::<RococoRuntimeConfig, _>::new(client).await.unwrap();
@@ -56,7 +56,7 @@ async fn main() {
 	// Signer is needed to set the nonce and sign the extrinsic.
 	api.set_signer(extrinsic_signer.clone());
 
-	let recipient: Address = MultiAddress::Id(AccountKeyring::Bob.to_account_id());
+	let recipient: Address = MultiAddress::Id(Sr25519Keyring::Bob.to_account_id());
 
 	// Get the last finalized header to retrieve information for Era for mortal transactions (online).
 	let last_finalized_header_hash = api.get_finalized_head().await.unwrap().unwrap();

--- a/examples/async/examples/custom_nonce.rs
+++ b/examples/async/examples/custom_nonce.rs
@@ -17,7 +17,7 @@
 //! without asking the node for nonce and does not need to know the metadata
 
 use rococo_runtime::{BalancesCall, RuntimeCall};
-use sp_keyring::AccountKeyring;
+use sp_keyring::Sr25519Keyring;
 use sp_runtime::{generic::Era, MultiAddress};
 use substrate_api_client::{
 	ac_primitives::{GenericAdditionalParams, RococoRuntimeConfig},
@@ -33,7 +33,7 @@ async fn main() {
 	env_logger::init();
 
 	// Initialize api and set the signer (sender) that is used to sign the extrinsics.
-	let signer = AccountKeyring::Alice.pair();
+	let signer = Sr25519Keyring::Alice.pair();
 	let client = JsonrpseeClient::with_default_url().await.unwrap();
 	let mut api = Api::<RococoRuntimeConfig, _>::new(client).await.unwrap();
 	api.set_signer(signer.into());
@@ -54,7 +54,7 @@ async fn main() {
 	println!("[+] Signer's Account Nonce is {}\n", signer_nonce);
 
 	// Create an extrinsic that should get included in the future pool due to a nonce that is too high.
-	let recipient = MultiAddress::Id(AccountKeyring::Bob.to_account_id());
+	let recipient = MultiAddress::Id(Sr25519Keyring::Bob.to_account_id());
 	let call =
 		RuntimeCall::Balances(BalancesCall::transfer_allow_death { dest: recipient, value: 42 });
 	let xt = api.compose_extrinsic_offline(call, signer_nonce + 1);

--- a/examples/async/examples/get_storage.rs
+++ b/examples/async/examples/get_storage.rs
@@ -18,7 +18,7 @@
 use codec::Encode;
 use frame_system::AccountInfo as GenericAccountInfo;
 use pallet_recovery::ActiveRecovery;
-use sp_keyring::AccountKeyring;
+use sp_keyring::Sr25519Keyring;
 use substrate_api_client::{
 	ac_compose_macros::compose_extrinsic,
 	ac_primitives::{Config, RococoRuntimeConfig},
@@ -58,7 +58,7 @@ async fn main() {
 	println!("[+] StorageValueProof: {:?}", proof);
 
 	// Get the AccountInfo of Alice and the associated StoragePrefix.
-	let account: sp_core::sr25519::Public = AccountKeyring::Alice.public();
+	let account: sp_core::sr25519::Public = Sr25519Keyring::Alice.public();
 	let (maybe_account_info, key_prefix) = tokio::try_join!(
 		api.get_storage_map::<_, AccountInfo>("System", "Account", account, None),
 		api.get_storage_map_key_prefix("System", "Account")
@@ -70,9 +70,9 @@ async fn main() {
 
 	// Get Alice's and Bobs AccountNonce with api.get_nonce(). Alice will be set as the signer for
 	// the current api, so the nonce retrieval can be simplified:
-	let signer = AccountKeyring::Alice.pair();
+	let signer = Sr25519Keyring::Alice.pair();
 	api.set_signer(signer.into());
-	let bob = AccountKeyring::Bob.to_account_id();
+	let bob = Sr25519Keyring::Bob.to_account_id();
 
 	let (alice_nonce, bob_nonce) =
 		tokio::try_join!(api.get_nonce(), api.get_account_nonce(&bob)).unwrap();
@@ -97,9 +97,9 @@ async fn main() {
 	}
 
 	// Create a recovery, so we can fetch an actual ActiveRecovery state from the chain.
-	let alice = AccountKeyring::Alice.to_account_id();
+	let alice = Sr25519Keyring::Alice.to_account_id();
 	let alice_multiaddress: Address = alice.clone().into();
-	let charlie = AccountKeyring::Charlie.to_account_id();
+	let charlie = Sr25519Keyring::Charlie.to_account_id();
 	let threshold: u16 = 2;
 	let delay_period: u32 = 1000;
 
@@ -116,7 +116,7 @@ async fn main() {
 	let _report = api.submit_and_watch_extrinsic_until(xt, XtStatus::InBlock).await.unwrap();
 
 	// Set Bob as signer, so we can send the recevory extrinsic as Bob.
-	let signer2 = AccountKeyring::Bob.pair();
+	let signer2 = Sr25519Keyring::Bob.pair();
 	api.set_signer(signer2.into());
 	let xt = compose_extrinsic!(&api, "Recovery", "initiate_recovery", alice_multiaddress).unwrap();
 

--- a/examples/async/examples/new_json_rpc_api_calls.rs
+++ b/examples/async/examples/new_json_rpc_api_calls.rs
@@ -19,7 +19,7 @@
 use codec::Encode;
 use serde_json::Value;
 use sp_core::Bytes;
-use sp_keyring::AccountKeyring;
+use sp_keyring::Sr25519Keyring;
 use substrate_api_client::{
 	ac_compose_macros::rpc_params,
 	ac_primitives::RococoRuntimeConfig,
@@ -36,7 +36,7 @@ async fn main() {
 	env_logger::init();
 
 	// Initialize api and set the signer (sender) that is used to sign the extrinsics.
-	let signer = AccountKeyring::Alice.pair();
+	let signer = Sr25519Keyring::Alice.pair();
 	let client = JsonrpseeClient::with_default_url().await.unwrap();
 	let mut api = Api::<RococoRuntimeConfig, _>::new(client).await.unwrap();
 	api.set_signer(signer.into());
@@ -60,7 +60,7 @@ async fn main() {
 	println!("Chain genesis Hash: {genesishash}");
 
 	// Submit and watch a transaction:
-	let bob = AccountKeyring::Bob.to_account_id();
+	let bob = Sr25519Keyring::Bob.to_account_id();
 	let encoded_extrinsic: Bytes = api
 		.balance_transfer_allow_death(bob.into(), 1000)
 		.await

--- a/examples/async/examples/query_runtime_api.rs
+++ b/examples/async/examples/query_runtime_api.rs
@@ -17,7 +17,7 @@
 
 use codec::Encode;
 use sp_core::sr25519;
-use sp_keyring::AccountKeyring;
+use sp_keyring::Sr25519Keyring;
 use substrate_api_client::{
 	ac_primitives::RococoRuntimeConfig,
 	extrinsic::BalancesExtrinsics,
@@ -36,12 +36,12 @@ async fn main() {
 	// Initialize the api, which retrieves the metadata from the node upon initialization.
 	let client = JsonrpseeClient::with_default_url().await.unwrap();
 	let mut api = Api::<RococoRuntimeConfig, _>::new(client).await.unwrap();
-	let alice_pair = AccountKeyring::Alice.pair();
+	let alice_pair = Sr25519Keyring::Alice.pair();
 	api.set_signer(alice_pair.into());
 	let runtime_api = api.runtime_api();
 
 	// Query the fee of an extrinsic.
-	let bob = AccountKeyring::Bob.to_account_id();
+	let bob = Sr25519Keyring::Bob.to_account_id();
 	let balance_extrinsic =
 		api.balance_transfer_allow_death(bob.clone().into(), 1000).await.unwrap();
 	let extrinsic_fee_details = runtime_api

--- a/examples/async/examples/query_runtime_api.rs
+++ b/examples/async/examples/query_runtime_api.rs
@@ -26,6 +26,8 @@ use substrate_api_client::{
 	Api, GetChainInfo,
 };
 
+const UNSTABLE_METADATA_VERSION: u32 = u32::MAX;
+
 // To test this example with CI we run it against the Polkadot Rococo node. Remember to switch the Config to match your
 // own runtime if it uses different parameter configurations. Several pre-compiled runtimes are available in the ac-primitives crate.
 
@@ -64,7 +66,7 @@ async fn main() {
 
 	// Query the available metadata versions.
 	let metadata_versions = runtime_api.metadata_versions(None).await.unwrap();
-	assert_eq!(metadata_versions, [14, 15]);
+	assert_eq!(metadata_versions, [14, 15, UNSTABLE_METADATA_VERSION]);
 
 	// List all apis and functions thereof.
 	let trait_names = runtime_api.list_traits(None).await.unwrap();

--- a/examples/async/examples/runtime_update_async.rs
+++ b/examples/async/examples/runtime_update_async.rs
@@ -16,7 +16,7 @@
 // To test this example with CI we run it against the Polkadot Rococo node. Remember to switch the Config to match your
 // own runtime if it uses different parameter configurations. Several pre-compiled runtimes are available in the ac-primitives crate.
 
-use sp_keyring::AccountKeyring;
+use sp_keyring::Sr25519Keyring;
 use sp_weights::Weight;
 use substrate_api_client::{
 	ac_compose_macros::{compose_call, compose_extrinsic},
@@ -38,7 +38,7 @@ async fn main() {
 	// Initialize the api.
 	let client = JsonrpseeClient::with_default_url().await.unwrap();
 	let mut api = Api::<RococoRuntimeConfig, _>::new(client).await.unwrap();
-	let sudoer = AccountKeyring::Alice.pair();
+	let sudoer = Sr25519Keyring::Alice.pair();
 	api.set_signer(sudoer.into());
 
 	let subscription = api.subscribe_events().await.unwrap();

--- a/examples/async/examples/staking_batch_payout_untested.rs
+++ b/examples/async/examples/staking_batch_payout_untested.rs
@@ -13,7 +13,7 @@
 
 use codec::{Decode, Encode};
 use pallet_staking::{ActiveEraInfo, Exposure};
-use sp_keyring::AccountKeyring;
+use sp_keyring::Sr25519Keyring;
 use sp_runtime::{app_crypto::Ss58Codec, AccountId32};
 use substrate_api_client::{
 	ac_primitives::RococoRuntimeConfig,
@@ -50,13 +50,13 @@ async fn main() {
 	env_logger::init();
 
 	// Initialize api and set the signer (sender) that is used to sign the extrinsics.
-	let alice = AccountKeyring::Alice.pair();
+	let alice = Sr25519Keyring::Alice.pair();
 	let client = JsonrpseeClient::with_default_url().await.unwrap();
 	let mut api = Api::<RococoRuntimeConfig, _>::new(client).await.unwrap();
 	api.set_signer(alice.into());
 
 	// Give a valid validator account address. In the kitchinsink runtime, this is Alice.
-	let validator_account = AccountKeyring::Alice.to_account_id();
+	let validator_account = Sr25519Keyring::Alice.to_account_id();
 	// Alice Stash:
 	let validator_stash =
 		AccountId32::from_ss58check("5GNJqTPyNqANBkUVMN1LPPrxXnFouWXoe2wNSmmEoLctxiZY").unwrap();

--- a/examples/async/examples/sudo.rs
+++ b/examples/async/examples/sudo.rs
@@ -17,7 +17,7 @@
 //! module, whereas the desired module and call are supplied as a string.
 
 use codec::Compact;
-use sp_keyring::AccountKeyring;
+use sp_keyring::Sr25519Keyring;
 use substrate_api_client::{
 	ac_compose_macros::{compose_call, compose_extrinsic},
 	ac_primitives::{
@@ -50,13 +50,13 @@ async fn main() {
 	env_logger::init();
 
 	// Initialize api and set the signer (sender) that is used to sign the extrinsics.
-	let sudoer = AccountKeyring::Alice.pair();
+	let sudoer = Sr25519Keyring::Alice.pair();
 	let client = JsonrpseeClient::with_default_url().await.unwrap();
 	let mut api = Api::<RococoRuntimeConfig, _>::new(client).await.unwrap();
 	api.set_signer(sudoer.into());
 
 	// Set the recipient of newly issued funds.
-	let recipient = AccountKeyring::Bob.to_account_id();
+	let recipient = Sr25519Keyring::Bob.to_account_id();
 
 	// Get the current balance of the recipient.
 	let recipient_balance = api.get_account_data(&recipient).await.unwrap().unwrap().free;

--- a/examples/sync/examples/runtime_update_sync.rs
+++ b/examples/sync/examples/runtime_update_sync.rs
@@ -20,7 +20,7 @@ use core::{
 	sync::atomic::{AtomicBool, Ordering},
 	time::Duration,
 };
-use sp_keyring::AccountKeyring;
+use sp_keyring::Sr25519Keyring;
 use sp_weights::Weight;
 use std::{sync::Arc, thread};
 use substrate_api_client::{
@@ -40,7 +40,7 @@ fn main() {
 	// Initialize the api.
 	let client = TungsteniteRpcClient::with_default_url(1);
 	let mut api = Api::<RococoRuntimeConfig, _>::new(client).unwrap();
-	let sudoer = AccountKeyring::Alice.pair();
+	let sudoer = Sr25519Keyring::Alice.pair();
 	api.set_signer(sudoer.into());
 
 	let subscription = api.subscribe_events().unwrap();

--- a/node-api/src/events/raw_event_details.rs
+++ b/node-api/src/events/raw_event_details.rs
@@ -91,7 +91,7 @@ impl<Hash: Encode + Decode> RawEventDetails<Hash> {
 	pub fn event_metadata<'a>(
 		&'a self,
 		metadata: &'a Metadata,
-	) -> Result<EventMetadataDetails, Error> {
+	) -> Result<EventMetadataDetails<'a>, Error> {
 		let pallet = metadata
 			.pallet_by_index(self.pallet_index())
 			.ok_or(Error::Metadata(MetadataError::PalletIndexNotFound(self.pallet_index())))?;
@@ -256,7 +256,7 @@ impl<Hash: Encode + Decode> RawEventDetails<Hash> {
 	pub(crate) fn event_metadata_unchecked<'a>(
 		&'a self,
 		metadata: &'a Metadata,
-	) -> EventMetadataDetails {
+	) -> EventMetadataDetails<'a> {
 		let pallet = metadata
 			.pallet_by_index(self.pallet_index())
 			.expect("event pallet to be found; we did this already during decoding");

--- a/primitives/src/extrinsics/mod.rs
+++ b/primitives/src/extrinsics/mod.rs
@@ -260,7 +260,7 @@ mod tests {
 		BalancesCall, Runtime, RuntimeCall, SignedExtra, SystemCall, UncheckedExtrinsic, VERSION,
 	};
 	use sp_core::{crypto::Ss58Codec, Pair, H256 as Hash};
-	use sp_keyring::AccountKeyring;
+	use sp_keyring::Sr25519Keyring;
 	use sp_runtime::{
 		generic::Era, testing::sr25519, traits::Hash as HashTrait, AccountId32, MultiAddress,
 		MultiSignature,
@@ -329,8 +329,8 @@ mod tests {
 	#[test]
 	fn xt_hash_matches_substrate_impl() {
 		// Define extrinsic params.
-		let alice = MultiAddress::Id(AccountKeyring::Alice.to_account_id());
-		let bob = MultiAddress::Id(AccountKeyring::Bob.to_account_id());
+		let alice = MultiAddress::Id(Sr25519Keyring::Alice.to_account_id());
+		let bob = MultiAddress::Id(Sr25519Keyring::Bob.to_account_id());
 		let call =
 			RuntimeCall::Balances(BalancesCall::transfer_allow_death { dest: bob, value: 42 });
 
@@ -389,7 +389,7 @@ mod tests {
 	#[test]
 	fn xt_hash_matches_substrate_impl_large_xt() {
 		// Define xt parameters,
-		let alice = MultiAddress::Id(AccountKeyring::Alice.to_account_id());
+		let alice = MultiAddress::Id(Sr25519Keyring::Alice.to_account_id());
 		let code: Vec<u8> = include_bytes!("solochain_template_runtime.wasm").to_vec();
 		let call = RuntimeCall::System(SystemCall::set_code { code });
 

--- a/primitives/src/extrinsics/signer.rs
+++ b/primitives/src/extrinsics/signer.rs
@@ -141,11 +141,11 @@ mod tests {
 	use crate::AssetRuntimeConfig;
 	use solochain_template_runtime::Signature;
 	use sp_core::sr25519;
-	use sp_keyring::AccountKeyring;
+	use sp_keyring::Sr25519Keyring;
 
 	#[test]
 	fn test_extrinsic_signer_clone() {
-		let pair = AccountKeyring::Alice.pair();
+		let pair = Sr25519Keyring::Alice.pair();
 		let signer = ExtrinsicSigner::<AssetRuntimeConfig>::new(pair);
 
 		let _signer2 = signer.clone();
@@ -153,7 +153,7 @@ mod tests {
 
 	#[test]
 	fn test_static_extrinsic_signer_clone() {
-		let pair = AccountKeyring::Alice.pair();
+		let pair = Sr25519Keyring::Alice.pair();
 		let signer = StaticExtrinsicSigner::<_, Signature>::new(pair);
 
 		let _signer2 = signer.clone();

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2024-09-01"
+channel = "nightly-2024-09-15"
 targets = ["wasm32-unknown-unknown", "wasm32-wasip1"]
 profile = "default" # include rustfmt, clippy

--- a/testing/async/examples/author_tests.rs
+++ b/testing/async/examples/author_tests.rs
@@ -17,7 +17,7 @@
 
 use rococo_runtime::{BalancesCall, RuntimeCall};
 use sp_core::{Encode, H256};
-use sp_keyring::AccountKeyring;
+use sp_keyring::Sr25519Keyring;
 use substrate_api_client::{
 	ac_node_api::RawEventDetails,
 	ac_primitives::{
@@ -38,10 +38,10 @@ type AccountId = <RococoRuntimeConfig as Config>::AccountId;
 async fn main() {
 	// Setup
 	let client = JsonrpseeClient::with_default_url().await.unwrap();
-	let alice_pair = AccountKeyring::Alice.pair();
+	let alice_pair = Sr25519Keyring::Alice.pair();
 	let mut api = MyApi::new(client).await.unwrap();
 	api.set_signer(alice_pair.into());
-	let bob: ExtrinsicAddressOf<ExtrinsicSigner> = AccountKeyring::Bob.to_account_id().into();
+	let bob: ExtrinsicAddressOf<ExtrinsicSigner> = Sr25519Keyring::Bob.to_account_id().into();
 	let signer_nonce = api.get_nonce().await.unwrap();
 	let transfer_call = RuntimeCall::Balances(BalancesCall::transfer_allow_death {
 		dest: bob.clone(),

--- a/testing/async/examples/chain_tests.rs
+++ b/testing/async/examples/chain_tests.rs
@@ -16,7 +16,7 @@
 //! Tests for the chain rpc interface functions, including testing the RococoRuntimeConfig
 //! and Signer generation for the RococoRuntimeConfig.
 
-use sp_keyring::AccountKeyring;
+use sp_keyring::Sr25519Keyring;
 use substrate_api_client::{
 	ac_primitives::RococoRuntimeConfig,
 	rpc::{HandleSubscription, JsonrpseeClient},
@@ -28,7 +28,7 @@ async fn main() {
 	// Setup
 	let client = JsonrpseeClient::with_default_url().await.unwrap();
 	let mut api = Api::<RococoRuntimeConfig, _>::new(client).await.unwrap();
-	let signer = AccountKeyring::Alice.pair();
+	let signer = Sr25519Keyring::Alice.pair();
 	api.set_signer(signer.into());
 
 	// GetChainInfo

--- a/testing/async/examples/dispatch_errors_tests.rs
+++ b/testing/async/examples/dispatch_errors_tests.rs
@@ -16,7 +16,7 @@
 //! Tests for the dispatch error.
 
 use sp_core::H256;
-use sp_keyring::AccountKeyring;
+use sp_keyring::Sr25519Keyring;
 use sp_runtime::MultiAddress;
 use substrate_api_client::{
 	ac_primitives::RococoRuntimeConfig, extrinsic::BalancesExtrinsics, rpc::JsonrpseeClient, Api,
@@ -27,19 +27,19 @@ use substrate_api_client::{
 async fn main() {
 	// Setup
 	let client = JsonrpseeClient::with_default_url().await.unwrap();
-	let alice_signer = AccountKeyring::Alice.pair();
-	let bob_signer = AccountKeyring::Bob.pair();
+	let alice_signer = Sr25519Keyring::Alice.pair();
+	let bob_signer = Sr25519Keyring::Bob.pair();
 	let mut api = Api::<RococoRuntimeConfig, _>::new(client).await.unwrap();
 
-	let alice = AccountKeyring::Alice.to_account_id();
+	let alice = Sr25519Keyring::Alice.to_account_id();
 	let balance_of_alice = api.get_account_data(&alice).await.unwrap().unwrap().free;
 	println!("[+] Alice's Free Balance is {}\n", balance_of_alice);
 
-	let bob = AccountKeyring::Bob.to_account_id();
+	let bob = Sr25519Keyring::Bob.to_account_id();
 	let balance_of_bob = api.get_account_data(&bob).await.unwrap().unwrap_or_default().free;
 	println!("[+] Bob's Free Balance is {}\n", balance_of_bob);
 
-	let one = AccountKeyring::One.to_account_id();
+	let one = Sr25519Keyring::One.to_account_id();
 	let balance_of_one = api.get_account_data(&one).await.unwrap().unwrap_or_default().free;
 	println!("[+] One's Free Balance is {}\n", balance_of_one);
 

--- a/testing/async/examples/events_tests.rs
+++ b/testing/async/examples/events_tests.rs
@@ -18,7 +18,7 @@
 use codec::Decode;
 use frame_support::dispatch::DispatchInfo;
 use rococo_runtime::RuntimeEvent;
-use sp_keyring::AccountKeyring;
+use sp_keyring::Sr25519Keyring;
 use substrate_api_client::{
 	ac_node_api::{EventDetails, StaticEvent},
 	ac_primitives::{Config, RococoRuntimeConfig},
@@ -44,11 +44,11 @@ impl StaticEvent for ExtrinsicSuccess {
 async fn main() {
 	// Setup
 	let client = JsonrpseeClient::with_default_url().await.unwrap();
-	let alice_pair = AccountKeyring::Alice.pair();
+	let alice_pair = Sr25519Keyring::Alice.pair();
 	let mut api = Api::<RococoRuntimeConfig, _>::new(client).await.unwrap();
 	api.set_signer(alice_pair.into());
 
-	let bob = AccountKeyring::Bob.to_account_id();
+	let bob = Sr25519Keyring::Bob.to_account_id();
 
 	// Test `fetch_events_from_block`: There should always be at least the
 	// timestamp set event.

--- a/testing/async/examples/frame_system_tests.rs
+++ b/testing/async/examples/frame_system_tests.rs
@@ -17,7 +17,7 @@
 
 use codec::Decode;
 use frame_support::dispatch::DispatchInfo;
-use sp_keyring::AccountKeyring;
+use sp_keyring::Sr25519Keyring;
 use substrate_api_client::{
 	ac_node_api::StaticEvent, ac_primitives::RococoRuntimeConfig, rpc::JsonrpseeClient, Api,
 	GetAccountInformation, SystemApi,
@@ -38,18 +38,18 @@ impl StaticEvent for ExtrinsicSuccess {
 async fn main() {
 	// Setup
 	let client = JsonrpseeClient::with_default_url().await.unwrap();
-	let alice_pair = AccountKeyring::Alice.pair();
+	let alice_pair = Sr25519Keyring::Alice.pair();
 	let mut api = Api::<RococoRuntimeConfig, _>::new(client).await.unwrap();
 	api.set_signer(alice_pair.into());
 
-	let alice = AccountKeyring::Alice.to_account_id();
+	let alice = Sr25519Keyring::Alice.to_account_id();
 
 	// GetAccountInformation
 	let _account_info = api.get_account_info(&alice).await.unwrap().unwrap();
 	let _account_data = api.get_account_data(&alice).await.unwrap().unwrap();
 
 	// Empty account information
-	let inexistent_account = AccountKeyring::Two.to_account_id();
+	let inexistent_account = Sr25519Keyring::Two.to_account_id();
 	let maybe_account_info = api.get_account_info(&inexistent_account).await.unwrap();
 	assert!(maybe_account_info.is_none());
 	let maybe_account_data = api.get_account_data(&inexistent_account).await.unwrap();

--- a/testing/async/examples/pallet_balances_tests.rs
+++ b/testing/async/examples/pallet_balances_tests.rs
@@ -16,7 +16,7 @@
 //! Tests for the pallet balances interface functions.
 
 use codec::Encode;
-use sp_keyring::AccountKeyring;
+use sp_keyring::Sr25519Keyring;
 use substrate_api_client::{
 	ac_primitives::RococoRuntimeConfig, extrinsic::BalancesExtrinsics, rpc::JsonrpseeClient, Api,
 	GetAccountInformation, GetBalance, GetTransactionPayment, SubmitAndWatch, XtStatus,
@@ -31,13 +31,13 @@ async fn main() {
 	let ed = api.get_existential_deposit().await.unwrap();
 	println!("[+] Existential deposit is {}\n", ed);
 
-	let alice = AccountKeyring::Alice.to_account_id();
-	let alice_signer = AccountKeyring::Alice.pair();
+	let alice = Sr25519Keyring::Alice.to_account_id();
+	let alice_signer = Sr25519Keyring::Alice.pair();
 	api.set_signer(alice_signer.into());
 	let balance_of_alice = api.get_account_data(&alice).await.unwrap().unwrap().free;
 	println!("[+] Alice's Free Balance is {}\n", balance_of_alice);
 
-	let bob = AccountKeyring::Bob.to_account_id();
+	let bob = Sr25519Keyring::Bob.to_account_id();
 	let balance_of_bob = api.get_account_data(&bob).await.unwrap().unwrap_or_default().free;
 	println!("[+] Bob's Free Balance is {}\n", balance_of_bob);
 

--- a/testing/async/examples/pallet_transaction_payment_tests.rs
+++ b/testing/async/examples/pallet_transaction_payment_tests.rs
@@ -16,7 +16,7 @@
 //! Tests for the pallet transaction payment interface functions.
 
 use codec::Encode;
-use sp_keyring::AccountKeyring;
+use sp_keyring::Sr25519Keyring;
 use substrate_api_client::{
 	ac_primitives::RococoRuntimeConfig, extrinsic::BalancesExtrinsics, rpc::JsonrpseeClient, Api,
 	GetChainInfo, GetTransactionPayment,
@@ -26,11 +26,11 @@ use substrate_api_client::{
 async fn main() {
 	// Setup
 	let client = JsonrpseeClient::with_default_url().await.unwrap();
-	let alice_pair = AccountKeyring::Alice.pair();
+	let alice_pair = Sr25519Keyring::Alice.pair();
 	let mut api = Api::<RococoRuntimeConfig, _>::new(client).await.unwrap();
 	api.set_signer(alice_pair.into());
 
-	let bob = AccountKeyring::Bob.to_account_id();
+	let bob = Sr25519Keyring::Bob.to_account_id();
 
 	let block_hash = api.get_block_hash(None).await.unwrap().unwrap();
 	let encoded_xt = api

--- a/testing/async/examples/runtime_api_tests.rs
+++ b/testing/async/examples/runtime_api_tests.rs
@@ -28,6 +28,8 @@ use substrate_api_client::{
 	Api, GetChainInfo,
 };
 
+const UNSTABLE_METADATA_VERSION: u32 = u32::MAX;
+
 #[tokio::main]
 async fn main() {
 	// Setup
@@ -73,7 +75,7 @@ async fn main() {
 	let _method_names = runtime_api.list_methods_of_trait("BabeApi", None).await.unwrap();
 	let _trait_names = runtime_api.list_traits(None).await.unwrap();
 	let metadata_versions = runtime_api.metadata_versions(None).await.unwrap();
-	assert_eq!(metadata_versions, [14, 15]);
+	assert_eq!(metadata_versions, [14, 15, UNSTABLE_METADATA_VERSION]);
 
 	// MMR
 	// This doesn't seem to work with the current substrate node. Tried it on polkadot.js aswell, but it keeps on runtime panicking.

--- a/testing/async/examples/runtime_api_tests.rs
+++ b/testing/async/examples/runtime_api_tests.rs
@@ -46,7 +46,7 @@ async fn main() {
 	// General Runtime Api
 	let bytes = runtime_api.rpc_call("Metadata_metadata_versions", None, None).await.unwrap();
 	let metadata_versions = Vec::<u32>::decode(&mut bytes.0.as_slice()).unwrap();
-	assert_eq!(metadata_versions, [14, 15]);
+	assert_eq!(metadata_versions, [14, 15, UNSTABLE_METADATA_VERSION]);
 
 	// AccountNonce
 	let alice_nonce = runtime_api.account_nonce(alice, None).await.unwrap();

--- a/testing/async/examples/runtime_api_tests.rs
+++ b/testing/async/examples/runtime_api_tests.rs
@@ -16,7 +16,7 @@
 //! Tests for the runtime api.
 
 use sp_core::{sr25519, Decode};
-use sp_keyring::AccountKeyring;
+use sp_keyring::Sr25519Keyring;
 use substrate_api_client::{
 	ac_primitives::RococoRuntimeConfig,
 	extrinsic::BalancesExtrinsics,
@@ -32,14 +32,14 @@ use substrate_api_client::{
 async fn main() {
 	// Setup
 	let client = JsonrpseeClient::with_default_url().await.unwrap();
-	let alice_pair = AccountKeyring::Alice.pair();
+	let alice_pair = Sr25519Keyring::Alice.pair();
 	let mut api = Api::<RococoRuntimeConfig, _>::new(client).await.unwrap();
 	api.set_signer(alice_pair.into());
 
 	let runtime_api = api.runtime_api();
 
-	let alice = AccountKeyring::Alice.to_account_id();
-	let bob = AccountKeyring::Bob.to_account_id();
+	let alice = Sr25519Keyring::Alice.to_account_id();
+	let bob = Sr25519Keyring::Bob.to_account_id();
 
 	// General Runtime Api
 	let bytes = runtime_api.rpc_call("Metadata_metadata_versions", None, None).await.unwrap();

--- a/testing/async/examples/state_tests.rs
+++ b/testing/async/examples/state_tests.rs
@@ -19,7 +19,7 @@ use codec::Decode;
 use pallet_balances::AccountData as GenericAccountData;
 use pallet_society::Vote;
 use sp_core::{crypto::Ss58Codec, sr25519};
-use sp_keyring::AccountKeyring;
+use sp_keyring::Sr25519Keyring;
 use substrate_api_client::{
 	ac_primitives::{Config, RococoRuntimeConfig},
 	rpc::JsonrpseeClient,
@@ -36,7 +36,7 @@ async fn main() {
 	let client = JsonrpseeClient::with_default_url().await.unwrap();
 	let api = Api::<KitchensinkConfig, _>::new(client).await.unwrap();
 
-	let alice = AccountKeyring::Alice.to_account_id();
+	let alice = Sr25519Keyring::Alice.to_account_id();
 	let block_hash = api.get_block_hash(None).await.unwrap().unwrap();
 	let alice_stash =
 		sr25519::Public::from_ss58check("5GNJqTPyNqANBkUVMN1LPPrxXnFouWXoe2wNSmmEoLctxiZY")


### PR DESCRIPTION
- Downgrade CI image to Ubuntu 22.04 due to https://github.com/scs/substrate-api-client/issues/817
- cargo update to commit right before introduction of ExtrinsicV5
- Replace `AccountKeyring` with `Sr25519Keyring` (see https://github.com/paritytech/polkadot-sdk/pull/5899)
- Fix runtime api metadata tests  (see https://github.com/paritytech/polkadot-sdk/pull/5732 for more Infos)
- Fix clippy lints `elided lifetime`


part of  #812 