### PR TITLE
Add Unicode-3.0 to accpeted licences

### DIFF
--- a/about.toml
+++ b/about.toml
@@ -15,8 +15,7 @@ accepted = [
     "Unicode-DFS-2016",
     "Unicode-3.0",
     "NOASSERTION",
-    "GPL-3.0",
-    "GPL-1.0-or-later"
+    "GPL-3.0"
 ]
 ignore-dev-dependencies = true
 ignore-build-dependencies = true

--- a/about.toml
+++ b/about.toml
@@ -10,6 +10,8 @@ accepted = [
     "OpenSSL",
     "OpenSSL-standalone",
     "SSLeay-standalone",
+    "LicenseRef-scancode-public-domain",
+    "LicenseRef-scancode-unknown-license-reference",
     "Unicode-DFS-2016",
     "Unicode-3.0",
     "NOASSERTION",

--- a/about.toml
+++ b/about.toml
@@ -9,6 +9,7 @@ accepted = [
     "ISC",
     "OpenSSL",
     "Unicode-DFS-2016",
+    "Unicode-3.0",
     "NOASSERTION",
     "GPL-3.0"
 ]

--- a/about.toml
+++ b/about.toml
@@ -17,5 +17,4 @@ ignore-dev-dependencies = true
 ignore-build-dependencies = true
 workarounds = [
     "ring",
-    "rustls",
 ]

--- a/about.toml
+++ b/about.toml
@@ -8,10 +8,15 @@ accepted = [
     "MPL-2.0",
     "ISC",
     "OpenSSL",
+    "OpenSSL-standalone",
+    "SSLeay-standalone",
+    "LicenseRef-scancode-public-domain",
+    "LicenseRef-scancode-unknown-license-reference",
     "Unicode-DFS-2016",
     "Unicode-3.0",
     "NOASSERTION",
-    "GPL-3.0"
+    "GPL-3.0",
+    "GPL-1.0-or-later"
 ]
 ignore-dev-dependencies = true
 ignore-build-dependencies = true

--- a/about.toml
+++ b/about.toml
@@ -10,8 +10,6 @@ accepted = [
     "OpenSSL",
     "OpenSSL-standalone",
     "SSLeay-standalone",
-    "LicenseRef-scancode-public-domain",
-    "LicenseRef-scancode-unknown-license-reference",
     "Unicode-DFS-2016",
     "Unicode-3.0",
     "NOASSERTION",

--- a/about.toml
+++ b/about.toml
@@ -8,10 +8,6 @@ accepted = [
     "MPL-2.0",
     "ISC",
     "OpenSSL",
-    "OpenSSL-standalone",
-    "SSLeay-standalone",
-    "LicenseRef-scancode-public-domain",
-    "LicenseRef-scancode-unknown-license-reference",
     "Unicode-DFS-2016",
     "Unicode-3.0",
     "NOASSERTION",
@@ -19,3 +15,7 @@ accepted = [
 ]
 ignore-dev-dependencies = true
 ignore-build-dependencies = true
+workarounds = [
+    "ring",
+    "rustls",
+]


### PR DESCRIPTION
ring licensing (3 in one file) confuses the cargo-about, so a workaround was added: https://embarkstudios.github.io/cargo-about/cli/generate/config.html

closes #814 