### PR TITLE
Remove obsolete solochain-template-runtime dev-dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,7 +132,6 @@ dependencies = [
  "scale-info",
  "serde",
  "serde_json",
- "solochain-template-runtime",
  "sp-application-crypto",
  "sp-core",
  "sp-crypto-hashing",
@@ -3727,22 +3726,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pallet-aura"
-version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#aa42debebaf3bf8e6979497256bc1fbad2db0e11"
-dependencies = [
- "frame-support",
- "frame-system",
- "log",
- "pallet-timestamp",
- "parity-scale-codec",
- "scale-info",
- "sp-application-crypto",
- "sp-consensus-aura",
- "sp-runtime",
-]
-
-[[package]]
 name = "pallet-authority-discovery"
 version = "28.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#aa42debebaf3bf8e6979497256bc1fbad2db0e11"
@@ -4425,18 +4408,6 @@ dependencies = [
  "scale-info",
  "sp-io",
  "sp-runtime",
-]
-
-[[package]]
-name = "pallet-template"
-version = "0.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#aa42debebaf3bf8e6979497256bc1fbad2db0e11"
-dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "parity-scale-codec",
- "scale-info",
 ]
 
 [[package]]
@@ -6169,47 +6140,6 @@ dependencies = [
  "log",
  "rand 0.8.5",
  "sha1",
-]
-
-[[package]]
-name = "solochain-template-runtime"
-version = "0.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#aa42debebaf3bf8e6979497256bc1fbad2db0e11"
-dependencies = [
- "frame-benchmarking",
- "frame-executive",
- "frame-metadata-hash-extension",
- "frame-support",
- "frame-system",
- "frame-system-benchmarking",
- "frame-system-rpc-runtime-api",
- "frame-try-runtime",
- "pallet-aura",
- "pallet-balances",
- "pallet-grandpa",
- "pallet-sudo",
- "pallet-template",
- "pallet-timestamp",
- "pallet-transaction-payment",
- "pallet-transaction-payment-rpc-runtime-api",
- "parity-scale-codec",
- "scale-info",
- "serde_json",
- "sp-api",
- "sp-block-builder",
- "sp-consensus-aura",
- "sp-consensus-grandpa",
- "sp-core",
- "sp-genesis-builder",
- "sp-inherents",
- "sp-keyring",
- "sp-offchain",
- "sp-runtime",
- "sp-session",
- "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
- "sp-transaction-pool",
- "sp-version",
- "substrate-wasm-builder",
 ]
 
 [[package]]

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -38,7 +38,6 @@ pallet-staking = { optional = true, git = "https://github.com/paritytech/polkado
 
 [dev-dependencies]
 frame-metadata-hash-extension = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "master" }
-solochain-template-runtime = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "master" }
 sp-keyring = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "master" }
 
 
@@ -59,6 +58,7 @@ std = [
     "sp-core/std",
     "sp-crypto-hashing/std",
     "sp-runtime/std",
+    "sp-runtime-interface/std",
     "sp-staking/std",
     "sp-version/std",
     "sp-weights/std",

--- a/primitives/src/extrinsics/signer.rs
+++ b/primitives/src/extrinsics/signer.rs
@@ -139,9 +139,9 @@ where
 mod tests {
 	use super::*;
 	use crate::AssetRuntimeConfig;
-	use solochain_template_runtime::Signature;
 	use sp_core::sr25519;
 	use sp_keyring::Sr25519Keyring;
+	use sp_runtime::MultiSignature;
 
 	#[test]
 	fn test_extrinsic_signer_clone() {
@@ -154,7 +154,7 @@ mod tests {
 	#[test]
 	fn test_static_extrinsic_signer_clone() {
 		let pair = Sr25519Keyring::Alice.pair();
-		let signer = StaticExtrinsicSigner::<_, Signature>::new(pair);
+		let signer = StaticExtrinsicSigner::<_, MultiSignature>::new(pair);
 
 		let _signer2 = signer.clone();
 	}


### PR DESCRIPTION
No need to import the full solochain for a single Signature Type.