### PR TITLE
Remove compilation feature `disable-metadata-hash-check`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,9 +105,6 @@ staking-xt = ["std", "ac-primitives/staking-xt"]
 # of the functionality this feature provides.
 contracts-xt = ["std", "ac-primitives/contracts-xt"]
 
-# Provides compatibility to RFC-0078: "Merkelized Metadata" but disables the check of the metadata hash
-disable-metadata-hash-check = ["ac-primitives/disable-metadata-hash-check"]
-
 # Enables all std features of dependencies in case of std build.
 std = [
     # crates.io no_std

--- a/examples/async/Cargo.toml
+++ b/examples/async/Cargo.toml
@@ -27,4 +27,4 @@ sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = 
 sp-weights = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "master" }
 
 # local deps
-substrate-api-client = { path = "../..", version = "1.16", features = ["staking-xt", "contracts-xt", "disable-metadata-hash-check"] }
+substrate-api-client = { path = "../..", version = "1.16", features = ["staking-xt", "contracts-xt"] }

--- a/examples/sync/Cargo.toml
+++ b/examples/sync/Cargo.toml
@@ -15,4 +15,4 @@ sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = 
 sp-weights = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "master" }
 
 # local deps
-substrate-api-client = { path = "../..", version = "1.16", default-features = false, features = ["tungstenite-client", "ws-client", "disable-metadata-hash-check"] }
+substrate-api-client = { path = "../..", version = "1.16", default-features = false, features = ["tungstenite-client", "ws-client"] }

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -48,7 +48,6 @@ default = ["std"]
 disable_target_static_assertions = [
     "sp-runtime-interface/disable_target_static_assertions",
 ]
-disable-metadata-hash-check = []
 std = [
     "codec/std",
     "primitive-types/std",

--- a/primitives/src/extrinsics/extrinsic_params.rs
+++ b/primitives/src/extrinsics/extrinsic_params.rs
@@ -17,7 +17,6 @@
 
 use crate::config::Config;
 use codec::{Codec, Decode, Encode};
-#[cfg(feature = "disable-metadata-hash-check")]
 use primitive_types::H256;
 use scale_info::{StaticTypeInfo, TypeInfo};
 use sp_runtime::{
@@ -42,19 +41,13 @@ pub struct GenericTxExtension<Tip, Index> {
 	#[codec(compact)]
 	pub nonce: Index,
 	pub tip: Tip,
-	#[cfg(feature = "disable-metadata-hash-check")]
 	pub check_hash: u8,
 }
 
 impl<Tip, Index> GenericTxExtension<Tip, Index> {
 	pub fn new(era: Era, nonce: Index, tip: Tip) -> Self {
-		#[cfg(feature = "disable-metadata-hash-check")]
 		{
 			Self { era, nonce, tip, check_hash: 0 }
-		}
-		#[cfg(not(feature = "disable-metadata-hash-check"))]
-		{
-			Self { era, nonce, tip }
 		}
 	}
 }
@@ -84,10 +77,7 @@ where
 // defines what is returned upon the `implicit` call. The Implicit defined here
 // must mirror these return values.
 // Example: https://github.com/paritytech/polkadot-sdk/blob/c139739868eddbda495d642219a57602f63c18f5/substrate/frame/system/src/extensions/check_mortality.rs#L62
-#[cfg(feature = "disable-metadata-hash-check")]
 pub type GenericImplicit<Hash> = ((), u32, u32, Hash, Hash, (), (), (), Option<H256>, ());
-#[cfg(not(feature = "disable-metadata-hash-check"))]
-pub type GenericImplicit<Hash> = ((), u32, u32, Hash, Hash, (), (), ());
 
 /// This trait allows you to configure the "signed extra" and
 /// "additional" parameters that are signed and used in substrate extrinsics.
@@ -154,9 +144,9 @@ pub struct GenericExtrinsicParams<T: Config, Tip> {
 /// needed for constructing an extrinsic with the trait `ExtrinsicParams`.
 #[derive(Decode, Encode, Copy, Clone, Eq, PartialEq, Debug)]
 pub struct GenericAdditionalParams<Tip, Hash> {
-	era: Era,
-	mortality_checkpoint: Option<Hash>,
-	tip: Tip,
+	pub era: Era,
+	pub mortality_checkpoint: Option<Hash>,
+	pub tip: Tip,
 }
 
 impl<Tip: Default, Hash> GenericAdditionalParams<Tip, Hash> {
@@ -223,7 +213,6 @@ where
 	}
 
 	fn implicit(&self) -> Self::Implicit {
-		#[cfg(feature = "disable-metadata-hash-check")]
 		{
 			(
 				(),
@@ -235,19 +224,6 @@ where
 				(),
 				(),
 				None,
-				(),
-			)
-		}
-		#[cfg(not(feature = "disable-metadata-hash-check"))]
-		{
-			(
-				(),
-				self.spec_version,
-				self.transaction_version,
-				self.genesis_hash,
-				self.mortality_checkpoint,
-				(),
-				(),
 				(),
 			)
 		}

--- a/primitives/src/extrinsics/extrinsic_params.rs
+++ b/primitives/src/extrinsics/extrinsic_params.rs
@@ -69,7 +69,8 @@ where
 }
 
 /// Default implicit fields of a Polkadot/Substrate node.
-/// Order: (CheckNonZeroSender, CheckSpecVersion, CheckTxVersion, CheckGenesis, CheckEra, CheckNonce, CheckWeight, transactionPayment::ChargeTransactionPayment, CheckMetadataHash, WeightReclaim).
+// Order: (CheckNonZeroSender, CheckSpecVersion, CheckTxVersion, CheckGenesis, CheckEra, CheckNonce, CheckWeight,
+// transactionPayment::ChargeTransactionPayment, CheckMetadataHash, WeightReclaim).
 // The order and types must match the one defined in the runtime.
 // Example: https://github.com/paritytech/polkadot-sdk/blob/c139739868eddbda495d642219a57602f63c18f5/substrate/bin/node/runtime/src/lib.rs#L2665-L2678
 // The `Implicit` is the tuple returned from the call TransactionExtension::implicit().

--- a/primitives/src/extrinsics/extrinsic_params_without_hash_check.rs
+++ b/primitives/src/extrinsics/extrinsic_params_without_hash_check.rs
@@ -1,0 +1,146 @@
+/*
+   Copyright 2019 Supercomputing Systems AG
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+	   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+*/
+
+//! Old style Extrinsic Parameters for older Substrate chains that do not yet use the newer transaction Logic.
+//!
+// E.g in the runtime/src/lib.rs file:
+// pub type TxExtension = (
+// 	frame_system::CheckNonZeroSender<Runtime>,
+// 	frame_system::CheckSpecVersion<Runtime>,
+// 	frame_system::CheckTxVersion<Runtime>,
+// 	frame_system::CheckGenesis<Runtime>,
+// 	frame_system::CheckEra<Runtime>,
+// 	frame_system::CheckNonce<Runtime>,
+// 	frame_system::CheckWeight<Runtime>,
+// 	pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
+// );
+
+use crate::{
+	config::Config,
+	extrinsic_params::{ExtrinsicParams, GenericAdditionalParams, GenericTxExtension},
+};
+use codec::{Codec, Decode, Encode};
+use scale_info::{StaticTypeInfo, TypeInfo};
+use sp_runtime::{
+	generic::Era,
+	impl_tx_ext_default,
+	traits::{Dispatchable, TransactionExtension},
+};
+
+#[derive(Decode, Encode, Copy, Clone, Eq, PartialEq, Debug, TypeInfo)]
+pub struct TxExtensionWithoutHashCheck<Tip, Index> {
+	pub era: Era,
+	#[codec(compact)]
+	pub nonce: Index,
+	pub tip: Tip,
+}
+
+impl<Tip, Index> TxExtensionWithoutHashCheck<Tip, Index> {
+	pub fn new(era: Era, nonce: Index, tip: Tip) -> Self {
+		{
+			Self { era, nonce, tip }
+		}
+	}
+}
+
+impl<Call, Tip, Index> TransactionExtension<Call> for TxExtensionWithoutHashCheck<Tip, Index>
+where
+	Call: Dispatchable,
+	TxExtensionWithoutHashCheck<Tip, Index>:
+		Codec + core::fmt::Debug + Sync + Send + Clone + Eq + PartialEq + StaticTypeInfo,
+	Tip: Codec + core::fmt::Debug + Sync + Send + Clone + Eq + PartialEq + StaticTypeInfo,
+	Index: Codec + core::fmt::Debug + Sync + Send + Clone + Eq + PartialEq + StaticTypeInfo,
+{
+	const IDENTIFIER: &'static str = "TxExtensionWithoutHashCheck";
+	type Implicit = ();
+	type Pre = ();
+	type Val = ();
+
+	impl_tx_ext_default!(Call; weight validate prepare);
+}
+
+pub type ImplicitWithoutHashCheck<Hash> = ((), u32, u32, Hash, Hash, (), (), ());
+
+/// An implementation of [`ExtrinsicParams`] that is suitable for constructing
+/// extrinsics that can be sent to a node with the same signed extra and additional
+/// parameters as a Polkadot/Substrate node.
+#[derive(Decode, Encode, Clone, Eq, PartialEq, Debug)]
+pub struct ExtrinsicParamsWithoutHashCheck<T: Config, Tip> {
+	era: Era,
+	nonce: T::Index,
+	tip: Tip,
+	spec_version: u32,
+	transaction_version: u32,
+	genesis_hash: T::Hash,
+	mortality_checkpoint: T::Hash,
+}
+
+impl<T, Tip> ExtrinsicParams<T::Index, T::Hash> for ExtrinsicParamsWithoutHashCheck<T, Tip>
+where
+	T: Config,
+	u128: From<Tip>,
+	Tip: Copy + Default + Encode,
+{
+	type AdditionalParams = GenericAdditionalParams<Tip, T::Hash>;
+	type TxExtension = GenericTxExtension<Tip, T::Index>;
+	type Implicit = ImplicitWithoutHashCheck<T::Hash>;
+
+	fn new(
+		spec_version: u32,
+		transaction_version: u32,
+		nonce: T::Index,
+		genesis_hash: T::Hash,
+		additional_params: Self::AdditionalParams,
+	) -> Self {
+		Self {
+			era: additional_params.era,
+			tip: additional_params.tip,
+			spec_version,
+			transaction_version,
+			genesis_hash,
+			mortality_checkpoint: additional_params.mortality_checkpoint.unwrap_or(genesis_hash),
+			nonce,
+		}
+	}
+
+	fn signed_extra(&self) -> Self::TxExtension {
+		self.transaction_extension()
+	}
+
+	fn transaction_extension(&self) -> Self::TxExtension {
+		Self::TxExtension::new(self.era, self.nonce, self.tip)
+	}
+
+	fn additional_signed(&self) -> Self::Implicit {
+		self.implicit()
+	}
+
+	fn implicit(&self) -> Self::Implicit {
+		{
+			(
+				(),
+				self.spec_version,
+				self.transaction_version,
+				self.genesis_hash,
+				self.mortality_checkpoint,
+				(),
+				(),
+				(),
+			)
+		}
+	}
+}

--- a/primitives/src/extrinsics/mod.rs
+++ b/primitives/src/extrinsics/mod.rs
@@ -30,5 +30,6 @@ pub use sp_runtime::generic::{Preamble, UncheckedExtrinsic};
 pub type CallIndex = [u8; 2];
 
 pub mod extrinsic_params;
+pub mod extrinsic_params_without_hash_check;
 mod extrinsic_v4;
 pub mod signer;

--- a/testing/async/Cargo.toml
+++ b/testing/async/Cargo.toml
@@ -23,4 +23,4 @@ pallet-balances = { git = "https://github.com/paritytech/polkadot-sdk.git", bran
 pallet-society = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "master" }
 
 # local deps
-substrate-api-client = { path = "../..", version = "1.16", features = ["staking-xt", "contracts-xt", "disable-metadata-hash-check"] }
+substrate-api-client = { path = "../..", version = "1.16", features = ["staking-xt", "contracts-xt"] }

--- a/testing/sync/Cargo.toml
+++ b/testing/sync/Cargo.toml
@@ -12,5 +12,5 @@ sp-core = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "ma
 sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "master" }
 
 # local deps
-substrate-api-client = { path = "../..", version = "1.16", default-features = false, features = ["tungstenite-client", "ws-client", "disable-metadata-hash-check"] }
+substrate-api-client = { path = "../..", version = "1.16", default-features = false, features = ["tungstenite-client", "ws-client"] }
 ac-keystore = { path = "../../keystore", version = "1.16" }


### PR DESCRIPTION
- Removes compilation feature `disable-metadata-hash-check`
- Adds struct `ExtrinsicParamsWithoutHashCheck` to still provide an "easy" compatibility with older nodes.
