### PR TITLE
CI: Change nightly build to weekly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
     branches: [ master, 'polkadot-v[0-9]+.[0-9]+.[0-9]+*', 'release-polkadot-v[0-9]+.[0-9]+.[0-9]+*' ]
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 0 * * 0" # weekly build: every sunday at midnight
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
As Parity and the api-client are much more stable, a weekly build for checking upstream changes should be enough.
@Niederb do you agree?

Thanks for the input @dhobi-scs!

